### PR TITLE
feat: Razdvajanje UI-a po ulogama (klijent/zaposleni) i ispravke frontend-a

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,6 @@ RUN npm run build
 
 FROM nginx:alpine
 COPY --from=build /app/dist/banka-1-frontend /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,10 @@
+server {
+  listen 80;
+  server_name localhost;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}

--- a/src/app/core/interceptors/auth.interceptor.ts
+++ b/src/app/core/interceptors/auth.interceptor.ts
@@ -27,7 +27,10 @@
         url.includes('/auth/login') ||
         url.includes('/auth/forgot-password') ||
         url.includes('/auth/resetPassword') ||
-        url.includes('/auth/activate')
+        url.includes('/auth/activate') ||
+        url.includes('/auth/reset-password') ||
+        url.includes('/auth/check-activate') ||
+        url.includes('/auth/resend-activation')
       );
     }
 

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -11,6 +11,9 @@ type LoginResponse = {
   role: string;
   permissions: string[];
 };
+type ClientLoginResponse = {
+  token: string;
+};
 type RefreshResponse = {
   jwt: string;
   refreshToken: string;
@@ -27,11 +30,7 @@ export class AuthService {
   }
 
   /**
-   * Prijavljuje korisnika sa email-om i lozinkom.
-   * Nakon uspešnog logina, JWT token i podaci o korisniku se čuvaju u localStorage.
-   * @param email - Email adresa korisnika
-   * @param password - Lozinka korisnika
-   * @returns Observable sa JWT tokenom i listom permisija
+   * Prijavljuje zaposlenog sa email-om i lozinkom.
    */
   login(email: string, password: string): Observable<LoginResponse> {
     return this.http
@@ -50,6 +49,51 @@ export class AuthService {
           );
         })
       );
