### PR TITLE
fix(#199): SELL navigation from portfolio, persistent account id, cancel dialog

### DIFF
--- a/src/app/features/client/components/portfolio/portfolio.component.html
+++ b/src/app/features/client/components/portfolio/portfolio.component.html
@@ -111,7 +111,7 @@
                 <td class="text-muted-foreground whitespace-nowrap">{{ formatDateTime(holding.lastModified) }}</td>
                 <td>
                   <div class="flex flex-col gap-3 items-start min-w-[260px]">
-                    <button type="button" class="z-btn-outline z-btn-sm" (click)="onSell()">
+                    <button type="button" class="z-btn-outline z-btn-sm" (click)="onSell(holding)">
                       Prodaj
                     </button>
 

--- a/src/app/features/client/components/portfolio/portfolio.component.ts
+++ b/src/app/features/client/components/portfolio/portfolio.component.ts
@@ -167,8 +167,15 @@ export class PortfolioComponent implements OnInit, OnDestroy {
       });
   }
 
-  onSell(): void {
-    // TODO: Povezati F1 Sell modal / Create order flow kada ta implementacija bude dostupna.
+  onSell(holding: PortfolioHolding): void {
+    // The Create Order route is parameterised by direction and the underlying
+    // listing id; without listingId the SELL flow cannot identify which
+    // security the form should pre-select.
+    if (typeof holding.listingId !== 'number') {
+      this.toastService.error('Nije moguce otvoriti formu za prodaju: nedostaje identifikator hartije.');
+      return;
+    }
+    this.router.navigate(['/orders/create', 'SELL', holding.listingId]);
   }
 
   isStock(holding: PortfolioHolding): boolean {

--- a/src/app/features/client/models/portfolio.model.ts
+++ b/src/app/features/client/models/portfolio.model.ts
@@ -2,6 +2,12 @@ export type PortfolioListingType = 'STOCK' | 'FUTURES' | 'FOREX' | 'OPTION';
 
 export interface PortfolioHolding {
   id?: number;
+  /**
+   * Identifier of the underlying security listing. Required by the SELL flow
+   * to navigate to a direction-specific Create Order route; without it the
+   * portfolio row carries no usable target for navigation.
+   */
+  listingId?: number;
   listingType: PortfolioListingType;
   ticker: string;
   quantity: number;

--- a/src/app/features/client/services/account.service.ts
+++ b/src/app/features/client/services/account.service.ts
@@ -57,8 +57,18 @@ export class AccountService {
 
     const currency = item.currency || item.valuta || 'RSD';
 
+    // Prefer the persistent primary key returned by the API. The legacy
+    // hash-of-account-number fallback exists only for older backend builds
+    // that did not yet expose `id`; values it produces do not map to either
+    // the database PK or the account number, so any subsequent lookup using
+    // the hash returns 404 and breaks order confirmation/execution flows.
+    const persistentId =
+      typeof item.id === 'number'
+        ? item.id
+        : this.hashAccountNumber(item.brojRacuna);
+
     return {
-      id: this.hashAccountNumber(item.brojRacuna),
+      id: persistentId,
       name: item.nazivRacuna || '',
       accountNumber: (item.brojRacuna || item.accountNumber || '').trim(),
       balance: item.stanjeRacuna || 0,

--- a/src/app/features/employee/components/orders-overview/orders-overview.component.ts
+++ b/src/app/features/employee/components/orders-overview/orders-overview.component.ts
@@ -174,7 +174,12 @@ export class OrdersOverviewComponent implements OnInit {
       return;
     }
     const order = this.cancelTarget;
-    const raw = this.cancelQuantityInput.trim();
+    // ngModel on <input type="number"> coerces the bound value to a JS number as
+    // soon as the user types a digit. Calling .trim() on a number throws a
+    // TypeError, which previously left confirmCancel() silently dead whenever
+    // the textbox contained any digit (only an empty input — still a string —
+    // worked). Coerce defensively to string before parsing.
+    const raw = String(this.cancelQuantityInput ?? '').trim();
     let quantity: number | undefined;
 
     if (raw !== '') {


### PR DESCRIPTION
## Sazetak

Pull request resava tri prijavljena problema u korisnickom interfejsu koji su
direktno blokirali ili tiho prekidali tokove BUY/SELL i otkazivanja ordera:

1. Dugme Prodaj iz `Moj Portfolio` nije imalo handler -- klik je bio no-op.
2. Lista racuna koristila je hash 32-bitnog broja racuna kao numericki id,
   sto je proizvodilo vrednosti koje ne mapiraju ni na PK ni na broj racuna.
   Naredni `/internal/accounts/id/...` poziv vracao je 404 i obao tokove.
3. Confirm cancel dugme radilo je samo dok je polje za kolicinu prazno; sa
   bilo kojom unetom cifrom nista se nije desavalo.

## Promene

### Portfolio SELL flow

- `PortfolioHolding` model dobija opciono polje `listingId: number`.
- `PortfolioComponent.onSell(holding)` navigira na
  `/orders/create/SELL/{listingId}`. Ako server ne vrati `listingId`,
  prikazuje se toast umesto tihog otvaranja prazne forme.
- HTML sablon prosleduje `holding` parametar handleru.

### Mapiranje racuna iz API odgovora

- `AccountService.mapToAccountFromClient` koristi `item.id` (perzistentni
  PK) kada je dostupan. `hashAccountNumber` ostaje kao fallback za starije
  backend deploy-e koji ne vracaju `id`.

### Confirm cancel dijalog

- `confirmCancel()` koercise `cancelQuantityInput` u string pre `.trim()`.
  Vrednost vezana preko `[(ngModel)]` na `input type=number` postaje
  JavaScript number cim korisnik unese cifru; `.trim()` na number-u baca
  `TypeError` koji se gubio u Angular zoni.

## Veza ka odbojnostima

| Prijava | Korenski uzrok | Ispravka |
|---------|----------------|----------|
| SELL forma se ne otvara iz Moj Portfolio | `onSell` je bio stub bez parametra | Implementiran handler + listingId u modelu + parametar u HTML-u |
| Naknadne /internal/accounts/id/... operacije vracaju 404 | Hash broja racuna koriscen kao id | Koriscenje `item.id` (PK), hash zadrzan samo kao fallback |
| Confirm cancel ne reaguje sa unetim brojem | type=number koercise u number; `.trim()` baca TypeError | `String(... ?? '').trim()` konverzija |

## Operativna napomena

Vec ulogovani korisnici treba da urade logout + login da bi sesija
propagirala perzistentne PK-ove umesto starih hash vrednosti.