### PR TITLE
feat(portfolio): add my portfolio page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -29,6 +29,8 @@ import { ExchangeListComponent } from './features/employee/components/exchange-l
 import { LoanRequestManagementComponent } from './features/employee/components/loan-request-management/loan-request-management.component';
 import { LoanManagementComponent } from './features/employee/components/loan-management/loan-management.component';
 import { LoanRequestComponent } from './features/client/components/loan-request/loan-request.component';
+import { PortfolioComponent } from './features/client/components/portfolio/portfolio.component';
+import { portfolioAccessGuard } from './core/guards/portfolio-access.guard';
 
 const routes: Routes = [
   {
@@ -172,6 +174,11 @@ const routes: Routes = [
     path: 'securities',
     component: SecuritiesListComponent,
     canActivate: [authGuard],
+  },
+  {
+    path: 'portfolio',
+    component: PortfolioComponent,
+    canActivate: [authGuard, portfolioAccessGuard],
   },
   {
     path: 'securities/stock/:ticker',

--- a/src/app/core/guards/portfolio-access.guard.spec.ts
+++ b/src/app/core/guards/portfolio-access.guard.spec.ts
@@ -1,0 +1,47 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { portfolioAccessGuard } from './portfolio-access.guard';
+import { AuthService } from '../services/auth.service';
+
+describe('portfolioAccessGuard', () => {
+  let router: Router;
+  let authServiceSpy: jasmine.SpyObj<AuthService>;
+
+  beforeEach(() => {
+    authServiceSpy = jasmine.createSpyObj<AuthService>('AuthService', ['canAccessPortfolio']);
+
+    TestBed.configureTestingModule({
+      imports: [
+        RouterTestingModule.withRoutes([
+          { path: '403', component: {} as any },
+        ]),
+      ],
+      providers: [
+        { provide: AuthService, useValue: authServiceSpy },
+      ],
+    });
+
+    router = TestBed.inject(Router);
+  });
+
+  it('should allow access when user can access portfolio', () => {
+    authServiceSpy.canAccessPortfolio.and.returnValue(true);
+    const navigateSpy = spyOn(router, 'navigate');
+
+    const result = TestBed.runInInjectionContext(() => portfolioAccessGuard());
+
+    expect(result).toBeTrue();
+    expect(navigateSpy).not.toHaveBeenCalled();
+  });
+
+  it('should redirect to /403 when user cannot access portfolio', () => {
+    authServiceSpy.canAccessPortfolio.and.returnValue(false);
+    const navigateSpy = spyOn(router, 'navigate');
+
+    const result = TestBed.runInInjectionContext(() => portfolioAccessGuard());
+
+    expect(result).toBeFalse();
+    expect(navigateSpy).toHaveBeenCalledWith(['/403']);
+  });
+});

--- a/src/app/core/guards/portfolio-access.guard.ts
+++ b/src/app/core/guards/portfolio-access.guard.ts
@@ -1,0 +1,15 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+export const portfolioAccessGuard: CanActivateFn = () => {
+  const router = inject(Router);
+  const authService = inject(AuthService);
+
+  if (!authService.canAccessPortfolio()) {
+    router.navigate(['/403']);
+    return false;
+  }
+
+  return true;
+};

--- a/src/app/core/services/auth.service.spec.ts
+++ b/src/app/core/services/auth.service.spec.ts
@@ -3,6 +3,10 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AuthService } from './auth.service';
 
+function createToken(payload: Record<string, unknown>): string {
+  return `header.${btoa(JSON.stringify(payload))}.signature`;
+}
+
 describe('AuthService', () => {
   let service: AuthService;
 
@@ -25,8 +29,6 @@ describe('AuthService', () => {
     localStorage.clear();
   });
 
-  // ─── getToken ───────────────────────────────────────────────────────────────
-
   describe('getToken', () => {
     it('should return null if no token in localStorage', () => {
       expect(service.getToken()).toBeNull();
@@ -38,7 +40,85 @@ describe('AuthService', () => {
     });
   });
 
-  // ─── isAuthenticated ────────────────────────────────────────────────────────
+  describe('getJwtRoles', () => {
+    it('should return empty array when token does not exist', () => {
+      expect(service.getJwtRoles()).toEqual([]);
+    });
+
+    it('should parse string role from token', () => {
+      localStorage.setItem('authToken', createToken({ roles: 'CLIENT_TRADING' }));
+
+      expect(service.getJwtRoles()).toEqual(['CLIENT_TRADING']);
+    });
+
+    it('should parse array roles from token', () => {
+      localStorage.setItem('authToken', createToken({ roles: ['agent', 'SUPERVISOR'] }));
+
+      expect(service.getJwtRoles()).toEqual(['AGENT', 'SUPERVISOR']);
+    });
+
+    it('should return empty array for malformed token', () => {
+      localStorage.setItem('authToken', 'invalid.token');
+
+      expect(service.getJwtRoles()).toEqual([]);
+    });
+  });
+
+  describe('isClient', () => {
+    it('should use JWT roles when available', () => {
+      localStorage.setItem('authToken', createToken({ roles: ['CLIENT_BASIC'] }));
+      localStorage.setItem('loggedUser', JSON.stringify({ email: 'test@test.com', role: 'Basic', permissions: [] }));
+
+      expect(service.isClient()).toBeTrue();
+    });
+
+    it('should fallback to logged user role when JWT roles are unavailable', () => {
+      localStorage.setItem('loggedUser', JSON.stringify({ email: 'test@test.com', role: 'CLIENT', permissions: [] }));
+
+      expect(service.isClient()).toBeTrue();
+    });
+  });
+
+  describe('isActuary', () => {
+    it('should return true for AGENT JWT role', () => {
+      localStorage.setItem('authToken', createToken({ roles: ['AGENT'] }));
+
+      expect(service.isActuary()).toBeTrue();
+    });
+
+    it('should return true for SUPERVISOR fallback role', () => {
+      localStorage.setItem('loggedUser', JSON.stringify({ email: 'test@test.com', role: 'SUPERVISOR', permissions: [] }));
+
+      expect(service.isActuary()).toBeTrue();
+    });
+
+    it('should return false when neither token nor stored role is actuary-like', () => {
+      localStorage.setItem('loggedUser', JSON.stringify({ email: 'test@test.com', role: 'BASIC', permissions: [] }));
+
+      expect(service.isActuary()).toBeFalse();
+    });
+  });
+
+  describe('canAccessPortfolio', () => {
+    it('should return true for client users', () => {
+      localStorage.setItem('authToken', createToken({ roles: ['CLIENT_TRADING'] }));
+
+      expect(service.canAccessPortfolio()).toBeTrue();
+    });
+
+    it('should return true for actuary users', () => {
+      localStorage.setItem('authToken', createToken({ roles: ['AGENT'] }));
+
+      expect(service.canAccessPortfolio()).toBeTrue();
+    });
+
+    it('should return false for unrelated roles', () => {
+      localStorage.setItem('authToken', createToken({ roles: ['EMPLOYEE'] }));
+      localStorage.setItem('loggedUser', JSON.stringify({ email: 'test@test.com', role: 'BASIC', permissions: [] }));
+
+      expect(service.canAccessPortfolio()).toBeFalse();
+    });
+  });
 
   describe('isAuthenticated', () => {
     it('should return false if no token', () => {
@@ -47,14 +127,14 @@ describe('AuthService', () => {
 
     it('should return false if token is expired', () => {
       const payload = { exp: Math.floor(Date.now() / 1000) - 3600 };
-      const token = `header.${btoa(JSON.stringify(payload))}.signature`;
+      const token = createToken(payload);
       localStorage.setItem('authToken', token);
       expect(service.isAuthenticated()).toBeFalse();
     });
 
     it('should return true if token is valid', () => {
       const payload = { exp: Math.floor(Date.now() / 1000) + 3600 };
-      const token = `header.${btoa(JSON.stringify(payload))}.signature`;
+      const token = createToken(payload);
       localStorage.setItem('authToken', token);
       expect(service.isAuthenticated()).toBeTrue();
     });
@@ -64,8 +144,6 @@ describe('AuthService', () => {
       expect(service.isAuthenticated()).toBeFalse();
     });
   });
-
-  // ─── hasPermission ──────────────────────────────────────────────────────────
 
   describe('hasPermission', () => {
     it('should return false if no user in localStorage', () => {
@@ -89,38 +167,29 @@ describe('AuthService', () => {
     });
   });
 
-  // ─── getUserIdFromToken ─────────────────────────────────────────────────────
-
   describe('getUserIdFromToken', () => {
     it('should return null if no token', () => {
       expect(service.getUserIdFromToken()).toBeNull();
     });
 
     it('should return user id from token', () => {
-      const payload = { id: 42 };
-      const token = `header.${btoa(JSON.stringify(payload))}.signature`;
-      localStorage.setItem('authToken', token);
+      localStorage.setItem('authToken', createToken({ id: 42 }));
       expect(service.getUserIdFromToken()).toBe(42);
     });
 
     it('should return null if token has no id field', () => {
-      const payload = { email: 'test@test.com' };
-      const token = `header.${btoa(JSON.stringify(payload))}.signature`;
-      localStorage.setItem('authToken', token);
+      localStorage.setItem('authToken', createToken({ email: 'test@test.com' }));
       expect(service.getUserIdFromToken()).toBeNull();
     });
   });
 
-  // ─── logout ─────────────────────────────────────────────────────────────────
-
   describe('logout', () => {
-    it('should clear all auth data from localStorage', async () => {
+    it('should clear all auth data from localStorage', () => {
       localStorage.setItem('authToken', 'token');
       localStorage.setItem('loggedUser', JSON.stringify({ email: 'test@test.com' }));
       localStorage.setItem('refreshToken', 'refresh');
 
       service.logout();
-      await TestBed.inject(RouterTestingModule as any, null);
 
       expect(localStorage.getItem('authToken')).toBeNull();
       expect(localStorage.getItem('loggedUser')).toBeNull();

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -99,12 +99,66 @@ export class AuthService {
     return (user as any)?.role ?? '';
   }
 
+  getJwtRoles(): string[] {
+    const token = this.getToken();
+
+    if (!token) {
+      return [];
+    }
+
+    try {
+      const payloadPart = token.split('.')[1];
+
+      if (!payloadPart) {
+        return [];
+      }
+
+      const normalizedPayload = payloadPart
+        .replace(/-/g, '+')
+        .replace(/_/g, '/');
+      const decodedPayload = atob(normalizedPayload);
+      const payload = JSON.parse(decodedPayload) as { roles?: string | string[] };
+
+      if (!payload.roles) {
+        return [];
+      }
+
+      const roles = Array.isArray(payload.roles) ? payload.roles : [payload.roles];
+      return roles
+        .map((role) => String(role).toUpperCase())
+        .filter(Boolean);
+    } catch {
+      return [];
+    }
+  }
+
   /**
    * Da li je ulogovani korisnik klijent.
    */
   isClient(): boolean {
+    const jwtRoles = this.getJwtRoles();
+
+    if (jwtRoles.length > 0) {
+      return jwtRoles.some((role) => role.startsWith('CLIENT'));
+    }
+
     const role = this.getUserRole().toUpperCase();
     return role.startsWith('CLIENT');
+  }
+
+  isActuary(): boolean {
+    const jwtRoles = this.getJwtRoles();
+
+    if (jwtRoles.length > 0) {
+      return jwtRoles.includes('AGENT') || jwtRoles.includes('SUPERVISOR');
+    }
+
+    const role = this.getUserRole().toUpperCase();
+    return role === 'AGENT' || role === 'SUPERVISOR';
+  }
+
+  canAccessPortfolio(): boolean {
+    return this.isClient() || this.isActuary();
   }
 
   /**

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -99,6 +99,11 @@ export class AuthService {
     return (user as any)?.role ?? '';
   }
 
+  /**
+   * Dekodira JWT role iz tokena.
+   * UPOZORENJE: Ovo se koristi samo za UI prikaz i frontend UX odluke.
+   * Backend mora da validira potpis tokena i role za sve autorizacione odluke.
+   */
   getJwtRoles(): string[] {
     const token = this.getToken();
 

--- a/src/app/features/client/components/portfolio/portfolio.component.html
+++ b/src/app/features/client/components/portfolio/portfolio.component.html
@@ -1,0 +1,167 @@
+<app-navbar />
+
+<div class="page-layout">
+  <div class="page-content">
+    <div class="flex items-center justify-between mb-6">
+      <div>
+        <h1 class="text-2xl font-bold text-foreground">Moj portfolio</h1>
+        <p class="text-sm text-muted-foreground mt-1">
+          Pregled hartija, ukupnog profita i poreskih obaveza.
+        </p>
+      </div>
+    </div>
+
+    <div *ngIf="isLoading" class="z-card p-12 text-center text-muted-foreground">
+      <svg class="w-8 h-8 mx-auto animate-spin text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <path d="M21 12a9 9 0 1 1-6.219-8.56"></path>
+      </svg>
+      <p class="mt-3 text-sm">Učitavanje portfolija...</p>
+    </div>
+
+    <div *ngIf="errorMessage && !isLoading" class="z-card p-8 text-center text-red-500 text-sm">
+      <p>{{ errorMessage }}</p>
+      <button type="button" class="z-btn-primary mt-4" (click)="loadPortfolio()">Pokušaj ponovo</button>
+    </div>
+
+    <ng-container *ngIf="!isLoading && !errorMessage">
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+        <div class="z-card p-5">
+          <p class="text-xs font-semibold tracking-wider text-muted-foreground uppercase mb-2">Profit</p>
+          <div class="flex items-end justify-between gap-4">
+            <div>
+              <p class="text-2xl font-bold" [ngClass]="getProfitClass(summary?.totalProfit ?? 0)">
+                {{ formatAmount(summary?.totalProfit ?? 0) }}
+              </p>
+              <p class="text-sm text-muted-foreground mt-1">Ukupan profit/gubitak za hartije koje trenutno držiš</p>
+            </div>
+            <span class="z-badge" [ngClass]="(summary?.totalProfit ?? 0) >= 0 ? 'z-badge-green' : 'z-badge-red'">
+              {{ (summary?.totalProfit ?? 0) >= 0 ? 'Dobitak' : 'Gubitak' }}
+            </span>
+          </div>
+        </div>
+
+        <div class="z-card p-5">
+          <p class="text-xs font-semibold tracking-wider text-muted-foreground uppercase mb-4">Porez</p>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div class="rounded-xl border border-green-200 bg-green-50 p-4">
+              <p class="text-xs font-semibold tracking-wider text-green-700 uppercase mb-1">Plaćeno ove godine</p>
+              <p class="text-xl font-bold text-green-700">{{ formatAmount(summary?.yearlyTaxPaid ?? 0) }} RSD</p>
+            </div>
+            <div class="rounded-xl border border-amber-200 bg-amber-50 p-4">
+              <p class="text-xs font-semibold tracking-wider text-amber-700 uppercase mb-1">Neplaćeno ovog meseca</p>
+              <p class="text-xl font-bold text-amber-700">{{ formatAmount(summary?.monthlyTaxDue ?? 0) }} RSD</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="z-card p-5">
+        <div class="flex items-center justify-between mb-4 gap-3 flex-wrap">
+          <div>
+            <p class="text-xs font-semibold tracking-wider text-muted-foreground uppercase">Hartije od vrednosti</p>
+            <p class="text-sm text-muted-foreground mt-1">Tip, ticker, količina, cena, profit i poslednja izmena.</p>
+          </div>
+          <span class="z-badge z-badge-blue">{{ holdings.length }} pozicija</span>
+        </div>
+
+        <div *ngIf="holdings.length === 0" class="py-10 text-center border border-dashed border-border rounded-lg bg-muted/30 text-muted-foreground text-sm">
+          <p>Trenutno nemaš nijednu hartiju u portfoliju.</p>
+        </div>
+
+        <div *ngIf="holdings.length > 0" class="overflow-x-auto rounded-xl border border-border">
+          <table class="z-table portfolio-table min-w-[980px]">
+            <thead>
+              <tr>
+                <th>Tip</th>
+                <th>Ticker</th>
+                <th>Amount</th>
+                <th>Price</th>
+                <th>Profit</th>
+                <th>Last modified</th>
+                <th>Akcije</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngFor="let holding of holdings; let i = index; trackBy: trackByHolding">
+                <td>
+                  <span class="z-badge" [ngClass]="{
+                    'z-badge-green': holding.listingType === 'STOCK',
+                    'z-badge-blue': holding.listingType === 'FUTURES',
+                    'z-badge-yellow': holding.listingType === 'FOREX',
+                    'z-badge-gray': holding.listingType === 'OPTION'
+                  }">
+                    {{ getTypeLabel(holding.listingType) }}
+                  </span>
+                </td>
+                <td class="font-semibold">{{ holding.ticker }}</td>
+                <td>{{ formatAmount(holding.quantity, 0) }}</td>
+                <td>{{ formatAmount(holding.currentPrice) }}</td>
+                <td class="font-semibold" [ngClass]="getProfitClass(holding.profit)">
+                  {{ formatAmount(holding.profit) }}
+                </td>
+                <td class="text-muted-foreground whitespace-nowrap">{{ formatDateTime(holding.lastModified) }}</td>
+                <td>
+                  <div class="flex flex-col gap-3 items-start min-w-[260px]">
+                    <button type="button" class="z-btn-outline z-btn-sm" (click)="onSell()">
+                      Prodaj
+                    </button>
+
+                    <div *ngIf="isStock(holding)" class="w-full rounded-lg border border-border bg-muted/20 p-3">
+                      <label class="block text-xs font-semibold tracking-wider text-muted-foreground uppercase mb-2">
+                        Javni režim za OTC
+                      </label>
+                      <div class="flex items-center gap-2">
+                        <input
+                          type="number"
+                          min="0"
+                          [max]="holding.quantity"
+                          class="z-input"
+                          [ngModel]="draftPublicQuantities[getHoldingKey(holding, i)]"
+                          (ngModelChange)="draftPublicQuantities[getHoldingKey(holding, i)] = $event"
+                        />
+                        <button
+                          type="button"
+                          class="z-btn-primary z-btn-sm whitespace-nowrap"
+                          [disabled]="savingPublicQuantity[getHoldingKey(holding, i)] || !hasPortfolioActionId(holding)"
+                          (click)="savePublicQuantity(holding, i)"
+                        >
+                          Sačuvaj
+                        </button>
+                      </div>
+                      <p *ngIf="!hasPortfolioActionId(holding)" class="text-xs text-muted-foreground mt-2">
+                        Ažuriranje će raditi kada backend vrati portfolio ID u listi holdings.
+                      </p>
+                    </div>
+
+                    <button
+                      *ngIf="canExerciseOption(holding)"
+                      type="button"
+                      class="z-btn-secondary z-btn-sm"
+                      [disabled]="exercisingOption[getHoldingKey(holding, i)] || !hasPortfolioActionId(holding)"
+                      (click)="exerciseOption(holding, i)"
+                    >
+                      Iskoristi opciju
+                    </button>
+
+                    <span
+                      *ngIf="isOption(holding) && isActuary && !holding.exercisable"
+                      class="text-xs text-muted-foreground"
+                    >
+                      Opcija trenutno nije dostupna za iskorišćavanje.
+                    </span>
+                    <span
+                      *ngIf="isOption(holding) && isActuary && holding.exercisable && !hasPortfolioActionId(holding)"
+                      class="text-xs text-muted-foreground"
+                    >
+                      Iskorišćavanje će raditi kada backend vrati portfolio ID u holdings odgovoru.
+                    </span>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </ng-container>
+  </div>
+</div>

--- a/src/app/features/client/components/portfolio/portfolio.component.scss
+++ b/src/app/features/client/components/portfolio/portfolio.component.scss
@@ -1,0 +1,3 @@
+.portfolio-table td {
+  vertical-align: top;
+}

--- a/src/app/features/client/components/portfolio/portfolio.component.spec.ts
+++ b/src/app/features/client/components/portfolio/portfolio.component.spec.ts
@@ -1,0 +1,145 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { PortfolioComponent } from './portfolio.component';
+import { PortfolioService } from '../../services/portfolio.service';
+import { AuthService } from '../../../../core/services/auth.service';
+import { ToastService } from '../../../../shared/services/toast.service';
+import { PortfolioSummary } from '../../models/portfolio.model';
+
+describe('PortfolioComponent', () => {
+  let component: PortfolioComponent;
+  let fixture: ComponentFixture<PortfolioComponent>;
+  let portfolioServiceSpy: jasmine.SpyObj<PortfolioService>;
+  let authServiceSpy: jasmine.SpyObj<AuthService>;
+  let toastServiceSpy: jasmine.SpyObj<ToastService>;
+
+  const portfolioSummary: PortfolioSummary = {
+    holdings: [
+      {
+        id: 11,
+        listingType: 'STOCK',
+        ticker: 'AAPL',
+        quantity: 10,
+        publicQuantity: 2,
+        exercisable: null,
+        lastModified: '2026-04-28T10:00:00',
+        currentPrice: 150,
+        averagePurchasePrice: 120,
+        profit: 300,
+      },
+      {
+        id: 12,
+        listingType: 'OPTION',
+        ticker: 'MSFT220C',
+        quantity: 1,
+        publicQuantity: 0,
+        exercisable: true,
+        lastModified: '2026-04-28T11:00:00',
+        currentPrice: 15,
+        averagePurchasePrice: 10,
+        profit: 5,
+      },
+    ],
+    totalProfit: 305,
+    yearlyTaxPaid: 1200,
+    monthlyTaxDue: 300,
+  };
+
+  beforeEach(() => {
+    portfolioServiceSpy = jasmine.createSpyObj<PortfolioService>(
+      'PortfolioService',
+      ['getPortfolio', 'setPublicQuantity', 'exerciseOption'],
+    );
+    authServiceSpy = jasmine.createSpyObj<AuthService>(
+      'AuthService',
+      ['isActuary', 'getLoggedUser', 'isClient', 'canAccessPortfolio', 'logout'],
+    );
+    toastServiceSpy = jasmine.createSpyObj<ToastService>('ToastService', [
+      'success',
+      'error',
+      'info',
+    ]);
+
+    portfolioServiceSpy.getPortfolio.and.returnValue(of(portfolioSummary));
+    authServiceSpy.isActuary.and.returnValue(true);
+    authServiceSpy.getLoggedUser.and.returnValue({
+      email: 'test@test.com',
+      permissions: [],
+    });
+    authServiceSpy.isClient.and.returnValue(true);
+    authServiceSpy.canAccessPortfolio.and.returnValue(true);
+
+    TestBed.configureTestingModule({
+      imports: [PortfolioComponent],
+      providers: [
+        { provide: PortfolioService, useValue: portfolioServiceSpy },
+        { provide: AuthService, useValue: authServiceSpy },
+        { provide: ToastService, useValue: toastServiceSpy },
+      ],
+    });
+
+    fixture = TestBed.createComponent(PortfolioComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create and load portfolio on init', () => {
+    expect(component).toBeTruthy();
+    expect(portfolioServiceSpy.getPortfolio).toHaveBeenCalled();
+    expect(component.holdings.length).toBe(2);
+    expect(component.draftPublicQuantities['AAPL-STOCK-0']).toBe(2);
+  });
+
+  it('should update local state after successful public quantity save', () => {
+    const holding = component.holdings[0];
+    const loadPortfolioSpy = spyOn(component, 'loadPortfolio');
+    portfolioServiceSpy.setPublicQuantity.and.returnValue(of(void 0));
+    component.draftPublicQuantities['AAPL-STOCK-0'] = 6;
+
+    component.savePublicQuantity(holding, 0);
+
+    expect(portfolioServiceSpy.setPublicQuantity).toHaveBeenCalledWith(11, { publicQuantity: 6 });
+    expect(holding.publicQuantity).toBe(6);
+    expect(component.draftPublicQuantities['AAPL-STOCK-0']).toBe(6);
+    expect(component.savingPublicQuantity['AAPL-STOCK-0']).toBeFalse();
+    expect(loadPortfolioSpy).not.toHaveBeenCalled();
+  });
+
+  it('should reset draft value when public quantity save fails', () => {
+    const holding = component.holdings[0];
+    portfolioServiceSpy.setPublicQuantity.and.returnValue(
+      throwError(() => new Error('save failed')),
+    );
+    spyOn(console, 'error');
+    component.draftPublicQuantities['AAPL-STOCK-0'] = 7;
+
+    component.savePublicQuantity(holding, 0);
+
+    expect(component.savingPublicQuantity['AAPL-STOCK-0']).toBeFalse();
+    expect(component.draftPublicQuantities['AAPL-STOCK-0']).toBe(2);
+    expect(toastServiceSpy.error).toHaveBeenCalled();
+  });
+
+  it('should not call service when holding id is missing', () => {
+    const holding = { ...component.holdings[0], id: undefined };
+
+    component.savePublicQuantity(holding, 0);
+
+    expect(portfolioServiceSpy.setPublicQuantity).not.toHaveBeenCalled();
+    expect(toastServiceSpy.info).toHaveBeenCalled();
+  });
+
+  it('should reset exercising state and log error when exercise fails', () => {
+    const holding = component.holdings[1];
+    portfolioServiceSpy.exerciseOption.and.returnValue(
+      throwError(() => new Error('exercise failed')),
+    );
+    spyOn(console, 'error');
+
+    component.exerciseOption(holding, 1);
+
+    expect(component.exercisingOption['MSFT220C-OPTION-1']).toBeFalse();
+    expect(console.error).toHaveBeenCalled();
+    expect(toastServiceSpy.error).toHaveBeenCalled();
+  });
+});

--- a/src/app/features/client/components/portfolio/portfolio.component.ts
+++ b/src/app/features/client/components/portfolio/portfolio.component.ts
@@ -1,0 +1,208 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { NavbarComponent } from '../../../../shared/components/navbar/navbar.component';
+import { PortfolioService } from '../../services/portfolio.service';
+import {
+  PortfolioHolding,
+  PortfolioListingType,
+  PortfolioSummary,
+} from '../../models/portfolio.model';
+import { AuthService } from '../../../../core/services/auth.service';
+import { ToastService } from '../../../../shared/services/toast.service';
+
+@Component({
+  selector: 'app-portfolio',
+  standalone: true,
+  imports: [CommonModule, FormsModule, NavbarComponent],
+  templateUrl: './portfolio.component.html',
+  styleUrls: ['./portfolio.component.scss'],
+})
+export class PortfolioComponent implements OnInit, OnDestroy {
+  summary: PortfolioSummary | null = null;
+  holdings: PortfolioHolding[] = [];
+  isLoading = false;
+  errorMessage = '';
+  isActuary = false;
+
+  draftPublicQuantities: Record<string, number> = {};
+  savingPublicQuantity: Record<string, boolean> = {};
+  exercisingOption: Record<string, boolean> = {};
+
+  private readonly destroy$ = new Subject<void>();
+
+  constructor(
+    private readonly portfolioService: PortfolioService,
+    private readonly authService: AuthService,
+    private readonly toastService: ToastService,
+  ) {}
+
+  ngOnInit(): void {
+    this.isActuary = this.authService.isActuary();
+    this.loadPortfolio();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  loadPortfolio(): void {
+    this.isLoading = true;
+    this.errorMessage = '';
+
+    this.portfolioService
+      .getPortfolio()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (summary) => {
+          this.summary = summary;
+          this.holdings = summary.holdings ?? [];
+          this.draftPublicQuantities = {};
+
+          this.holdings.forEach((holding, index) => {
+            this.draftPublicQuantities[this.getHoldingKey(holding, index)] =
+              holding.publicQuantity ?? 0;
+          });
+
+          this.isLoading = false;
+        },
+        error: () => {
+          this.errorMessage =
+            'Greška pri učitavanju portfolija. Pokušajte ponovo.';
+          this.isLoading = false;
+        },
+      });
+  }
+
+  getHoldingKey(holding: PortfolioHolding, index: number): string {
+    return `${holding.ticker}-${holding.listingType}-${index}`;
+  }
+
+  hasPortfolioActionId(holding: PortfolioHolding): boolean {
+    return holding.id !== undefined && holding.id !== null;
+  }
+
+  savePublicQuantity(holding: PortfolioHolding, index: number): void {
+    const key = this.getHoldingKey(holding, index);
+    const value = Number(this.draftPublicQuantities[key] ?? 0);
+
+    if (!this.hasPortfolioActionId(holding)) {
+      this.toastService.info('Backend trenutno ne vraća portfolio ID, pa ova akcija još nije dostupna.');
+      return;
+    }
+
+    if (!Number.isFinite(value) || value < 0) {
+      this.toastService.error('Javna količina mora biti 0 ili veća.');
+      return;
+    }
+
+    if (value > holding.quantity) {
+      this.toastService.error('Javna količina ne može biti veća od ukupne količine.');
+      return;
+    }
+
+    this.savingPublicQuantity[key] = true;
+
+    this.portfolioService
+      .setPublicQuantity(holding.id as number, { publicQuantity: value })
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => {
+          this.toastService.success('Javna količina je uspešno ažurirana.');
+          this.loadPortfolio();
+        },
+        error: () => {
+          this.toastService.error('Nije moguće sačuvati javnu količinu.');
+          this.savingPublicQuantity[key] = false;
+        },
+      });
+  }
+
+  exerciseOption(holding: PortfolioHolding, index: number): void {
+    const key = this.getHoldingKey(holding, index);
+
+    if (!this.hasPortfolioActionId(holding)) {
+      this.toastService.info('Backend trenutno ne vraća portfolio ID, pa ova akcija još nije dostupna.');
+      return;
+    }
+
+    this.exercisingOption[key] = true;
+
+    this.portfolioService
+      .exerciseOption(holding.id as number)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => {
+          this.toastService.success('Opcija je uspešno iskorišćena.');
+          this.loadPortfolio();
+        },
+        error: () => {
+          this.toastService.error('Nije moguće iskoristiti opciju.');
+          this.exercisingOption[key] = false;
+        },
+      });
+  }
+
+  onSell(): void {
+    // TODO: Povezati F1 Sell modal / Create order flow kada ta implementacija bude dostupna.
+  }
+
+  isStock(holding: PortfolioHolding): boolean {
+    return holding.listingType === 'STOCK';
+  }
+
+  isOption(holding: PortfolioHolding): boolean {
+    return holding.listingType === 'OPTION';
+  }
+
+  canExerciseOption(holding: PortfolioHolding): boolean {
+    return this.isActuary && this.isOption(holding) && holding.exercisable === true;
+  }
+
+  getTypeLabel(type: PortfolioListingType): string {
+    const labels: Record<PortfolioListingType, string> = {
+      STOCK: 'Akcija',
+      FUTURES: 'Fjučers',
+      FOREX: 'Forex',
+      OPTION: 'Opcija',
+    };
+
+    return labels[type] ?? type;
+  }
+
+  formatAmount(value: number | null | undefined, digits = 2): string {
+    return new Intl.NumberFormat('sr-RS', {
+      minimumFractionDigits: digits,
+      maximumFractionDigits: digits,
+    }).format(value ?? 0);
+  }
+
+  formatDateTime(value: string): string {
+    const date = new Date(value);
+
+    if (Number.isNaN(date.getTime())) {
+      return value;
+    }
+
+    return new Intl.DateTimeFormat('sr-RS', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(date);
+  }
+
+  getProfitClass(value: number): string {
+    if (value > 0) return 'text-green-600';
+    if (value < 0) return 'text-red-600';
+    return 'text-muted-foreground';
+  }
+
+  trackByHolding(index: number, holding: PortfolioHolding): string {
+    return this.getHoldingKey(holding, index);
+  }
+}

--- a/src/app/features/client/components/portfolio/portfolio.component.ts
+++ b/src/app/features/client/components/portfolio/portfolio.component.ts
@@ -69,9 +69,10 @@ export class PortfolioComponent implements OnInit, OnDestroy {
 
           this.isLoading = false;
         },
-        error: () => {
+        error: (error) => {
+          console.error('Error loading portfolio:', error);
           this.errorMessage =
-            'Greška pri učitavanju portfolija. Pokušajte ponovo.';
+            'Gre�ka pri ucitavanju portfolija. Poku�ajte ponovo.';
           this.isLoading = false;
         },
       });
@@ -82,65 +83,72 @@ export class PortfolioComponent implements OnInit, OnDestroy {
   }
 
   hasPortfolioActionId(holding: PortfolioHolding): boolean {
-    return holding.id !== undefined && holding.id !== null;
+    return typeof holding.id === 'number';
   }
 
   savePublicQuantity(holding: PortfolioHolding, index: number): void {
     const key = this.getHoldingKey(holding, index);
     const value = Number(this.draftPublicQuantities[key] ?? 0);
+    const holdingId = holding.id;
 
-    if (!this.hasPortfolioActionId(holding)) {
-      this.toastService.info('Backend trenutno ne vraća portfolio ID, pa ova akcija još nije dostupna.');
+    if (typeof holdingId !== 'number') {
+      this.toastService.info('Backend trenutno ne vraca portfolio ID, pa ova akcija jo� nije dostupna.');
       return;
     }
 
     if (!Number.isFinite(value) || value < 0) {
-      this.toastService.error('Javna količina mora biti 0 ili veća.');
+      this.toastService.error('Javna kolicina mora biti 0 ili veca.');
       return;
     }
 
     if (value > holding.quantity) {
-      this.toastService.error('Javna količina ne može biti veća od ukupne količine.');
+      this.toastService.error('Javna kolicina ne mo�e biti veca od ukupne kolicine.');
       return;
     }
 
     this.savingPublicQuantity[key] = true;
 
     this.portfolioService
-      .setPublicQuantity(holding.id as number, { publicQuantity: value })
+      .setPublicQuantity(holdingId, { publicQuantity: value })
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: () => {
-          this.toastService.success('Javna količina je uspešno ažurirana.');
-          this.loadPortfolio();
-        },
-        error: () => {
-          this.toastService.error('Nije moguće sačuvati javnu količinu.');
+          this.toastService.success('Javna kolicina je uspe�no a�urirana.');
+          holding.publicQuantity = value;
+          this.draftPublicQuantities[key] = value;
           this.savingPublicQuantity[key] = false;
+        },
+        error: (error) => {
+          console.error('Error saving public quantity:', error);
+          this.toastService.error('Nije moguce sacuvati javnu kolicinu.');
+          this.savingPublicQuantity[key] = false;
+          this.draftPublicQuantities[key] = holding.publicQuantity ?? 0;
         },
       });
   }
 
   exerciseOption(holding: PortfolioHolding, index: number): void {
     const key = this.getHoldingKey(holding, index);
+    const holdingId = holding.id;
 
-    if (!this.hasPortfolioActionId(holding)) {
-      this.toastService.info('Backend trenutno ne vraća portfolio ID, pa ova akcija još nije dostupna.');
+    if (typeof holdingId !== 'number') {
+      this.toastService.info('Backend trenutno ne vraca portfolio ID, pa ova akcija jo� nije dostupna.');
       return;
     }
 
     this.exercisingOption[key] = true;
 
     this.portfolioService
-      .exerciseOption(holding.id as number)
+      .exerciseOption(holdingId)
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: () => {
-          this.toastService.success('Opcija je uspešno iskorišćena.');
+          this.toastService.success('Opcija je uspe�no iskori�cena.');
           this.loadPortfolio();
         },
-        error: () => {
-          this.toastService.error('Nije moguće iskoristiti opciju.');
+        error: (error) => {
+          console.error('Error exercising option:', error);
+          this.toastService.error('Nije moguce iskoristiti opciju.');
           this.exercisingOption[key] = false;
         },
       });
@@ -165,7 +173,7 @@ export class PortfolioComponent implements OnInit, OnDestroy {
   getTypeLabel(type: PortfolioListingType): string {
     const labels: Record<PortfolioListingType, string> = {
       STOCK: 'Akcija',
-      FUTURES: 'Fjučers',
+      FUTURES: 'Fjucers',
       FOREX: 'Forex',
       OPTION: 'Opcija',
     };

--- a/src/app/features/client/models/portfolio.model.ts
+++ b/src/app/features/client/models/portfolio.model.ts
@@ -1,0 +1,25 @@
+export type PortfolioListingType = 'STOCK' | 'FUTURES' | 'FOREX' | 'OPTION';
+
+export interface PortfolioHolding {
+  id?: number;
+  listingType: PortfolioListingType;
+  ticker: string;
+  quantity: number;
+  publicQuantity: number;
+  exercisable: boolean | null;
+  lastModified: string;
+  currentPrice: number;
+  averagePurchasePrice: number;
+  profit: number;
+}
+
+export interface PortfolioSummary {
+  holdings: PortfolioHolding[];
+  totalProfit: number;
+  yearlyTaxPaid: number;
+  monthlyTaxDue: number;
+}
+
+export interface SetPublicQuantityRequest {
+  publicQuantity: number;
+}

--- a/src/app/features/client/services/portfolio.service.spec.ts
+++ b/src/app/features/client/services/portfolio.service.spec.ts
@@ -1,0 +1,56 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { PortfolioService } from './portfolio.service';
+import { environment } from '../../../../environments/environment';
+
+describe('PortfolioService', () => {
+  let service: PortfolioService;
+  let httpMock: HttpTestingController;
+
+  const baseUrl = `${environment.apiUrl}/order/portfolio`;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [PortfolioService],
+    });
+
+    service = TestBed.inject(PortfolioService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should fetch portfolio summary', () => {
+    service.getPortfolio().subscribe();
+
+    const req = httpMock.expectOne(baseUrl);
+    expect(req.request.method).toBe('GET');
+    req.flush({
+      holdings: [],
+      totalProfit: 0,
+      yearlyTaxPaid: 0,
+      monthlyTaxDue: 0,
+    });
+  });
+
+  it('should send public quantity update', () => {
+    service.setPublicQuantity(15, { publicQuantity: 3 }).subscribe();
+
+    const req = httpMock.expectOne(`${baseUrl}/15/set-public`);
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toEqual({ publicQuantity: 3 });
+    req.flush(null);
+  });
+
+  it('should send exercise option request', () => {
+    service.exerciseOption(22).subscribe();
+
+    const req = httpMock.expectOne(`${baseUrl}/22/exercise-option`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({});
+    req.flush(null);
+  });
+});

--- a/src/app/features/client/services/portfolio.service.ts
+++ b/src/app/features/client/services/portfolio.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import {
+  PortfolioSummary,
+  SetPublicQuantityRequest,
+} from '../models/portfolio.model';
+
+@Injectable({ providedIn: 'root' })
+export class PortfolioService {
+  private readonly baseUrl = `${environment.apiUrl}/order/portfolio`;
+
+  constructor(private readonly http: HttpClient) {}
+
+  getPortfolio(): Observable<PortfolioSummary> {
+    return this.http.get<PortfolioSummary>(this.baseUrl);
+  }
+
+  setPublicQuantity(
+    portfolioId: number,
+    request: SetPublicQuantityRequest,
+  ): Observable<void> {
+    return this.http.put<void>(`${this.baseUrl}/${portfolioId}/set-public`, request);
+  }
+
+  exerciseOption(portfolioId: number): Observable<void> {
+    return this.http.post<void>(`${this.baseUrl}/${portfolioId}/exercise-option`, {});
+  }
+}

--- a/src/app/shared/components/navbar/navbar.component.ts
+++ b/src/app/shared/components/navbar/navbar.component.ts
@@ -20,6 +20,7 @@ export class NavbarComponent implements OnInit {
   navLinks: NavLink[] = [];
   userRole = '';
   userName = '';
+  private readonly portfolioLink: NavLink = { label: 'Moj portfolio', route: '/portfolio', icon: 'work' };
 
   private readonly clientLinks: NavLink[] = [
     { label: 'Početna',    route: '/home',                icon: 'home' },
@@ -31,6 +32,7 @@ export class NavbarComponent implements OnInit {
     { label: 'Menjačnica', route: '/exchange',            icon: 'currency_exchange' },
     { label: 'Primaoci plaćanja', route: '/payments/recipients', icon: 'people' },
     { label: 'Hartije',    route: '/securities',          icon: 'trending_up' },
+    this.portfolioLink,
     { label: 'Krediti',    route: '/loans',               icon: 'credit_card' },
     { label: 'Berza',      route: '/stock-exchange',      icon: 'show_chart' },
   ];
@@ -63,13 +65,14 @@ export class NavbarComponent implements OnInit {
       const permissions: string[] = (user as any)?.permissions ?? [];
       this.navLinks = [
         ...this.employeeLinks,
+        ...(this.authService.canAccessPortfolio() ? [this.portfolioLink] : []),
         ...(permissions.includes('FUND_AGENT_MANAGE') ? this.supervisorLinks : [])
       ];
     }
   }
 
   isClient(): boolean {
-    return this.userRole.toUpperCase().startsWith('CLIENT');
+    return this.authService.isClient();
   }
 
   logout(): void {


### PR DESCRIPTION
Added /portfolio page

The page includes:

holdings table
total profit/loss
yearly paid tax and current monthly unpaid tax
publicQuantity input for stocks
option exercise action for actuaries when allowed

Sell is left as a TODO until the F1 flow exists.