+  }
+
+  /**
+   * Prijavljuje klijenta sa email-om i lozinkom.
+   */
+  loginClient(email: string, password: string): Observable<ClientLoginResponse> {
+    return this.http
+      .post<ClientLoginResponse>(`${environment.apiUrl}/clients/auth/login`, {email, password})
+      .pipe(
+        tap(res => {
+          localStorage.setItem(this.TOKEN_KEY, res.token);
+
+          // Izvuci ulogu iz JWT tokena
+          let role = 'CLIENT';
+          try {
+            const payload = JSON.parse(atob(res.token.split('.')[1]));
+            role = payload.roles ?? 'CLIENT';
+          } catch (_) {}
+
+          localStorage.setItem(
+            this.USER_KEY,
+            JSON.stringify({
+              email,
+              role,
+              permissions: ['BANKING_BASIC']
+            })
+          );
+        })
+      );
+  }
+
+  /**
+   * Vraća ulogu korisnika.
+   */
+  getUserRole(): string {
+    const user = this.getLoggedUser();
+    return (user as any)?.role ?? '';
+  }
+
+  /**
+   * Da li je ulogovani korisnik klijent.
+   */
+  isClient(): boolean {
+    const role = this.getUserRole().toUpperCase();
+    return role.startsWith('CLIENT');
   }
 
   /**

--- a/src/app/features/auth/components/login/login.component.ts
+++ b/src/app/features/auth/components/login/login.component.ts
@@ -29,25 +29,36 @@ export class LoginComponent {
     const trimmedPassword = this.password.trim();
 
     if (!trimmedEmail || !trimmedPassword) {
-      this.errorMessage = 'Email and password are required.';
+      this.errorMessage = 'Email i lozinka su obavezni.';
       return;
     }
 
     this.isLoading = true;
 
-    this.authService.login(trimmedEmail, trimmedPassword).subscribe({
+    // Prvo pokušaj kao klijent, pa ako ne uspe kao zaposleni
+    this.authService.loginClient(trimmedEmail, trimmedPassword).subscribe({
       next: () => {
         this.isLoading = false;
-        this.toastService.success('Successfully signed in.');
-        this.router.navigate(['/employees']);
+        this.toastService.success('Uspešna prijava.');
+        this.router.navigate(['/home']);
       },
-      error: (error: HttpErrorResponse) => {
-        this.isLoading = false;
-        this.errorMessage =
-          error.error?.message ||
-          error.error?.error ||
-          'Login failed. Please check your credentials.';
-        this.toastService.error(this.errorMessage);
+      error: () => {
+        // Klijentski login nije uspeo, pokušaj kao zaposleni
+        this.authService.login(trimmedEmail, trimmedPassword).subscribe({
+          next: () => {
+            this.isLoading = false;
+            this.toastService.success('Uspešna prijava.');
+            this.router.navigate(['/employees']);
+          },
+          error: (error: HttpErrorResponse) => {
+            this.isLoading = false;
+            this.errorMessage =
+              error.error?.message ||
+              error.error?.error ||
+              'Prijava neuspešna. Proverite vaše podatke.';
+            this.toastService.error(this.errorMessage);
+          }
+        });
       }
     });
   }

--- a/src/app/features/client/components/account-create/account-create.component.ts
+++ b/src/app/features/client/components/account-create/account-create.component.ts
@@ -476,7 +476,7 @@ export class AccountCreateComponent implements OnInit, OnDestroy {
         next: (items: ClientDto[]) => {
           this.clients = items.map((client) => ({
             id: String(client.id),
-            name: client.ime ?? `${client.ime ?? ''} ${client.prezime  ?? ''}`.trim()
+            name: `${client.ime ?? ''} ${client.prezime ?? ''}`.trim() || `Klijent #${client.id}`
           }));
         },
         error: (err: unknown) => {

--- a/src/app/features/client/components/account-list/account-list.component.html
+++ b/src/app/features/client/components/account-list/account-list.component.html
@@ -90,9 +90,44 @@
         <span class="text-xs text-muted-foreground font-medium">{{ selectedAccount.name }}</span>
       </div>
 
-      <div class="py-10 text-center border border-dashed border-border rounded-lg bg-muted/30 text-muted-foreground text-sm">
-        <p>Transakcije za ovaj račun biće prikazane ovde.</p>
+      <div *ngIf="transactionsLoading" class="py-6 text-center">
+        <svg class="w-6 h-6 mx-auto animate-spin text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M21 12a9 9 0 1 1-6.219-8.56"></path>
+        </svg>
       </div>
+
+      <div *ngIf="!transactionsLoading && transactions.length === 0"
+           class="py-10 text-center border border-dashed border-border rounded-lg bg-muted/30 text-muted-foreground text-sm">
+        <p>Nema transakcija za ovaj račun.</p>
+      </div>
+
+      <table *ngIf="!transactionsLoading && transactions.length > 0" class="z-table">
+        <thead>
+          <tr>
+            <th>Datum</th>
+            <th>Primalac</th>
+            <th>Iznos</th>
+            <th>Valuta</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let tx of transactions">
+            <td class="text-muted-foreground whitespace-nowrap">{{ formatDate(tx.createdAt) }}</td>
+            <td class="font-medium">{{ tx.recipientName }}</td>
+            <td class="font-semibold">{{ formatAmount(tx.amount) }} </td>
+            <td>{{ tx.currency }}</td>
+            <td>
+              <span class="z-badge" [ngClass]="{
+                'z-badge-green': tx.status === 'COMPLETED',
+                'z-badge-gray': tx.status === 'PENDING',
+                'z-badge-red': tx.status === 'FAILED',
+                'z-badge-yellow': tx.status === 'CANCELLED'
+              }">{{ getStatusLabel(tx.status) }}</span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </div>
 </div>

--- a/src/app/features/client/components/account-list/account-list.component.ts
+++ b/src/app/features/client/components/account-list/account-list.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Account } from '../../models/account.model';
+import { Transaction } from '../../models/transaction.model';
 import { NavbarComponent } from 'src/app/shared/components/navbar/navbar.component';
 import { AccountDetailsModalComponent } from '../../modals/account-details-modal/account-details-modal.component';
 import { AccountService } from '../../services/account.service';
@@ -21,6 +22,8 @@ export class AccountListComponent implements OnInit {
   public isDetailsModalOpen = false;
   public isLoading = false;
   public errorMessage = '';
+  public transactions: Transaction[] = [];
+  public transactionsLoading = false;
 
   constructor(
     private readonly accountService: AccountService,
@@ -53,7 +56,7 @@ export class AccountListComponent implements OnInit {
           .sort((a, b) => b.availableBalance - a.availableBalance);
 
         if (this.accounts.length > 0) {
-          this.selectedAccount = this.accounts[0];
+          this.selectAccount(this.accounts[0]);
         }
 
         this.isLoading = false;
@@ -74,6 +77,7 @@ export class AccountListComponent implements OnInit {
    */
   public selectAccount(account: Account): void {
     this.selectedAccount = account;
+    this.loadTransactions(account.accountNumber);
   }
 
   /**
@@ -169,5 +173,39 @@ export class AccountListComponent implements OnInit {
 
   public onCreateAccount(): void {
     this.router.navigate(['/accounts/new']);
+  }
+
+  private loadTransactions(accountNumber: string): void {
+    this.transactionsLoading = true;
+    this.transactions = [];
+
+    this.accountService.getTransactions(+accountNumber, 0, 5).subscribe({
+      next: (data: Transaction[]) => {
+        this.transactions = data ?? [];
+        this.transactionsLoading = false;
+      },
+      error: () => {
+        this.transactions = [];
+        this.transactionsLoading = false;
+      }
+    });
+  }
+
+  public formatDate(dateStr: string): string {
+    const date = new Date(dateStr);
+    const day = String(date.getDate()).padStart(2, '0');
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const year = date.getFullYear();
+    return `${day}.${month}.${year}`;
+  }
+
+  public getStatusLabel(status: string): string {
+    const map: Record<string, string> = {
+      COMPLETED: 'Odobreno',
+      PENDING: 'Čekanje',
+      FAILED: 'Odbijeno',
+      CANCELLED: 'Otkazano'
+    };
+    return map[status] ?? status;
   }
 }

--- a/src/app/features/client/components/client-detail/client-detail.component.html
+++ b/src/app/features/client/components/client-detail/client-detail.component.html
@@ -11,14 +11,18 @@
       Nazad na listu
     </button>
 
-    <h1 class="text-2xl font-bold text-foreground mb-6">Detalji klijenta: {{ clientForm.get('firstName')?.value }}</h1>
+    <h1 class="text-2xl font-bold text-foreground mb-6">Detalji klijenta: {{ clientForm.get('ime')?.value }}</h1>
 
     <div class="z-card p-6">
-      <div *ngIf="errorMessage" class="mb-4 px-4 py-3 rounded-lg bg-red-50 border border-red-200 text-red-700 text-sm">
+      <div *ngIf="isLoading" class="flex justify-center items-center p-12">
+        <svg class="w-8 h-8 text-primary animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg>
+      </div>
+
+      <div *ngIf="errorMessage && !isLoading" class="mb-4 px-4 py-3 rounded-lg bg-red-50 border border-red-200 text-red-700 text-sm">
         {{ errorMessage }}
       </div>
 
-      <form [formGroup]="clientForm" (ngSubmit)="onSubmit()">
+      <form *ngIf="!isLoading" [formGroup]="clientForm" (ngSubmit)="onSubmit()">
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
             <label class="z-label">Ime</label>
@@ -30,7 +34,9 @@
           </div>
           <div>
             <label class="z-label">Email</label>
-            <input type="email" formControlName="email" class="z-input" />
+            <input type="email" formControlName="email" class="z-input" [class.border-red-500]="clientForm.get('email')?.invalid && clientForm.get('email')?.touched" />
+            <p *ngIf="clientForm.get('email')?.hasError('email') && clientForm.get('email')?.touched" class="text-xs text-red-500 mt-1">Unesite validan email.</p>
+            <p *ngIf="backendEmailError" class="text-xs text-red-500 mt-1">{{ backendEmailError }}</p>
           </div>
           <div>
             <label class="z-label">Broj telefona</label>

--- a/src/app/features/client/components/client-detail/client-detail.component.ts
+++ b/src/app/features/client/components/client-detail/client-detail.component.ts
@@ -44,7 +44,9 @@ export class ClientDetailComponent implements OnInit {
       
       if (passedClient) {
         this.patchFormWithClient(passedClient);
-      } 
+      } else {
+        this.loadClient(this.clientId);
+      }
     }
   }
 
@@ -81,6 +83,20 @@ onSubmit(): void {
     });
   }
 }
+
+  private loadClient(id: string): void {
+    this.isLoading = true;
+    this.clientService.getClientById(id).subscribe({
+      next: (client) => {
+        this.patchFormWithClient(client);
+        this.isLoading = false;
+      },
+      error: () => {
+        this.errorMessage = 'Greška pri učitavanju podataka klijenta.';
+        this.isLoading = false;
+      }
+    });
+  }
 
   onCancel(): void {
     this.router.navigate(['/clients']);

--- a/src/app/features/client/home/home.component.html
+++ b/src/app/features/client/home/home.component.html
@@ -56,6 +56,7 @@
         <div class="z-card p-5 row-span-2 hover:shadow-md transition-shadow">
           <div class="flex items-center justify-between mb-4">
             <span class="text-[11px] font-bold tracking-wider text-muted-foreground uppercase">Računi</span>
+            <a routerLink="/accounts" class="text-xs text-primary hover:underline font-medium">Svi računi</a>
           </div>
 
           <ng-container *ngIf="loading">
@@ -90,9 +91,12 @@
         <div class="z-card p-5 col-span-2 hover:shadow-md transition-shadow">
           <div class="flex items-center justify-between mb-4">
             <span class="text-[11px] font-bold tracking-wider text-muted-foreground uppercase">Pregled transakcija</span>
-            <span *ngIf="selectedAccount" class="text-xs text-muted-foreground font-medium">
-              {{ selectedAccount.name }}
-            </span>
+            <div class="flex items-center gap-3">
+              <span *ngIf="selectedAccount" class="text-xs text-muted-foreground font-medium">
+                {{ selectedAccount.name }}
+              </span>
+              <a routerLink="/payments" class="text-xs text-primary hover:underline font-medium">Sve transakcije</a>
+            </div>
           </div>
 
           <ng-container *ngIf="transactionsLoading">
@@ -116,6 +120,7 @@
               <tr>
                 <th>Datum</th>
                 <th>Primalac</th>
+                <th>Tip</th>
                 <th>Iznos</th>
                 <th>Status</th>
               </tr>
@@ -124,6 +129,14 @@
               <tr *ngFor="let tx of transactions">
                 <td class="text-muted-foreground whitespace-nowrap">{{ formatDate(tx.createdAt) }}</td>
                 <td class="font-medium">{{ tx.recipientName }}</td>
+                <td>
+                  <span class="z-badge" [ngClass]="{
+                    'z-badge-blue': tx.type === 'TRANSFER',
+                    'z-badge-gray': tx.type === 'PAYMENT',
+                    'z-badge-green': tx.type === 'DEPOSIT',
+                    'z-badge-yellow': tx.type === 'WITHDRAWAL'
+                  }">{{ getTypeLabel(tx.type) }}</span>
+                </td>
                 <td class="font-semibold whitespace-nowrap">{{ formatAmount(tx.amount, tx.currency) }}</td>
                 <td>
                   <span class="z-badge" [ngClass]="{
@@ -143,7 +156,12 @@
           <div class="flex items-center justify-between mb-4">
             <span class="text-[11px] font-bold tracking-wider text-muted-foreground uppercase">Menjačnica</span>
           </div>
-          <p class="text-sm text-muted-foreground text-center py-5 italic">Kalkulator menjačnice — dostupno uskoro.</p>
+          <div class="text-center py-4">
+            <div class="w-12 h-12 mx-auto mb-3 rounded-full bg-secondary flex items-center justify-center">
+              <span class="material-icons text-primary text-xl">currency_exchange</span>
+            </div>
+            <p class="text-sm text-muted-foreground italic">Kalkulator menjačnice — dostupno uskoro.</p>
+          </div>
         </div>
 
         <!-- Quick payment placeholder -->
@@ -151,7 +169,12 @@
           <div class="flex items-center justify-between mb-4">
             <span class="text-[11px] font-bold tracking-wider text-muted-foreground uppercase">Brzo plaćanje</span>
           </div>
-          <p class="text-sm text-muted-foreground text-center py-5 italic">Brzo plaćanje — dostupno uskoro.</p>
+          <div class="text-center py-4">
+            <div class="w-12 h-12 mx-auto mb-3 rounded-full bg-secondary flex items-center justify-center">
+              <span class="material-icons text-primary text-xl">bolt</span>
+            </div>
+            <p class="text-sm text-muted-foreground italic">Brzo plaćanje — dostupno uskoro.</p>
+          </div>
         </div>
 
       </div>

--- a/src/app/features/client/home/home.component.ts
+++ b/src/app/features/client/home/home.component.ts
@@ -206,4 +206,14 @@ export class HomeComponent implements OnInit {
     };
     return map[status] ?? status;
   }
+
+  getTypeLabel(type: string): string {
+    const map: Record<string, string> = {
+      PAYMENT: 'Plaćanje',
+      TRANSFER: 'Transfer',
+      DEPOSIT: 'Uplata',
+      WITHDRAWAL: 'Isplata'
+    };
+    return map[type] ?? type;
+  }
 }

--- a/src/app/features/client/modals/account-details-modal/account-details-modal.component.html
+++ b/src/app/features/client/modals/account-details-modal/account-details-modal.component.html
@@ -42,6 +42,41 @@
         </div>
       </div>
 
+      <!-- Limits section -->
+      <div class="space-y-2">
+        <p class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Limiti i potrošnja</p>
+        <div class="divide-y divide-border rounded-lg border border-border overflow-hidden">
+          <div class="flex justify-between items-center px-4 py-2.5 bg-card">
+            <span class="text-sm text-muted-foreground">Dnevni limit</span>
+            <span class="text-sm font-medium">{{ formatAmount(account.dailyLimit) }} {{ account.currency }}</span>
+          </div>
+          <div class="flex justify-between items-center px-4 py-2.5 bg-card">
+            <span class="text-sm text-muted-foreground">Dnevna potrošnja</span>
+            <span class="text-sm font-medium">{{ formatAmount(account.dailySpending) }} {{ account.currency }}</span>
+          </div>
+          <div class="flex justify-between items-center px-4 py-2.5 bg-card">
+            <span class="text-sm text-muted-foreground">Mesečni limit</span>
+            <span class="text-sm font-medium">{{ formatAmount(account.monthlyLimit) }} {{ account.currency }}</span>
+          </div>
+          <div class="flex justify-between items-center px-4 py-2.5 bg-card">
+            <span class="text-sm text-muted-foreground">Mesečna potrošnja</span>
+            <span class="text-sm font-medium">{{ formatAmount(account.monthlySpending) }} {{ account.currency }}</span>
+          </div>
+          <div class="flex justify-between items-center px-4 py-2.5 bg-card">
+            <span class="text-sm text-muted-foreground">Naknada za održavanje</span>
+            <span class="text-sm font-medium">{{ formatAmount(account.maintenanceFee) }} {{ account.currency }}</span>
+          </div>
+          <div class="flex justify-between items-center px-4 py-2.5 bg-card">
+            <span class="text-sm text-muted-foreground">Datum kreiranja</span>
+            <span class="text-sm font-medium">{{ account.createdAt | date:'dd.MM.yyyy' }}</span>
+          </div>
+          <div class="flex justify-between items-center px-4 py-2.5 bg-card" *ngIf="account.expiryDate">
+            <span class="text-sm text-muted-foreground">Datum isteka</span>
+            <span class="text-sm font-medium">{{ account.expiryDate | date:'dd.MM.yyyy' }}</span>
+          </div>
+        </div>
+      </div>
+
       <!-- Company section -->
       <div *ngIf="isBusinessAccount()" class="space-y-2">
         <p class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Podaci o firmi</p>

--- a/src/app/features/client/modals/account-details-modal/account-details-modal.component.ts
+++ b/src/app/features/client/modals/account-details-modal/account-details-modal.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
 import { Account } from '../../models/account.model';
 import { RenameAccountComponent } from '../../components/rename-account/rename-account.component';
 import { ChangeLimitModalComponent } from '../change-limit-modal/change-limit-modal.component';
@@ -22,6 +23,8 @@ export class AccountDetailsModalComponent {
 
     return ['DOO', 'AD', 'FOUNDATION', 'FOREIGN_BUSINESS'].includes(this.account.subtype);
   }
+
+  constructor(private router: Router) {}
 
   public getModalSubtitle(): string {
     return this.isBusinessAccount()
@@ -50,9 +53,10 @@ export class AccountDetailsModalComponent {
     this.showRenameModal = false;
   }
 
-  // TODO: navigate na stranicu za novo placanje (sledeci sprint)
+  // Navigate to new payment page
   public onNewPayment(): void {
-    console.log('Open new payment flow');
+    this.closeModal();
+    this.router.navigate(['/accounts/payment/new']);
   }
 
   public isChangeLimitModalOpen = false;

--- a/src/app/features/client/modals/verification-modal/verification-modal.component.html
+++ b/src/app/features/client/modals/verification-modal/verification-modal.component.html
@@ -6,21 +6,36 @@
     </div>
 
     <div class="z-modal-body space-y-4">
-      <p class="text-sm text-muted-foreground">Verifikacioni kod je poslat na vaš uređaj (Mock: 1234).</p>
-      <div>
+      <p class="text-sm text-muted-foreground">
+        Verifikacioni kod je poslat na vaš email.
+        <span class="text-xs text-muted-foreground/70 block mt-1">(Za testiranje koristite kod: 1234)</span>
+      </p>
+
+      <div *ngIf="isSendingCode" class="flex justify-center py-4">
+        <svg class="w-6 h-6 animate-spin text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M21 12a9 9 0 1 1-6.219-8.56"></path>
+        </svg>
+      </div>
+
+      <div *ngIf="!isSendingCode">
         <label for="code" class="z-label">Unesite kod</label>
         <input type="text" id="code" class="z-input text-center tracking-[0.5em] text-lg font-semibold"
                [(ngModel)]="verificationCode" placeholder="0000" maxlength="4"
                (keyup.enter)="verificationCode.length === 4 && onConfirm()" />
       </div>
+
       <div *ngIf="attempts > 0">
         <span class="z-badge z-badge-yellow text-xs">Pokušaji: {{ attempts }} / {{ maxAttempts }}</span>
       </div>
+
+      <button type="button" class="text-xs text-primary hover:underline" (click)="sendVerificationCode()" [disabled]="isSendingCode">
+        Pošalji ponovo
+      </button>
     </div>
 
     <div class="z-modal-footer">
       <button type="button" class="z-btn-outline" (click)="onClose()">Odustani</button>
-      <button type="button" class="z-btn-primary" (click)="onConfirm()" [disabled]="verificationCode.length < 4">Potvrdi</button>
+      <button type="button" class="z-btn-primary" (click)="onConfirm()" [disabled]="verificationCode.length < 4 || isSendingCode">Potvrdi</button>
     </div>
   </div>
 </div>

--- a/src/app/features/client/modals/verification-modal/verification-modal.component.ts
+++ b/src/app/features/client/modals/verification-modal/verification-modal.component.ts
@@ -1,7 +1,10 @@
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { HttpClient } from '@angular/common/http';
 import { ToastService } from '../../../../shared/services/toast.service';
+import { AuthService } from '../../../../core/services/auth.service';
+import { environment } from '../../../../../environments/environment';
 
 @Component({
   selector: 'app-verification-modal',
@@ -10,29 +13,78 @@ import { ToastService } from '../../../../shared/services/toast.service';
   templateUrl: './verification-modal.component.html',
   styleUrls: ['./verification-modal.component.scss']
 })
-export class VerificationModalComponent {
+export class VerificationModalComponent implements OnInit {
   @Output() confirmed = new EventEmitter<boolean>();
   @Output() closed = new EventEmitter<void>();
 
   verificationCode: string = '';
   attempts: number = 0;
-  readonly correctCode: string = '1234';
   readonly maxAttempts: number = 3;
+  codeSent = false;
+  isSendingCode = false;
 
-  constructor(private toastService: ToastService) {}
+  constructor(
+    private toastService: ToastService,
+    private authService: AuthService,
+    private http: HttpClient
+  ) {}
+
+  ngOnInit(): void {
+    this.sendVerificationCode();
+  }
+
+  sendVerificationCode(): void {
+    this.isSendingCode = true;
+    const user = this.authService.getLoggedUser();
+    const email = user?.email;
+
+    if (!email) {
+      this.toastService.error('Nije moguće poslati verifikacioni kod.');
+      this.isSendingCode = false;
+      this.codeSent = true;
+      return;
+    }
+
+    this.http.post(`${environment.apiUrl}/clients/auth/send-verification`, { email }, { responseType: 'text' })
+      .subscribe({
+        next: () => {
+          this.codeSent = true;
+          this.isSendingCode = false;
+          this.toastService.info('Verifikacioni kod je poslat na vaš email.');
+        },
+        error: () => {
+          this.codeSent = true;
+          this.isSendingCode = false;
+          this.toastService.warning('Kod nije poslat - koristite testni kod: 1234');
+        }
+      });
+  }
 
   onConfirm() {
-    if (this.verificationCode === this.correctCode) {
-      this.confirmed.emit(true);
-    } else {
-      this.attempts++;
-      if (this.attempts >= this.maxAttempts) {
-        this.toastService.error('Transakcija je otkazana zbog previše neuspešnih pokušaja.');
-        this.closed.emit();
-      } else {
-        this.toastService.warning(`Pogrešan kod. Preostalo pokušaja: ${this.maxAttempts - this.attempts}`);
+    if (!this.verificationCode || this.verificationCode.length < 4) return;
+
+    this.http.post(`${environment.apiUrl}/clients/auth/verify-code`,
+      { code: this.verificationCode },
+      { responseType: 'text' }
+    ).subscribe({
+      next: () => {
+        this.confirmed.emit(true);
+      },
+      error: () => {
+        // Fallback: accept mock code "1234" for development
+        if (this.verificationCode === '1234') {
+          this.confirmed.emit(true);
+          return;
+        }
+        this.attempts++;
+        if (this.attempts >= this.maxAttempts) {
+          this.toastService.error('Transakcija je otkazana zbog previše neuspešnih pokušaja.');
+          this.closed.emit();
+        } else {
+          this.toastService.warning(`Pogrešan kod. Preostalo pokušaja: ${this.maxAttempts - this.attempts}`);
+        }
       }
-    }
+    });
   }
 
   onClose() {

--- a/src/app/features/client/services/payment.service.ts
+++ b/src/app/features/client/services/payment.service.ts
@@ -40,8 +40,10 @@ export class PaymentService {
     if (filters.status) {
       params = params.set('status', filters.status);
     }
-    
-    
+    if (filters.type) {
+      params = params.set('type', filters.type);
+    }
+
     return this.http.get<PaymentPage>(this.baseUrl, { params });
   }
 

--- a/src/app/shared/components/navbar/navbar.component.html
+++ b/src/app/shared/components/navbar/navbar.component.html
@@ -57,7 +57,7 @@
     <button class="w-9 h-9 rounded-full bg-white/10 text-white flex items-center justify-center border-0 cursor-pointer hover:bg-white/20 transition-colors" title="Obaveštenja">
       <span class="material-icons text-xl">notifications</span>
     </button>
-    <span class="text-sm text-white/80 whitespace-nowrap">Dobro došli</span>
+    <span class="text-sm text-white/80 whitespace-nowrap">{{ userName || 'Dobro došli' }}</span>
     <button class="w-9 h-9 rounded-full bg-white/10 text-white flex items-center justify-center border-0 cursor-pointer hover:bg-white/20 transition-colors" routerLink="/profile" title="Profil">
       <span class="material-icons text-xl">account_circle</span>
     </button>

--- a/src/app/shared/components/navbar/navbar.component.ts
+++ b/src/app/shared/components/navbar/navbar.component.ts
@@ -1,7 +1,13 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { AuthService } from '../../../core/services/auth.service';
+
+interface NavLink {
+  label: string;
+  route: string;
+  icon: string;
+}
 
 @Component({
   selector: 'app-navbar',
@@ -10,21 +16,45 @@ import { AuthService } from '../../../core/services/auth.service';
   templateUrl: './navbar.component.html',
   styleUrls: ['./navbar.component.scss']
 })
-export class NavbarComponent {
-  constructor(private authService: AuthService) {}
+export class NavbarComponent implements OnInit {
+  navLinks: NavLink[] = [];
+  userRole = '';
+  userName = '';
 
-  navLinks = [
+  private readonly clientLinks: NavLink[] = [
+    { label: 'Početna',    route: '/home',                icon: 'home' },
     { label: 'Računi',     route: '/accounts',            icon: 'account_balance' },
-    { label: 'Klijenti',   route: '/clients',             icon: 'person' },
     { label: 'Plaćanja',   route: '/payments',            icon: 'payments' },
     { label: 'Prenos',     route: '/transfers/same',      icon: 'compare_arrows' },
     { label: 'Transfer',   route: '/transfers/different', icon: 'currency_exchange' },
     { label: 'Menjačnica', route: '/exchange',            icon: 'currency_exchange' },
-    { label: 'Kartice',    route: '/cards',               icon: 'credit_card' },
-    { label: 'Krediti',    route: '/loans',               icon: 'account_balance_wallet' },
-    {label: 'Upravljanje računima',route: '/account-management',icon: 'account_balance'},
     { label: 'Primaoci plaćanja', route: '/payments/recipients', icon: 'people' },
   ];
+
+  private readonly employeeLinks: NavLink[] = [
+    { label: 'Zaposleni',  route: '/employees',           icon: 'badge' },
+    { label: 'Klijenti',   route: '/clients',             icon: 'person' },
+    { label: 'Kreiraj račun', route: '/accounts/new',     icon: 'add_card' },
+    { label: 'Upravljanje računima', route: '/account-management', icon: 'account_balance' },
+  ];
+
+  constructor(private authService: AuthService) {}
+
+  ngOnInit(): void {
+    const user = this.authService.getLoggedUser();
+    this.userRole = (user as any)?.role ?? '';
+    this.userName = user?.email ?? '';
+
+    if (this.isClient()) {
+      this.navLinks = this.clientLinks;
+    } else {
+      this.navLinks = this.employeeLinks;
+    }
+  }
+
+  isClient(): boolean {
+    return this.userRole.toUpperCase().startsWith('CLIENT');
+  }
 
   logout(): void {
     this.authService.logout();


### PR DESCRIPTION
## Opis promena

Kompletno razdvajanje frontend UI-a na osnovu uloge korisnika (klijent vs zaposleni), sa nizom ispravki i poboljsanja.

### Login
- Automatska detekcija tipa korisnika - prvo pokusava klijentski login, pa zaposleni
- Nema rucnog biranja tipa (uklonjeni tabovi Klijent/Zaposleni)
- Podrska za CLIENT_BASIC ulogu iz JWT tokena

### Navbar
- Klijent vidi: Pocetna, Racuni, Placanja, Prenos, Transfer, Menjacnica, Primaoci
- Zaposleni vidi: Zaposleni, Klijenti, Kreiraj racun, Upravljanje racunima

### Klijentske stranice
- **Pocetna**: prikaz transakcija sa tipom, linkovi na sve racune i placanja
- **Racuni**: tabela transakcija za selektovani racun (datum, primalac, iznos, valuta, status)
- **Detalji racuna (modal)**: limiti, potrosnja, datum kreiranja/isteka, navigacija na novo placanje
- **Verifikacija (modal)**: slanje koda na email sa fallback-om za dev
- **Placanja**: ispravljen type filter u servisu (domestic/transfer tabovi sada rade)

### Zaposlene stranice
- **Kreiranje racuna**: prikaz punog imena klijenta u dropdown-u
- **Detalji klijenta**: ispravljen naslov, email validacija, ucitavanje sa API-ja, loading stanje

### Infrastruktura
- Dockerfile: dodat nginx.conf za SPA routing
- Auth interceptor: prosirena skip lista za auth URL-ove

### Kredencijali za testiranje
| Tip | Email | Lozinka | Redirect |
|---|---|---|---|
| Admin | admin@banka.com | admin123 | /employees |
| Klijent | marko.markovic@banka.com | admin123 | /home |
