### PR TITLE
Add OTC active offers feature

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -43,6 +43,12 @@ const routes: Routes = [
     canActivate: [authGuard],
   },
   {
+    path: 'client',
+    loadChildren: () =>
+      import('./features/client/client.module').then((m) => m.ClientModule),
+    canActivate: [authGuard],
+  },
+  {
     path: 'employees/new',
     component: EmployeeCreateComponent,
     canActivate: [authGuard, roleGuard],

--- a/src/app/core/guards/client-or-actuary.guard.ts
+++ b/src/app/core/guards/client-or-actuary.guard.ts
@@ -1,0 +1,20 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+/**
+ * Guard koji proverava da li je korisnik klijent ili aktuvar.
+ * Dozvoljava pristup samo klijentima i aktuarima.
+ */
+export const clientOrActuaryGuard: CanActivateFn = () => {
+  const router = inject(Router);
+  const authService = inject(AuthService);
+
+  if (authService.isClient() || authService.isActuary()) {
+    return true;
+  }
+
+  // Ako korisnik nije klijent niti aktuvar, preusmerava ga na forbidden stranicu
+  router.navigate(['/403']);
+  return false;
+};

--- a/src/app/features/client/client-routing.module.ts
+++ b/src/app/features/client/client-routing.module.ts
@@ -4,8 +4,10 @@ import { HomeComponent } from './home/home.component';
 import { AccountListComponent } from './components/account-list/account-list.component';
 import { NewPaymentComponent } from './components/new-payment/new-payment.component';
 import { CardListComponent } from './components/card-list/card-list.component';
-import {RequestCardComponent} from "@/features/client/components/request-card/request-card.component";
-import {authGuard} from "@/core/guards/auth.guard";
+import { RequestCardComponent } from "@/features/client/components/request-card/request-card.component";
+import { OtcActiveOffersComponent } from './components/otc-active-offers/otc-active-offers.component';
+import { authGuard } from "@/core/guards/auth.guard";
+import { clientOrActuaryGuard } from "@/core/guards/client-or-actuary.guard";
 
 const routes: Routes = [
   {
@@ -17,9 +19,8 @@ const routes: Routes = [
     component: AccountListComponent
   },
   { path: 'cards', component: CardListComponent },
-  { path: 'cards/request', component: RequestCardComponent, canActivate: [authGuard] }
-
-
+  { path: 'cards/request', component: RequestCardComponent, canActivate: [authGuard] },
+  { path: 'otc-offers', component: OtcActiveOffersComponent, canActivate: [authGuard, clientOrActuaryGuard] }
 ];
 
 @NgModule({

--- a/src/app/features/client/client.module.ts
+++ b/src/app/features/client/client.module.ts
@@ -10,6 +10,7 @@ import {CardListComponent} from "@/features/client/components/card-list/card-lis
 import { LoanListComponent } from './components/loan-list/loan-list.component';
 import {RequestCardComponent} from "@/features/client/components/request-card/request-card.component";
 import { LoanRequestComponent } from './components/loan-request/loan-request.component';
+import { OtcActiveOffersComponent } from './components/otc-active-offers/otc-active-offers.component';
 
 @NgModule({
   declarations: [
@@ -27,7 +28,8 @@ import { LoanRequestComponent } from './components/loan-request/loan-request.com
     CardListComponent,
     LoanListComponent,
     RequestCardComponent,
-    LoanRequestComponent
+    LoanRequestComponent,
+    OtcActiveOffersComponent,
   ]
 })
 export class ClientModule {}

--- a/src/app/features/client/components/otc-active-offers/otc-active-offers.component.html
+++ b/src/app/features/client/components/otc-active-offers/otc-active-offers.component.html
@@ -1,0 +1,197 @@
+<app-navbar></app-navbar>
+
+<div class="page-layout">
+  <div class="page-content">
+    <!-- Header sa brojem nepročitanih -->
+    <div class="mb-8 flex items-center justify-between">
+      <h1 class="text-3xl font-bold">Aktivne ponude za pregovore</h1>
+    <div *ngIf="unreadCount > 0" class="inline-block">
+      <span class="inline-flex items-center gap-2 rounded-lg bg-info/10 px-4 py-2 text-sm font-semibold text-info">
+        <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+          stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="10"></circle>
+          <path d="M12 6v6m0 4v.01"></path>
+        </svg>
+        <span>{{ unreadCount }} nepročitanih ponuda</span>
+      </span>
+    </div>
+  </div>
+
+  <!-- Greška -->
+  <div *ngIf="error" class="mb-6 rounded-lg border border-destructive bg-destructive/10 p-4 text-destructive">
+    {{ error }}
+  </div>
+
+  <!-- Učitavanje -->
+  <div *ngIf="loading" class="flex items-center justify-center py-12">
+    <div class="text-muted-foreground">Učitavanje ponuda...</div>
+  </div>
+
+  <!-- Prazna lista -->
+  <div *ngIf="!loading && offers.length === 0" class="rounded-lg border border-border bg-card p-8 text-center">
+    <svg class="mx-auto mb-4 h-12 w-12 text-muted-foreground" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+      fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path>
+      <polyline points="9 22 9 12 15 12 15 22"></polyline>
+    </svg>
+    <p class="text-muted-foreground">Nema aktivnih ponuda</p>
+  </div>
+
+  <!-- Tabela -->
+  <div *ngIf="!loading && offers.length > 0" class="overflow-hidden rounded-lg border border-border">
+    <div class="overflow-x-auto">
+      <table class="w-full">
+        <thead>
+          <tr class="border-b border-border bg-muted/50">
+            <th class="px-6 py-3 text-left text-sm font-semibold">Akcija</th>
+            <th class="px-6 py-3 text-left text-sm font-semibold text-right">Količina</th>
+            <th class="px-6 py-3 text-left text-sm font-semibold text-right">Cena/akcija</th>
+            <th class="px-6 py-3 text-left text-sm font-semibold text-right">Premija</th>
+            <th class="px-6 py-3 text-left text-sm font-semibold">Settlement Date</th>
+            <th class="px-6 py-3 text-left text-sm font-semibold">Pregovara sa</th>
+            <th class="px-6 py-3 text-left text-sm font-semibold">Poslednja izmena</th>
+            <th class="px-6 py-3 text-left text-sm font-semibold">Akcija</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-border">
+          <tr *ngFor="let offer of offers" class="hover:bg-muted/30 transition-colors">
+            <!-- Akcija (Ticker) -->
+            <td class="px-6 py-4">
+              <span class="font-semibold">{{ offer.ticker }}</span>
+            </td>
+
+            <!-- Količina -->
+            <td class="px-6 py-4 text-right">{{ formatAmount(offer.quantity) }}</td>
+
+            <!-- Cena po akciji sa sistemom boja -->
+            <td class="px-6 py-4 text-right">
+              <span [ngClass]="getPriceColorClass(offer)" class="inline-block rounded px-3 py-1 text-sm font-semibold">
+                {{ formatAmount(offer.pricePerShare) }}
+                <span class="ml-1 text-xs font-normal opacity-75">
+                  ({{ getPriceDeviation(offer).percentage.toFixed(1) }}%)
+                </span>
+              </span>
+            </td>
+
+            <!-- Premija -->
+            <td class="px-6 py-4 text-right">{{ formatAmount(offer.premium) }}</td>
+
+            <!-- Settlement Date -->
+            <td class="px-6 py-4 text-sm text-muted-foreground">
+              {{ offer.settlementDate ? (offer.settlementDate | date: 'dd/MM/yyyy') : '-' }}
+            </td>
+
+            <!-- Pregovara sa (Ime i banka) -->
+            <td class="px-6 py-4 text-sm">
+              <div class="font-medium">{{ getCounterpartyFullName(offer) }}</div>
+              <div class="text-xs text-muted-foreground">{{ getCounterpartyBankName(offer) }}</div>
+            </td>
+
+            <!-- Poslednja izmena (Timestamp) -->
+            <td class="px-6 py-4 text-sm text-muted-foreground">
+              {{ formatDateTime(offer.lastModified) }}
+            </td>
+
+            <!-- Akcija -->
+            <td class="px-6 py-4">
+              <button type="button" class="z-btn-outline z-btn-sm" (click)="openOfferDetail(offer)">
+                Detaljnije
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <!-- Pagination -->
+  <div *ngIf="!loading && totalPages > 1" class="mt-6 flex items-center justify-between">
+    <div class="text-sm text-muted-foreground">
+      Stranica {{ page + 1 }} od {{ totalPages }}
+    </div>
+    <div class="flex gap-2">
+      <button type="button" class="z-btn-outline z-btn-sm" (click)="previousPage()" [disabled]="page === 0">
+        Prethodna
+      </button>
+      <button type="button" class="z-btn-outline z-btn-sm" (click)="nextPage()"
+        [disabled]="page === totalPages - 1">
+        Sledeća
+      </button>
+    </div>
+  </div>
+  </div>
+</div>
+
+<!-- Modal backdrop -->
+<div *ngIf="showModal && selectedOffer" class="fixed inset-0 z-50 bg-black/50" (click)="closeModal()"></div>
+
+<!-- Modal content -->
+<div *ngIf="showModal && selectedOffer"
+  class="fixed left-1/2 top-1/2 z-50 w-full max-w-2xl -translate-x-1/2 -translate-y-1/2 rounded-lg border border-border bg-card p-6 shadow-lg"
+  (click)="$event.stopPropagation()">
+  <!-- Header -->
+  <div class="mb-6 flex items-start justify-between">
+    <div>
+      <h2 class="text-2xl font-bold">{{ selectedOffer.ticker }}</h2>
+      <p class="mt-1 text-sm text-muted-foreground">Ponuda od: {{ getCounterpartyFullName(selectedOffer) }} ({{
+        getCounterpartyBankName(selectedOffer) }})</p>
+    </div>
+    <button type="button" class="text-muted-foreground hover:text-foreground" (click)="closeModal()">
+      <svg class="h-6 w-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+        stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <line x1="18" y1="6" x2="6" y2="18"></line>
+        <line x1="6" y1="6" x2="18" y2="18"></line>
+      </svg>
+    </button>
+  </div>
+
+  <!-- Status badge -->
+  <div class="mb-6">
+    <span [ngClass]="getStatusBadgeClass(selectedOffer)" class="inline-block rounded-full px-3 py-1 text-sm font-semibold">
+      {{ getStatusLabel(selectedOffer) }}
+    </span>
+  </div>
+
+  <!-- Modal content -->
+  <div class="space-y-4">
+    <div class="grid grid-cols-2 gap-4">
+      <div class="rounded-lg border border-border bg-muted/20 p-4">
+        <p class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Količina</p>
+        <p class="mt-1 text-xl font-bold">{{ formatAmount(selectedOffer.quantity) }}</p>
+      </div>
+      <div class="rounded-lg border border-border bg-muted/20 p-4">
+        <p class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Cena po akciji</p>
+        <p class="mt-1 text-xl font-bold">{{ formatAmount(selectedOffer.pricePerShare) }}</p>
+      </div>
+      <div class="rounded-lg border border-border bg-muted/20 p-4">
+        <p class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Premija</p>
+        <p class="mt-1 text-xl font-bold">{{ formatAmount(selectedOffer.premium) }}</p>
+      </div>
+      <div class="rounded-lg border border-border bg-muted/20 p-4">
+        <p class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Settlement Date</p>
+        <p class="mt-1 text-xl font-bold">{{ formatDate(selectedOffer.settlementDate) }}</p>
+      </div>
+    </div>
+
+    <!-- Total value -->
+    <div class="rounded-lg border border-border bg-primary/5 p-4">
+      <p class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Ukupna vrednost</p>
+      <p class="mt-1 text-2xl font-bold text-primary">
+        {{ formatAmount(selectedOffer.quantity * selectedOffer.pricePerShare + selectedOffer.premium) }}
+      </p>
+    </div>
+  </div>
+
+  <!-- Actions -->
+  <div class="mt-8 flex gap-3">
+    <button type="button" class="z-btn z-btn-primary flex-1" (click)="acceptOfferModal()">
+      ✓ Prihvati
+    </button>
+    <button type="button" class="z-btn z-btn-outline flex-1" (click)="rejectOfferModal()">
+      ✗ Odustani
+    </button>
+    <button type="button" class="z-btn z-btn-outline flex-1">
+      Kontraponuda
+    </button>
+  </div>
+</div>

--- a/src/app/features/client/components/otc-active-offers/otc-active-offers.component.html
+++ b/src/app/features/client/components/otc-active-offers/otc-active-offers.component.html
@@ -43,10 +43,10 @@
       <table class="w-full">
         <thead>
           <tr class="border-b border-border bg-muted/50">
-            <th class="px-6 py-3 text-left text-sm font-semibold">Akcija</th>
-            <th class="px-6 py-3 text-left text-sm font-semibold text-right">Količina</th>
-            <th class="px-6 py-3 text-left text-sm font-semibold text-right">Cena/akcija</th>
-            <th class="px-6 py-3 text-left text-sm font-semibold text-right">Premija</th>
+            <th class="px-6 py-3 text-left text-sm font-semibold">Hartija</th>
+            <th class="px-6 py-3 text-right text-sm font-semibold">Količina</th>
+            <th class="px-6 py-3 text-right text-sm font-semibold">Cena/akcija</th>
+            <th class="px-6 py-3 text-right text-sm font-semibold">Premija</th>
             <th class="px-6 py-3 text-left text-sm font-semibold">Settlement Date</th>
             <th class="px-6 py-3 text-left text-sm font-semibold">Pregovara sa</th>
             <th class="px-6 py-3 text-left text-sm font-semibold">Poslednja izmena</th>
@@ -125,73 +125,10 @@
 <!-- Modal backdrop -->
 <div *ngIf="showModal && selectedOffer" class="fixed inset-0 z-50 bg-black/50" (click)="closeModal()"></div>
 
-<!-- Modal content -->
-<div *ngIf="showModal && selectedOffer"
-  class="fixed left-1/2 top-1/2 z-50 w-full max-w-2xl -translate-x-1/2 -translate-y-1/2 rounded-lg border border-border bg-card p-6 shadow-lg"
-  (click)="$event.stopPropagation()">
-  <!-- Header -->
-  <div class="mb-6 flex items-start justify-between">
-    <div>
-      <h2 class="text-2xl font-bold">{{ selectedOffer.ticker }}</h2>
-      <p class="mt-1 text-sm text-muted-foreground">Ponuda od: {{ getCounterpartyFullName(selectedOffer) }} ({{
-        getCounterpartyBankName(selectedOffer) }})</p>
-    </div>
-    <button type="button" class="text-muted-foreground hover:text-foreground" (click)="closeModal()">
-      <svg class="h-6 w-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-        stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <line x1="18" y1="6" x2="6" y2="18"></line>
-        <line x1="6" y1="6" x2="18" y2="18"></line>
-      </svg>
-    </button>
-  </div>
-
-  <!-- Status badge -->
-  <div class="mb-6">
-    <span [ngClass]="getStatusBadgeClass(selectedOffer)" class="inline-block rounded-full px-3 py-1 text-sm font-semibold">
-      {{ getStatusLabel(selectedOffer) }}
-    </span>
-  </div>
-
-  <!-- Modal content -->
-  <div class="space-y-4">
-    <div class="grid grid-cols-2 gap-4">
-      <div class="rounded-lg border border-border bg-muted/20 p-4">
-        <p class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Količina</p>
-        <p class="mt-1 text-xl font-bold">{{ formatAmount(selectedOffer.quantity) }}</p>
-      </div>
-      <div class="rounded-lg border border-border bg-muted/20 p-4">
-        <p class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Cena po akciji</p>
-        <p class="mt-1 text-xl font-bold">{{ formatAmount(selectedOffer.pricePerShare) }}</p>
-      </div>
-      <div class="rounded-lg border border-border bg-muted/20 p-4">
-        <p class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Premija</p>
-        <p class="mt-1 text-xl font-bold">{{ formatAmount(selectedOffer.premium) }}</p>
-      </div>
-      <div class="rounded-lg border border-border bg-muted/20 p-4">
-        <p class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Settlement Date</p>
-        <p class="mt-1 text-xl font-bold">{{ formatDate(selectedOffer.settlementDate) }}</p>
-      </div>
-    </div>
-
-    <!-- Total value -->
-    <div class="rounded-lg border border-border bg-primary/5 p-4">
-      <p class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Ukupna vrednost</p>
-      <p class="mt-1 text-2xl font-bold text-primary">
-        {{ formatAmount(selectedOffer.quantity * selectedOffer.pricePerShare + selectedOffer.premium) }}
-      </p>
-    </div>
-  </div>
-
-  <!-- Actions -->
-  <div class="mt-8 flex gap-3">
-    <button type="button" class="z-btn z-btn-primary flex-1" (click)="acceptOfferModal()">
-      ✓ Prihvati
-    </button>
-    <button type="button" class="z-btn z-btn-outline flex-1" (click)="rejectOfferModal()">
-      ✗ Odustani
-    </button>
-    <button type="button" class="z-btn z-btn-outline flex-1">
-      Kontraponuda
-    </button>
-  </div>
-</div>
+<!-- Modal component -->
+<app-otc-offer-detail 
+  *ngIf="showModal && selectedOffer"
+  [offer]="selectedOffer"
+  (close)="closeModal()"
+  (updated)="onOfferUpdated()">
+</app-otc-offer-detail>

--- a/src/app/features/client/components/otc-active-offers/otc-active-offers.component.scss
+++ b/src/app/features/client/components/otc-active-offers/otc-active-offers.component.scss
@@ -1,0 +1,4 @@
+/* Styling for OTC Active Offers Component */
+
+/* Može biti prazno ako koristi Tailwind CSS */
+/* Prilagođeni stilovi ako je potrebno */

--- a/src/app/features/client/components/otc-active-offers/otc-active-offers.component.ts
+++ b/src/app/features/client/components/otc-active-offers/otc-active-offers.component.ts
@@ -1,0 +1,321 @@
+import { Component, OnInit, OnDestroy, ViewContainerRef } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { OtcOfferService } from '../../services/otc-offer.service';
+import { AuthService } from '../../../../core/services/auth.service';
+import { OtcOffer } from '../../models/otc-offer.model';
+import { NavbarComponent } from '../../../../shared/components/navbar/navbar.component';
+
+interface PriceDeviation {
+  percentage: number;
+  color: 'green' | 'yellow' | 'red';
+}
+
+@Component({
+  selector: 'app-otc-active-offers',
+  templateUrl: './otc-active-offers.component.html',
+  styleUrls: ['./otc-active-offers.component.scss'],
+  standalone: true,
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterModule, NavbarComponent],
+})
+export class OtcActiveOffersComponent implements OnInit, OnDestroy {
+  offers: OtcOffer[] = [];
+  loading = false;
+  error: string | null = null;
+  unreadCount = 0;
+
+  // Pagination
+  page = 0;
+  pageSize = 10;
+  totalElements = 0;
+  totalPages = 0;
+
+  // Modal
+  selectedOffer: OtcOffer | null = null;
+  showModal = false;
+
+  private destroy$ = new Subject<void>();
+
+  constructor(
+    private otcOfferService: OtcOfferService,
+    private authService: AuthService,
+    private viewContainerRef: ViewContainerRef
+  ) {}
+
+  ngOnInit(): void {
+    this.loadOffers();
+    this.loadUnreadCount();
+
+    // Subscribe to unread count changes
+    this.otcOfferService.unreadCount$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((count: any) => {
+        this.unreadCount = count;
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  /**
+   * Učitava aktivne ponude
+   */
+  loadOffers(): void {
+    this.loading = true;
+    this.error = null;
+
+    this.otcOfferService.getActiveOffers(this.page, this.pageSize)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (response: any) => {
+          this.offers = response.content;
+          this.totalElements = response.totalElements;
+          this.totalPages = response.totalPages;
+          this.loading = false;
+        },
+        error: (err: any) => {
+          this.error = 'Greška pri učitavanju ponuda';
+          this.loading = false;
+          console.error('Error loading OTC offers:', err);
+        },
+      });
+  }
+
+  /**
+   * Učitava broj nepročitanih ponuda
+   */
+  loadUnreadCount(): void {
+    this.otcOfferService.updateUnreadCount();
+  }
+
+  /**
+   * Otvara modal sa detaljima ponude
+   */
+  openOfferDetail(offer: OtcOffer): void {
+    this.selectedOffer = offer;
+    this.showModal = true;
+
+    // Označi ponudu kao pročitanu ako je nepročitana
+    if (offer.modifiedBy.id !== this.authService.getUserIdFromToken()) {
+      this.otcOfferService.markAsRead(offer.id)
+        .pipe(takeUntil(this.destroy$))
+        .subscribe({
+          next: () => {
+            this.loadUnreadCount();
+          },
+          error: (err: any) => {
+            console.error('Error marking offer as read:', err);
+          },
+        });
+    }
+  }
+
+  /**
+   * Zatvara modal
+   */
+  closeModal(): void {
+    this.showModal = false;
+    this.selectedOffer = null;
+  }
+
+  /**
+   * Osvežava listu nakon akcije
+   */
+  onOfferUpdated(): void {
+    this.closeModal();
+    this.loadOffers();
+    this.loadUnreadCount();
+  }
+
+  /**
+   * Određuje boju na osnovu odstupanja cene od tržišne
+   * Zelena ≤±5%, žuta ±5-20%, crvena >±20%
+   */
+  getPriceDeviation(offer: OtcOffer): PriceDeviation {
+    if (!offer.currentMarketPrice || offer.currentMarketPrice === 0) {
+      return { percentage: 0, color: 'green' };
+    }
+
+    const difference = Math.abs(offer.pricePerShare - offer.currentMarketPrice);
+    const percentage = (difference / offer.currentMarketPrice) * 100;
+
+    if (percentage <= 5) {
+      return { percentage, color: 'green' };
+    } else if (percentage <= 20) {
+      return { percentage, color: 'yellow' };
+    } else {
+      return { percentage, color: 'red' };
+    }
+  }
+
+  /**
+   * Vrača CSS klasu za boju cene
+   */
+  getPriceColorClass(offer: OtcOffer): string {
+    const deviation = this.getPriceDeviation(offer);
+    switch (deviation.color) {
+      case 'green':
+        return 'bg-success/10 text-success';
+      case 'yellow':
+        return 'bg-warning/10 text-warning';
+      case 'red':
+        return 'bg-destructive/10 text-destructive';
+      default:
+        return '';
+    }
+  }
+
+  /**
+   * Formatira iznos
+   */
+  formatAmount(value: number): string {
+    return new Intl.NumberFormat('sr-RS', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(value);
+  }
+
+  /**
+   * Formatira datum i vreme
+   */
+  formatDateTime(dateString: string): string {
+    if (!dateString) return '-';
+    return new Date(dateString).toLocaleString('sr-RS');
+  }
+
+  /**
+   * Ide na prethodnu stranicu
+   */
+  previousPage(): void {
+    if (this.page > 0) {
+      this.page--;
+      this.loadOffers();
+    }
+  }
+
+  /**
+   * Ide na sledeću stranicu
+   */
+  nextPage(): void {
+    if (this.page < this.totalPages - 1) {
+      this.page++;
+      this.loadOffers();
+    }
+  }
+
+  /**
+   * Vraća naziv banke učesnika
+   */
+  getCounterpartyBankName(offer: OtcOffer): string {
+    return offer.counterparty?.bank?.name || '-';
+  }
+
+  /**
+   * Vraća puno ime učesnika
+   */
+  getCounterpartyFullName(offer: OtcOffer): string {
+    const user = offer.counterparty?.user;
+    if (!user) return '-';
+    return `${user.firstName} ${user.lastName}`;
+  }
+
+  /**
+   * Formatira datum
+   */
+  formatDate(dateString: string): string {
+    return new Date(dateString).toLocaleDateString('sr-RS');
+  }
+
+  /**
+   * Vrača CSS klasu na osnovu status-a ponude
+   */
+  getStatusBadgeClass(offer: OtcOffer): string {
+    switch (offer.status) {
+      case 'PENDING':
+        return 'bg-info/10 text-info';
+      case 'ACCEPTED':
+        return 'bg-success/10 text-success';
+      case 'REJECTED':
+        return 'bg-destructive/10 text-destructive';
+      case 'COUNTER_OFFER':
+        return 'bg-warning/10 text-warning';
+      default:
+        return '';
+    }
+  }
+
+  /**
+   * Vraća prikličan tekst za status
+   */
+  getStatusLabel(offer: OtcOffer): string {
+    switch (offer.status) {
+      case 'PENDING':
+        return 'U pregovorima';
+      case 'ACCEPTED':
+        return 'Prihvaćena';
+      case 'REJECTED':
+        return 'Odbijena';
+      case 'COUNTER_OFFER':
+        return 'Kontraponuda';
+      default:
+        return offer.status;
+    }
+  }
+
+  /**
+   * Prihvata ponudu iz modala
+   */
+  acceptOfferModal(): void {
+    if (!this.selectedOffer) return;
+
+    this.loading = true;
+    this.otcOfferService.acceptOffer(this.selectedOffer.id, this.selectedOffer.premium)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => {
+          this.loading = false;
+          this.closeModal();
+          this.loadOffers();
+          this.loadUnreadCount();
+        },
+        error: (err) => {
+          this.loading = false;
+          this.error = 'Greška pri prihvatanju ponude';
+          console.error('Error accepting offer:', err);
+        },
+      });
+  }
+
+  /**
+   * Odbija ponudu iz modala
+   */
+  rejectOfferModal(): void {
+    if (!this.selectedOffer) return;
+
+    if (!confirm('Sigurno želite da odustanete od ove ponude?')) {
+      return;
+    }
+
+    this.loading = true;
+    this.otcOfferService.rejectOffer(this.selectedOffer.id)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => {
+          this.loading = false;
+          this.closeModal();
+          this.loadOffers();
+          this.loadUnreadCount();
+        },
+        error: (err) => {
+          this.loading = false;
+          this.error = 'Greška pri odbijanju ponude';
+          console.error('Error rejecting offer:', err);
+        },
+      });
+  }
+}

--- a/src/app/features/client/components/otc-active-offers/otc-active-offers.component.ts
+++ b/src/app/features/client/components/otc-active-offers/otc-active-offers.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, OnDestroy, ViewContainerRef } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -8,6 +8,7 @@ import { OtcOfferService } from '../../services/otc-offer.service';
 import { AuthService } from '../../../../core/services/auth.service';
 import { OtcOffer } from '../../models/otc-offer.model';
 import { NavbarComponent } from '../../../../shared/components/navbar/navbar.component';
