### PR TITLE
Fix accountNumber type and rename account flow

### DIFF
--- a/src/app/features/client/components/account-list/account-list.component.html
+++ b/src/app/features/client/components/account-list/account-list.component.html
@@ -136,5 +136,5 @@
   *ngIf="isDetailsModalOpen && detailsAccount"
   [account]="detailsAccount"
   [allAccounts]="accounts"
-  (close)="closeDetailsModal()">
+  (close)="closeDetailsModal(); loadAccounts()">
 </app-account-details-modal>

--- a/src/app/features/client/components/account-list/account-list.component.ts
+++ b/src/app/features/client/components/account-list/account-list.component.ts
@@ -45,7 +45,7 @@ export class AccountListComponent implements OnInit {
    * - Kada backend bude potpuno stabilan i više ne bude potrebe za lokalnim prikazom,
    *   zakomentarisani mock deo moze da se obrise.
    */
-  private loadAccounts(): void {
+  public loadAccounts(): void {
     this.isLoading = true;
     this.errorMessage = '';
 
@@ -179,7 +179,7 @@ export class AccountListComponent implements OnInit {
     this.transactionsLoading = true;
     this.transactions = [];
 
-    this.accountService.getTransactions(+accountNumber, 0, 5).subscribe({
+    this.accountService.getTransactions(accountNumber, 0, 5).subscribe({
       next: (data: Transaction[]) => {
         this.transactions = data ?? [];
         this.transactionsLoading = false;

--- a/src/app/features/client/components/rename-account/rename-account.component.html
+++ b/src/app/features/client/components/rename-account/rename-account.component.html
@@ -32,6 +32,7 @@
         </div>
       </div>
 
+      <p *ngIf="errorMessage" class="z-error px-5 pb-2">{{ errorMessage }}</p>
       <div class="z-modal-footer">
         <button type="button" class="z-btn z-btn-outline" (click)="onCancel()">Nazad</button>
         <button type="button" class="z-btn z-btn-primary" (click)="onConfirm()" [disabled]="renameForm.invalid">Potvrdi</button>

--- a/src/app/features/client/components/rename-account/rename-account.component.ts
+++ b/src/app/features/client/components/rename-account/rename-account.component.ts
@@ -18,6 +18,7 @@ export class RenameAccountComponent implements OnInit {
   @Output() updated = new EventEmitter<string>();
 
   renameForm: FormGroup;
+  errorMessage = '';
 
   constructor(private fb: FormBuilder, private accountService: AccountService) {
     this.renameForm = this.fb.group({
@@ -70,9 +71,15 @@ export class RenameAccountComponent implements OnInit {
     if (this.renameForm.valid) {
       // Trimujemo pre slanja na backend da ne bismo slali prazna mesta
       const newName = this.renameForm.value.newName.trim(); 
-      this.accountService.renameAccount(+this.account.accountNumber, newName).subscribe(() => {
-        this.updated.emit(newName);
-        this.onCancel();
+      this.errorMessage = '';
+      this.accountService.renameAccount(this.account.accountNumber, newName).subscribe({
+        next: () => {
+          this.updated.emit(newName);
+          this.onCancel();
+        },
+        error: () => {
+          this.errorMessage = 'Greška pri promeni naziva. Pokušajte ponovo.';
+        }
       });
     }
   }

--- a/src/app/features/client/home/home.component.ts
+++ b/src/app/features/client/home/home.component.ts
@@ -59,14 +59,14 @@ export class HomeComponent implements OnInit {
 
   selectAccount(account: Account): void {
     this.selectedAccount = account;
-    this.loadTransactions(+account.accountNumber);
+    this.loadTransactions(account.accountNumber);
   }
 
   isSelected(account: Account): boolean {
     return this.selectedAccount?.id === account.id;
   }
 
-  loadTransactions(accountNumber: number): void {
+  loadTransactions(accountNumber: string): void {
     this.transactionsLoading = true;
     this.transactionsError = false;
     this.transactions = [];

--- a/src/app/features/client/modals/change-limit-modal/change-limit-modal.component.ts
+++ b/src/app/features/client/modals/change-limit-modal/change-limit-modal.component.ts
@@ -78,7 +78,7 @@ export class ChangeLimitModalComponent implements OnInit {
       verificationCode: formValue.verificationCode
     };
 
-    this.accountService.changeLimit(+this.account.accountNumber, payload.dailyLimit, payload.monthlyLimit, payload.verificationCode, '123456789')
+    this.accountService.changeLimit(this.account.accountNumber, payload.dailyLimit, payload.monthlyLimit, payload.verificationCode, '123456789')
       .subscribe({
         next: () => {
           this.toastService.success('Limiti računa su uspešno ažurirani.');

--- a/src/app/features/client/services/account.service.ts
+++ b/src/app/features/client/services/account.service.ts
@@ -103,7 +103,7 @@ export class AccountService {
   }
 
   getTransactions(
-    accountNumber: number,
+    accountNumber: string,
     page = 0,
     size = 5,
   ): Observable<Transaction[]> {
@@ -117,15 +117,16 @@ export class AccountService {
       .pipe(map((res) => res.content));
   }
 
-  renameAccount(accountNumber: number, name: string): Observable<void> {
+  renameAccount(accountNumber: string, name: string): Observable<void> {
     return this.http.put<void>(
       `${this.api}/client/api/accounts/${accountNumber}/name`,
       { accountName: name },
+      { responseType: 'text' as 'json' },
     );
   }
 
   changeLimit(
-    accountNumber: number,
+    accountNumber: string,
     dailyLimit: number,
     monthlyLimit: number,
     verificationCode: string,


### PR DESCRIPTION
- Change accountNumber from number to string throughout account service, home and account-list components to prevent precision loss on 18-digit values
- Add error handling and responseType fix to renameAccount so empty backend responses are handled correctly and UI reflects success/failure
- Reload account list after details modal closes