### PR TITLE
fix(#199): SELL forma + AccountId hash fallback + portfolio listingId

### DIFF
--- a/src/app/features/client/components/portfolio/portfolio.component.html
+++ b/src/app/features/client/components/portfolio/portfolio.component.html
@@ -111,7 +111,7 @@
                 <td class="text-muted-foreground whitespace-nowrap">{{ formatDateTime(holding.lastModified) }}</td>
                 <td>
                   <div class="flex flex-col gap-3 items-start min-w-[260px]">
-                    <button type="button" class="z-btn-outline z-btn-sm" (click)="onSell()">
+                    <button type="button" class="z-btn-outline z-btn-sm" (click)="onSell(holding)">
                       Prodaj
                     </button>
 

--- a/src/app/features/client/components/portfolio/portfolio.component.ts
+++ b/src/app/features/client/components/portfolio/portfolio.component.ts
@@ -167,8 +167,21 @@ export class PortfolioComponent implements OnInit, OnDestroy {
       });
   }
 
-  onSell(): void {
-    // TODO: Povezati F1 Sell modal / Create order flow kada ta implementacija bude dostupna.
+  /**
+   * Otvara Create Order formu u SELL modu za odabranu poziciju iz portfolija.
+   *
+   * GHI #199: ranije je dugme "Prodaj" bilo no-op (TODO komentar) jer
+   * (a) odgovor servera nije sadrzao listingId, pa nije bilo cime se navigirati,
+   * (b) sam handler nije bio povezan sa router-om. Posle backend popravke koja
+   * dodaje listingId u PortfolioResponse, ovde samo nesmetano gradimo url
+   * /orders/create/SELL/{listingId} koji create-order komponenta vec razume.
+   */
+  onSell(holding: PortfolioHolding): void {
+    if (typeof holding?.listingId !== 'number') {
+      this.toastService.error('Hartija nema listingId, prodaja nije dostupna.');
+      return;
+    }
+    this.router.navigate(['/orders/create', 'SELL', holding.listingId]);
   }
 
   isStock(holding: PortfolioHolding): boolean {

--- a/src/app/features/client/models/portfolio.model.ts
+++ b/src/app/features/client/models/portfolio.model.ts
@@ -2,6 +2,12 @@ export type PortfolioListingType = 'STOCK' | 'FUTURES' | 'FOREX' | 'OPTION';
 
 export interface PortfolioHolding {
   id?: number;
+  /**
+   * ID of the underlying listing/security. Required to navigate from "Moj Portfolio"
+   * into the Create Order page in SELL mode (issue #199); previously the response did
+   * not include it, which is why the Sell button did nothing.
+   */
+  listingId: number;
   listingType: PortfolioListingType;
   ticker: string;
   quantity: number;

--- a/src/app/features/client/services/account.service.ts
+++ b/src/app/features/client/services/account.service.ts
@@ -57,8 +57,17 @@ export class AccountService {
 
     const currency = item.currency || item.valuta || 'RSD';
 
+    // Use the server-provided primary key when present; only fall back to the legacy
+    // hashAccountNumber bridge if the response is missing `id` for some reason.
+    // Hash-derived ids do not map to anything on the backend and broke order BUY/SELL
+    // accountId resolution in /internal/accounts/id/{accountId}/details (GHI #199).
+    const id =
+      typeof item.id === 'number'
+        ? item.id
+        : this.hashAccountNumber(item.brojRacuna || item.accountNumber || '');
+
     return {
-      id: this.hashAccountNumber(item.brojRacuna),
+      id,
       name: item.nazivRacuna || '',
       accountNumber: (item.brojRacuna || item.accountNumber || '').trim(),
       balance: item.stanjeRacuna || 0,


### PR DESCRIPTION
﻿Closes #199 (frontend deo). Odgovarajuci backend PR: RAF-SI-2025/Banka-1-Backend#202

## Bug 1 - SELL dugme iz "Moj Portfolio" je bilo no-op

- `PortfolioHolding` model dobija `listingId: number` (backend sada salje ovo polje).
- `portfolio.component.ts`: `onSell(holding)` zove `router.navigate(['/orders/create','SELL',holding.listingId])` -- bio prazan TODO stub koji nista nije radio.
- `portfolio.component.html`: dugme prosledjuje `holding` kao parametar.

## Pomocni 8 - `/order/orders/{id}/confirm` vracao 500 (hash-ovani accountId)

`AccountService.mapToAccountFromClient` je fallback-ovao na `hashAccountNumber(item.brojRacuna)` jer `AccountResponseDto` nije imao polje `id`. Hash (32-bit int) ne mapira na PK racuna u bazi, pa je order-service dobijao 404 -> 500 Serverska greska pri svakom confirm-u.

Ispravljeno: `mapToAccountFromClient` koristi `item.id` kada je number; hash fallback ostaje samo kao defenzivna mreza za stare backend verzije.

> Napomena: korisnici koji su vec ulogovani moraju logout + login da bi dobili novu (PK-baziranu) listu racuna. Stara sesija nosi hash-ID-jeve i confirm i dalje puca dok frontend ne dobije fresh listu.

## Promenjeni fajlovi (4)

- `src/app/features/client/models/portfolio.model.ts` -- listingId polje
- `src/app/features/client/components/portfolio/portfolio.component.ts` -- onSell navigacija
- `src/app/features/client/components/portfolio/portfolio.component.html` -- dugme prosledjuje holding
- `src/app/features/client/services/account.service.ts` -- item.id umesto hasha