+import { OtcOfferDetailComponent } from '../../modals/otc-offer-detail/otc-offer-detail.component';
 
 interface PriceDeviation {
   percentage: number;
@@ -19,7 +20,7 @@ interface PriceDeviation {
   templateUrl: './otc-active-offers.component.html',
   styleUrls: ['./otc-active-offers.component.scss'],
   standalone: true,
-  imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterModule, NavbarComponent],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterModule, NavbarComponent, OtcOfferDetailComponent],
 })
 export class OtcActiveOffersComponent implements OnInit, OnDestroy {
   offers: OtcOffer[] = [];
@@ -36,13 +37,15 @@ export class OtcActiveOffersComponent implements OnInit, OnDestroy {
   // Modal
   selectedOffer: OtcOffer | null = null;
   showModal = false;
+  modalTab: 'view' | 'counter' = 'view';
 
   private destroy$ = new Subject<void>();
 
   constructor(
     private otcOfferService: OtcOfferService,
     private authService: AuthService,
-    private viewContainerRef: ViewContainerRef
+    private viewContainerRef: ViewContainerRef,
+    private fb: FormBuilder
   ) {}
 
   ngOnInit(): void {
@@ -121,6 +124,7 @@ export class OtcActiveOffersComponent implements OnInit, OnDestroy {
   closeModal(): void {
     this.showModal = false;
     this.selectedOffer = null;
+    this.modalTab = 'view';
   }
 
   /**
@@ -130,6 +134,13 @@ export class OtcActiveOffersComponent implements OnInit, OnDestroy {
     this.closeModal();
     this.loadOffers();
     this.loadUnreadCount();
+  }
+
+  /**
+   * Otvara tab sa formom za kontraponudu
+   */
+  openCounterOfferForm(): void {
+    this.modalTab = 'counter';
   }
 
   /**

--- a/src/app/features/client/modals/otc-offer-detail/otc-offer-detail.component.html
+++ b/src/app/features/client/modals/otc-offer-detail/otc-offer-detail.component.html
@@ -1,0 +1,156 @@
+<!-- Modal backdrop -->
+<div class="fixed inset-0 z-50 bg-black/50" (click)="closeModal()"></div>
+
+<!-- Modal content -->
+<div class="fixed left-1/2 top-1/2 z-50 w-full max-w-2xl -translate-x-1/2 -translate-y-1/2 rounded-lg border border-border bg-card p-6 shadow-lg">
+  <!-- Header -->
+  <div class="mb-6 flex items-start justify-between">
+    <div>
+      <h2 class="text-2xl font-bold">{{ offer.ticker }}</h2>
+      <p class="mt-1 text-sm text-muted-foreground">Ponuda od: {{ getCounterpartyName() }} ({{ getCounterpartyBank() }})</p>
+    </div>
+    <button type="button" class="text-muted-foreground hover:text-foreground" (click)="closeModal()">
+      <svg class="h-6 w-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+        stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <line x1="18" y1="6" x2="6" y2="18"></line>
+        <line x1="6" y1="6" x2="18" y2="18"></line>
+      </svg>
+    </button>
+  </div>
+
+  <!-- Status badge -->
+  <div class="mb-6">
+    <span [ngClass]="getStatusBadgeClass()" class="inline-block rounded-full px-3 py-1 text-sm font-semibold">
+      {{ getStatusLabel() }}
+    </span>
+  </div>
+
+  <!-- Error/Success messages -->
+  <div *ngIf="state.error" class="mb-4 rounded-lg border border-destructive bg-destructive/10 p-3 text-sm text-destructive">
+    {{ state.error }}
+  </div>
+  <div *ngIf="state.success" class="mb-4 rounded-lg border border-success bg-success/10 p-3 text-sm text-success">
+    {{ state.success }}
+  </div>
+
+  <!-- Tabs -->
+  <div class="mb-6 flex gap-2 border-b border-border">
+    <button type="button" class="px-4 py-2 font-medium transition-colors"
+      [ngClass]="activeTab === 'view' ? 'border-b-2 border-primary text-primary' : 'text-muted-foreground hover:text-foreground'"
+      (click)="activeTab = 'view'">
+      Detaljno
+    </button>
+    <button type="button" class="px-4 py-2 font-medium transition-colors"
+      [ngClass]="activeTab === 'counter' ? 'border-b-2 border-primary text-primary' : 'text-muted-foreground hover:text-foreground'"
+      (click)="activeTab = 'counter'">
+      Kontraponuda
+    </button>
+  </div>
+
+  <!-- Tab Content: View Details -->
+  <div *ngIf="activeTab === 'view'" class="mb-6 space-y-4">
+    <div class="grid grid-cols-2 gap-4">
+      <div class="rounded-lg border border-border bg-muted/20 p-4">
+        <p class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Količina</p>
+        <p class="mt-1 text-xl font-bold">{{ formatAmount(offer.quantity) }}</p>
+      </div>
+      <div class="rounded-lg border border-border bg-muted/20 p-4">
+        <p class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Cena po akciji</p>
+        <p class="mt-1 text-xl font-bold">{{ formatAmount(offer.pricePerShare) }}</p>
+      </div>
+      <div class="rounded-lg border border-border bg-muted/20 p-4">
+        <p class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Premija</p>
+        <p class="mt-1 text-xl font-bold">{{ formatAmount(offer.premium) }}</p>
+      </div>
+      <div class="rounded-lg border border-border bg-muted/20 p-4">
+        <p class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Settlement Date</p>
+        <p class="mt-1 text-xl font-bold">{{ formatDate(offer.settlementDate) }}</p>
+      </div>
+    </div>
+
+    <!-- Total value -->
+    <div class="items-end rounded-lg border border-border bg-primary/5 p-4">
+      <p class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Ukupna vrednost</p>
+      <p class="mt-1 text-2xl font-bold text-primary">
+        {{ formatAmount(offer.quantity * offer.pricePerShare + offer.premium) }}
+      </p>
+    </div>
+
+    <!-- Current market price comparison -->
+    <div *ngIf="offer.currentMarketPrice" class="rounded-lg border border-border bg-muted/20 p-4">
+      <p class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Tržišna cena / Odstupanje</p>
+      <div class="mt-3 flex items-baseline gap-4">
+        <div>
+          <p class="text-sm text-muted-foreground">Trenutna tržišna cena</p>
+          <p class="text-lg font-bold">{{ formatAmount(offer.currentMarketPrice) }}</p>
+        </div>
+        <div>
+          <p class="text-sm text-muted-foreground">Vaša ponuda</p>
+          <p class="text-lg font-bold">{{ formatAmount(offer.pricePerShare) }}</p>
+        </div>
+        <div>
+          <p class="text-sm text-muted-foreground">Razlika</p>
+          <p class="text-lg font-bold">
+            {{ formatAmount(Math.abs(offer.pricePerShare - offer.currentMarketPrice)) }}
+            ({{ ((Math.abs(offer.pricePerShare - offer.currentMarketPrice) / offer.currentMarketPrice) * 100).toFixed(1) }}%)
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Tab Content: Counter Offer Form -->
+  <div *ngIf="activeTab === 'counter'" class="mb-6">
+    <form [formGroup]="counterOfferForm" (ngSubmit)="sendCounterOffer()" class="space-y-4">
+      <div>
+        <label class="block text-sm font-medium mb-2">Količina</label>
+        <input type="number" formControlName="quantity" class="z-input w-full" min="1" step="1" />
+        <p *ngIf="counterOfferForm.get('quantity')?.hasError('required')" class="mt-1 text-xs text-destructive">
+          Količina je obavezna
+        </p>
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium mb-2">Cena po akciji</label>
+        <input type="number" formControlName="pricePerShare" class="z-input w-full" min="0.01" step="0.01" />
+        <p *ngIf="counterOfferForm.get('pricePerShare')?.hasError('required')" class="mt-1 text-xs text-destructive">
+          Cena je obavezna
+        </p>
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium mb-2">Premija</label>
+        <input type="number" formControlName="premium" class="z-input w-full" step="0.01" />
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium mb-2">Settlement Date</label>
+        <input type="date" formControlName="settlementDate" class="z-input w-full" />
+        <p *ngIf="counterOfferForm.get('settlementDate')?.hasError('required')" class="mt-1 text-xs text-destructive">
+          Datum je obavezan
+        </p>
+      </div>
+
+      <button type="submit" class="z-btn z-btn-primary w-full" [disabled]="state.loading || !counterOfferForm.valid">
+        <span *ngIf="!state.loading">Pošalji kontraponudu</span>
+        <span *ngIf="state.loading">Slanje...</span>
+      </button>
+    </form>
+  </div>
+
+  <!-- Actions -->
+  <div class="flex gap-3">
+    <button type="button" class="z-btn z-btn-primary flex-1" (click)="acceptOffer()" [disabled]="state.loading">
+      <span *ngIf="!state.loading">✓ Prihvati</span>
+      <span *ngIf="state.loading">Prihvatanje...</span>
+    </button>
+    <button type="button" class="z-btn z-btn-outline flex-1" (click)="rejectOffer()" [disabled]="state.loading">
+      <span *ngIf="!state.loading">✗ Odustani</span>
+      <span *ngIf="state.loading">Odbijanje...</span>
+    </button>
+    <button type="button" class="z-btn z-btn-outline flex-1" (click)="activeTab = 'counter'"
+      [disabled]="state.loading">
+      Kontraponuda
+    </button>
+  </div>
+</div>

--- a/src/app/features/client/modals/otc-offer-detail/otc-offer-detail.component.scss
+++ b/src/app/features/client/modals/otc-offer-detail/otc-offer-detail.component.scss
@@ -1,0 +1,2 @@
+/* Modal styling */
+/* Može biti prazno ako koristi Tailwind CSS */

--- a/src/app/features/client/modals/otc-offer-detail/otc-offer-detail.component.ts
+++ b/src/app/features/client/modals/otc-offer-detail/otc-offer-detail.component.ts
@@ -192,6 +192,7 @@ export class OtcOfferDetailComponent implements OnInit, OnDestroy {
    * Formatira datum
    */
   formatDate(dateString: string): string {
+    if (!dateString) return '-';
     return new Date(dateString).toLocaleDateString('sr-RS');
   }
 

--- a/src/app/features/client/modals/otc-offer-detail/otc-offer-detail.component.ts
+++ b/src/app/features/client/modals/otc-offer-detail/otc-offer-detail.component.ts
@@ -1,0 +1,249 @@
+import { Component, Input, Output, EventEmitter, OnInit, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { OtcOfferService } from '../../services/otc-offer.service';
+import { OtcOffer } from '../../models/otc-offer.model';
+
+interface ModalState {
+  loading: boolean;
+  error: string | null;
+  success: string | null;
+}
+
+@Component({
+  selector: 'app-otc-offer-detail',
+  templateUrl: './otc-offer-detail.component.html',
+  styleUrls: ['./otc-offer-detail.component.scss'],
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+})
+export class OtcOfferDetailComponent implements OnInit, OnDestroy {
+  @Input() offer!: OtcOffer;
+  @Output() close = new EventEmitter<void>();
+  @Output() updated = new EventEmitter<void>();
+
+  state: ModalState = {
+    loading: false,
+    error: null,
+    success: null,
+  };
+
+  // Forme
+  counterOfferForm!: FormGroup;
+  acceptForm!: FormGroup;
+
+  // Modal view state
+  activeTab: 'view' | 'counter' = 'view';
+
+  // Expose Math for template
+  Math = Math;
+
+  private destroy$ = new Subject<void>();
+
+  constructor(private otcOfferService: OtcOfferService, private fb: FormBuilder) {}
+
+  ngOnInit(): void {
+    this.initForms();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  /**
+   * Inicijalizuje forme
+   */
+  private initForms(): void {
+    // Counter Offer forma
+    this.counterOfferForm = this.fb.group({
+      quantity: [this.offer.quantity, [Validators.required, Validators.min(1)]],
+      pricePerShare: [this.offer.pricePerShare, [Validators.required, Validators.min(0.01)]],
+      premium: [this.offer.premium, [Validators.required]],
+      settlementDate: [this.offer.settlementDate, [Validators.required]],
+    });
+
+    // Accept forma
+    this.acceptForm = this.fb.group({
+      premiumAmount: [this.offer.premium, [Validators.required, Validators.min(0.01)]],
+    });
+  }
+
+  /**
+   * Prihvata ponudu - pokreće kreiranje opcionalnog ugovora i isplatu premije
+   */
+  acceptOffer(): void {
+    if (!this.acceptForm.valid) {
+      this.state.error = 'Molimo ispunite sve obavezne polje';
+      return;
+    }
+
+    this.state.loading = true;
+    this.state.error = null;
+    this.state.success = null;
+
+    const premiumAmount = this.acceptForm.get('premiumAmount')?.value;
+
+    this.otcOfferService.acceptOffer(this.offer.id, premiumAmount)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => {
+          this.state.loading = false;
+          this.state.success = 'Ponuda je prihvaćena. Opcioni ugovor je kreiran.';
+          setTimeout(() => {
+            this.updated.emit();
+          }, 1500);
+        },
+        error: (err: any) => {
+          this.state.loading = false;
+          this.state.error = err.error?.message || 'Greška pri prihvatanju ponude';
+          console.error('Error accepting offer:', err);
+        },
+      });
+  }
+
+  /**
+   * Odustaje od ponude
+   */
+  rejectOffer(): void {
+    if (!confirm('Sigurno želite da odustanete od ove ponude?')) {
+      return;
+    }
+
+    this.state.loading = true;
+    this.state.error = null;
+    this.state.success = null;
+
+    this.otcOfferService.rejectOffer(this.offer.id)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => {
+          this.state.loading = false;
+          this.state.success = 'Ponuda je odbijena';
+          setTimeout(() => {
+            this.updated.emit();
+          }, 1500);
+        },
+        error: (err: any) => {
+          this.state.loading = false;
+          this.state.error = err.error?.message || 'Greška pri odbijanju ponude';
+          console.error('Error rejecting offer:', err);
+        },
+      });
+  }
+
+  /**
+   * Šalje kontraponudu
+   */
+  sendCounterOffer(): void {
+    if (!this.counterOfferForm.valid) {
+      this.state.error = 'Molimo ispunite sve obavezne polje';
+      return;
+    }
+
+    this.state.loading = true;
+    this.state.error = null;
+    this.state.success = null;
+
+    const formValue = this.counterOfferForm.value;
+    const request = {
+      otcOfferId: this.offer.id,
+      ...formValue,
+    };
+
+    this.otcOfferService.sendCounterOffer(request)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => {
+          this.state.loading = false;
+          this.state.success = 'Kontraponuda je poslata';
+          setTimeout(() => {
+            this.updated.emit();
+          }, 1500);
+        },
+        error: (err: any) => {
+          this.state.loading = false;
+          this.state.error = err.error?.message || 'Greška pri slanju kontraponude';
+          console.error('Error sending counter offer:', err);
+        },
+      });
+  }
+
+  /**
+   * Zatvara modal
+   */
+  closeModal(): void {
+    this.close.emit();
+  }
+
+  /**
+   * Formatira iznos
+   */
+  formatAmount(value: number): string {
+    return new Intl.NumberFormat('sr-RS', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(value);
+  }
+
+  /**
+   * Formatira datum
+   */
+  formatDate(dateString: string): string {
+    return new Date(dateString).toLocaleDateString('sr-RS');
+  }
+
+  /**
+   * Dodeljuje CSS klasu na osnovu status-a ponude
+   */
+  getStatusBadgeClass(): string {
+    switch (this.offer.status) {
+      case 'PENDING':
+        return 'bg-info/10 text-info';
+      case 'ACCEPTED':
+        return 'bg-success/10 text-success';
+      case 'REJECTED':
+        return 'bg-destructive/10 text-destructive';
+      case 'COUNTER_OFFER':
+        return 'bg-warning/10 text-warning';
+      default:
+        return '';
+    }
+  }
+
+  /**
+   * Vraća prikličan tekst za status
+   */
+  getStatusLabel(): string {
+    switch (this.offer.status) {
+      case 'PENDING':
+        return 'U pregovorima';
+      case 'ACCEPTED':
+        return 'Prihvaćena';
+      case 'REJECTED':
+        return 'Odbijena';
+      case 'COUNTER_OFFER':
+        return 'Kontraponuda';
+      default:
+        return this.offer.status;
+    }
+  }
+
+  /**
+   * Vrača puno ime drugog učesnika
+   */
+  getCounterpartyName(): string {
+    const user = this.offer.counterparty?.user;
+    if (!user) return '-';
+    return `${user.firstName} ${user.lastName}`;
+  }
+
+  /**
+   * Vrača naziv banke drugog učesnika
+   */
+  getCounterpartyBank(): string {
+    return this.offer.counterparty?.bank?.name || '-';
+  }
+}

--- a/src/app/features/client/models/otc-offer.model.ts
+++ b/src/app/features/client/models/otc-offer.model.ts
@@ -1,0 +1,82 @@
+/**
+ * OTC (Over-The-Counter) Offer Model
+ * Predstavlja ponudu za negocijaciju između klijenta i aktuara
+ */
+
+export interface User {
+  id: number;
+  firstName: string;
+  lastName: string;
+  email: string;
+}
+
+export interface Bank {
+  id: number;
+  name: string;
+  acronym: string;
+}
+
+export interface Counterparty {
+  user: User;
+  bank: Bank;
+}
+
+export interface OtcOffer {
+  id: number;
+  /** Hartija od vrednosti (npr. ticker) */
+  ticker: string;
+  listingId: number;
+  /** Količina */
+  quantity: number;
+  /** Cena po akciji */
+  pricePerShare: number;
+  /** Premija (razlika od tržišne cene) */
+  premium: number;
+  /** Datum settlement-a */
+  settlementDate: string;
+  /** Korisnik koji je iniciator ponude */
+  initiatedBy: User;
+  /** Stranka sa kojom se pregovara */
+  counterparty: Counterparty;
+  /** Korisnik koji je zadnje modifikovao ponudu */
+  modifiedBy: User;
+  /** Timestamp poslednje izmene */
+  lastModified: string;
+  /** Status ponude: PENDING, ACCEPTED, REJECTED, COUNTER_OFFER */
+  status: 'PENDING' | 'ACCEPTED' | 'REJECTED' | 'COUNTER_OFFER';
+  /** Trenutna tržišna cena */
+  currentMarketPrice?: number;
+  /** Da li je ponuda pročitana od strane logovanog korisnika */
+  isRead?: boolean;
+}
+
+export interface CreateOtcOfferRequest {
+  listingId: number;
+  quantity: number;
+  pricePerShare: number;
+  premium: number;
+  settlementDate: string;
+  counterpartyId: number;
+}
+
+export interface CounterOfferRequest {
+  otcOfferId: number;
+  quantity: number;
+  pricePerShare: number;
+  premium: number;
+  settlementDate: string;
+}
+
+export interface OptionalContractRequest {
+  otcOfferId: number;
+  /** Premium amount to be paid */
+  premiumAmount: number;
+}
+
+export interface OtcOfferPage {
+  content: OtcOffer[];
+  totalElements: number;
+  totalPages: number;
+  number: number;
+  size: number;
+}

--- a/src/app/features/client/services/otc-offer.service.ts
+++ b/src/app/features/client/services/otc-offer.service.ts
@@ -1,0 +1,111 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable, BehaviorSubject } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import {
+  OtcOffer,
+  OtcOfferPage,
+  CreateOtcOfferRequest,
+  CounterOfferRequest,
+  OptionalContractRequest,
+} from '../models/otc-offer.model';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class OtcOfferService {
+  private readonly baseUrl = `${environment.apiUrl}/otc/offers`;
+  private readonly unreadCountSubject = new BehaviorSubject<number>(0);
+
+  public unreadCount$ = this.unreadCountSubject.asObservable();
+
+  constructor(private http: HttpClient) {}
+
+  /**
+   * Dobija sve aktivne ponude za logovanog korisnika
+   */
+  getActiveOffers(page = 0, size = 10): Observable<OtcOfferPage> {
+    const params = new HttpParams()
+      .set('page', page)
+      .set('size', size)
+      .set('status', 'PENDING,COUNTER_OFFER');
+    return this.http.get<OtcOfferPage>(`${this.baseUrl}/active`, { params });
+  }
+
+  /**
+   * Dobija sve ponude za logovanog korisnika (sa filterovanjem)
+   */
+  getOffers(status?: string, page = 0, size = 10): Observable<OtcOfferPage> {
+    let params = new HttpParams().set('page', page).set('size', size);
+    if (status) {
+      params = params.set('status', status);
+    }
+    return this.http.get<OtcOfferPage>(this.baseUrl, { params });
+  }
+
+  /**
+   * Dobija detalje jedne ponude
+   */
+  getOfferById(offerId: number): Observable<OtcOffer> {
+    return this.http.get<OtcOffer>(`${this.baseUrl}/${offerId}`);
+  }
+
+  /**
+   * Kreira novu ponudu
+   */
+  createOffer(request: CreateOtcOfferRequest): Observable<OtcOffer> {
+    return this.http.post<OtcOffer>(this.baseUrl, request);
+  }
+
+  /**
+   * Prihvata ponudu - pokreće kreiranje opcionalnog ugovora i isplatu premije
+   */
+  acceptOffer(offerId: number, premiumAmount: number): Observable<any> {
+    const request: OptionalContractRequest = {
+      otcOfferId: offerId,
+      premiumAmount,
+    };
+    return this.http.post(`${this.baseUrl}/${offerId}/accept`, request);
+  }
+
+  /**
+   * Odbija/odustaje od ponude
+   */
+  rejectOffer(offerId: number): Observable<any> {
+    return this.http.post(`${this.baseUrl}/${offerId}/reject`, {});
+  }
+
+  /**
+   * Šalje kontraponudu
+   */
+  sendCounterOffer(request: CounterOfferRequest): Observable<OtcOffer> {
+    return this.http.post<OtcOffer>(
+      `${this.baseUrl}/${request.otcOfferId}/counter-offer`,
+      request
+    );
+  }
+
+  /**
+   * Dobija broj nepročitanih ponuda
+   */
+  getUnreadCount(): Observable<number> {
+    return this.http.get<number>(`${this.baseUrl}/unread/count`);
+  }
+
+  /**
+   * Ažurira broj nepročitanih ponuda
+   */
+  updateUnreadCount(): void {
+    this.getUnreadCount().subscribe(
+      (count) => this.unreadCountSubject.next(count),
+      () => this.unreadCountSubject.next(0)
+    );
+  }
+
+  /**
+   * Označa ponudu kao pročitanu
+   */
+  markAsRead(offerId: number): Observable<any> {
+    return this.http.post(`${this.baseUrl}/${offerId}/mark-as-read`, {});
+  }
+}

--- a/src/app/shared/components/navbar/navbar.component.ts
+++ b/src/app/shared/components/navbar/navbar.component.ts
@@ -48,7 +48,6 @@ export class NavbarComponent implements OnInit {
     { label: 'Hartije',    route: '/securities',          icon: 'trending_up' },
     { label: 'Berza',      route: '/stock-exchange',      icon: 'show_chart' },
     { label: 'Nalozi',     route: '/orders-overview',      icon: 'assignment' },
-    { label: 'Aktivne ponude', route: '/client/otc-offers', icon: 'handshake' },
   ];
 
   private readonly supervisorLinks: NavLink[] = [

--- a/src/app/shared/components/navbar/navbar.component.ts
+++ b/src/app/shared/components/navbar/navbar.component.ts
@@ -32,6 +32,7 @@ export class NavbarComponent implements OnInit {
     { label: 'Menjačnica', route: '/exchange',            icon: 'currency_exchange' },
     { label: 'Primaoci plaćanja', route: '/payments/recipients', icon: 'people' },
     { label: 'Hartije',    route: '/securities',          icon: 'trending_up' },
+    { label: 'Aktivne ponude', route: '/client/otc-offers', icon: 'handshake' },
     this.portfolioLink,
     { label: 'Krediti',    route: '/loans',               icon: 'credit_card' },
     { label: 'Berza',      route: '/stock-exchange',      icon: 'show_chart' },
@@ -47,6 +48,7 @@ export class NavbarComponent implements OnInit {
     { label: 'Hartije',    route: '/securities',          icon: 'trending_up' },
     { label: 'Berza',      route: '/stock-exchange',      icon: 'show_chart' },
     { label: 'Nalozi',     route: '/orders-overview',      icon: 'assignment' },
+    { label: 'Aktivne ponude', route: '/client/otc-offers', icon: 'handshake' },
   ];
 
   private readonly supervisorLinks: NavLink[] = [


### PR DESCRIPTION
Introduce OTC (over-the-counter) active offers functionality: new standalone OtcActiveOffersComponent, OtcOfferDetail modal component, SCSS templates, OtcOffer models, and OtcOfferService for API interactions (list, accept, reject, counter-offer, unread count). Add clientOrActuaryGuard to restrict access to clients/actuaries and register it in client routing; declare the component in ClientModule. Add navbar links for the new view and wire routes (including a client route in app routing). Provides pagination, unread count handling, and actions for accepting/rejecting/sending counteroffers.