### PR TITLE
Implement OTC in-app notifications

### DIFF
--- a/cypress/e2e/otc-notifications.cy.ts
+++ b/cypress/e2e/otc-notifications.cy.ts
@@ -1,0 +1,274 @@
+/**
+ * Celina 4 / F11: OTC notifikacije — test po test (mock API, bez backend-a).
+ *
+ * Zahtev: `npm start` sa najnovijim kodom (topbar data-testid=notification-bell).
+ */
+
+const MOCK_JWT_BUYER =
+  'eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjk5OTk5OTk5OTksImlkIjo3N30.mock';
+
+const OTC_USER = {
+  email: 'otc.test@banka.com',
+  permissions: ['CLIENT_TRADING'],
+};
+
+const BASE_OFFER = {
+  id: 1,
+  stockTicker: 'AAPL',
+  buyerId: 77,
+  sellerId: 88,
+  amount: 10,
+  pricePerStock: 150,
+  premium: 400,
+  settlementDate: '2027-12-31',
+  modifiedBy: '77',
+  lastModified: '2026-05-01T10:00:00',
+};
+
+function settlementInDays(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return d.toISOString().substring(0, 10);
+}
+
+function stubOtcMonitor(): void {
+  cy.intercept('GET', '**/api/interbank/otc/negotiations', {
+    statusCode: 200,
+    body: [],
+  });
+  cy.intercept('GET', '**/otc/contracts/my**', {
+    statusCode: 200,
+    body: [],
+  }).as('contractsActive');
+  cy.intercept('GET', '**/otc/offers/active', {
+    statusCode: 200,
+    body: [{ ...BASE_OFFER, status: 'PENDING_SELLER' }],
+  }).as('offersActive');
+}
+
+function stubHomePage(): void {
+  cy.intercept('GET', '**/accounts/client/accounts*', {
+    statusCode: 200,
+    body: { content: [], totalElements: 0, totalPages: 0, number: 0, size: 50 },
+  });
+  cy.intercept('GET', '**/exchange/rates*', {
+    statusCode: 200,
+    body: [],
+  });
+}
+
+function stubOtcPortal(): void {
+  cy.intercept('GET', '**/otc/public-stocks', {
+    statusCode: 200,
+    body: [],
+  });
+}
+
+function visitHome(): void {
+  cy.visit('/home', {
+    onBeforeLoad(win) {
+      win.__OTC_POLL_MS = 500;
+      win.localStorage.setItem('authToken', MOCK_JWT_BUYER);
+      win.localStorage.setItem('loggedUser', JSON.stringify(OTC_USER));
+    },
+  });
+}
+
+function visitOtc(): void {
+  cy.visit('/otc', {
+    onBeforeLoad(win) {
+      win.__OTC_POLL_MS = 500;
+      win.localStorage.setItem('authToken', MOCK_JWT_BUYER);
+      win.localStorage.setItem('loggedUser', JSON.stringify(OTC_USER));
+    },
+  });
+}
+
+function waitInitialMonitorPoll(): void {
+  cy.wait(['@offersActive', '@contractsActive']);
+}
+
+function waitSecondOfferPoll(): void {
+  cy.wait('@offersActive', { timeout: 15000 });
+}
+
+describe('OTC notifikacije (F11)', () => {
+  beforeEach(() => {
+    cy.clearLocalStorage();
+    stubOtcMonitor();
+    stubHomePage();
+    stubOtcPortal();
+  });
+
+  it('1 — otvara zvonce i prikazuje prazan inbox', () => {
+    cy.visit('/home', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('authToken', MOCK_JWT_BUYER);
+        win.localStorage.setItem('loggedUser', JSON.stringify(OTC_USER));
+      },
+    });
+
+    cy.wait(['@offersActive', '@contractsActive']);
+
+    cy.get('app-topbar').should('be.visible');
+    cy.get('app-topbar [data-testid=notification-bell]', { timeout: 5000 })
+      .should('exist')
+      .and('be.visible')
+      .click();
+
+    cy.get('[data-testid=notification-bell]').should('have.attr', 'aria-expanded', 'true');
+    cy.get('[data-testid=notification-menu]').should('be.visible');
+    cy.contains('[data-testid=notification-menu]', 'Nema novih obaveštenja.').should(
+      'be.visible',
+    );
+  });
+
+  it('2 — kontraponuda: toast i stavka u zvoncu', () => {
+    let poll = 0;
+    cy.intercept('GET', '**/otc/offers/active', (req) => {
+      poll += 1;
+      const body =
+        poll === 1
+          ? [{ ...BASE_OFFER, status: 'PENDING_SELLER', modifiedBy: '77' }]
+          : [
+              {
+                ...BASE_OFFER,
+                status: 'PENDING_BUYER',
+                pricePerStock: 165,
+                modifiedBy: '88',
+                lastModified: '2026-05-18T12:00:00',
+              },
+            ];
+      req.reply({ statusCode: 200, body });
+    }).as('offersActive');
+
+    visitHome();
+    waitInitialMonitorPoll();
+    waitSecondOfferPoll();
+
+    cy.contains('.toast-content', 'kontraponudu za AAPL', { timeout: 10000 }).should(
+      'be.visible',
+    );
+
+    cy.get('[data-testid=notification-bell]').click();
+    cy.get('[data-testid=notification-item]')
+      .should('contain.text', 'kontraponudu za AAPL')
+      .and('be.visible');
+  });
+
+  it('3 — prihvaćena ponuda: toast i zvonce', () => {
+    let poll = 0;
+    cy.intercept('GET', '**/otc/offers/active', (req) => {
+      poll += 1;
+      const body =
+        poll === 1
+          ? [{ ...BASE_OFFER, status: 'PENDING_BUYER', modifiedBy: '88' }]
+          : [{ ...BASE_OFFER, status: 'ACCEPTED', modifiedBy: '88' }];
+      req.reply({ statusCode: 200, body });
+    }).as('offersActive');
+
+    visitHome();
+    waitInitialMonitorPoll();
+    waitSecondOfferPoll();
+
+    cy.contains('.toast-content', 'Ponuda za AAPL je prihvaćena.', { timeout: 10000 }).should(
+      'be.visible',
+    );
+
+    cy.get('[data-testid=notification-bell]').click();
+    cy.get('[data-testid=notification-item]').should(
+      'contain.text',
+      'Ponuda za AAPL je prihvaćena.',
+    );
+  });
+
+  it('4 — povučena ponuda: toast i zvonce', () => {
+    let poll = 0;
+    cy.intercept('GET', '**/otc/offers/active', (req) => {
+      poll += 1;
+      const body =
+        poll === 1
+          ? [{ ...BASE_OFFER, status: 'PENDING_SELLER', modifiedBy: '77' }]
+          : [];
+      req.reply({ statusCode: 200, body });
+    }).as('offersActive');
+
+    visitHome();
+    waitInitialMonitorPoll();
+    waitSecondOfferPoll();
+
+    cy.contains('.toast-content', 'odustala od ponude za AAPL', { timeout: 10000 }).should(
+      'be.visible',
+    );
+
+    cy.get('[data-testid=notification-bell]').click();
+    cy.get('[data-testid=notification-item]').should(
+      'contain.text',
+      'odustala od ponude za AAPL',
+    );
+  });
+
+  it('5 — banner za ugovor koji uskoro ističe (OTC portal)', () => {
+    const soon = settlementInDays(2);
+    cy.intercept('GET', '**/otc/contracts/my**', {
+      statusCode: 200,
+      body: [
+        {
+          id: 9,
+          offerId: 1,
+          stockTicker: 'AAPL',
+          buyerId: 77,
+          sellerId: 88,
+          amount: 10,
+          pricePerStock: 150,
+          settlementDate: soon,
+          status: 'ACTIVE',
+          createdAt: '2026-01-01T10:00:00',
+        },
+      ],
+    }).as('contractsTab');
+
+    visitOtc();
+    cy.contains('button', 'Izvršeni ugovori').click();
+    cy.wait('@contractsTab');
+
+    cy.get('[data-testid=otc-expiry-warning]').should('be.visible');
+    cy.contains('[data-testid=otc-expiry-warning]', 'AAPL').should('be.visible');
+    cy.contains('[data-testid=otc-expiry-warning]', 'uskoro ističu').should('be.visible');
+  });
+
+  it('6 — istek ugovora u inboxu zvona (bez toasta na prvom poll-u)', () => {
+    const soon = settlementInDays(2);
+    cy.intercept('GET', '**/otc/contracts/my**', {
+      statusCode: 200,
+      body: [
+        {
+          id: 9,
+          offerId: 1,
+          stockTicker: 'AAPL',
+          buyerId: 77,
+          sellerId: 88,
+          amount: 10,
+          pricePerStock: 150,
+          settlementDate: soon,
+          status: 'ACTIVE',
+          createdAt: '2026-01-01T10:00:00',
+        },
+      ],
+    }).as('contractsActive');
+    cy.intercept('GET', '**/otc/offers/active', {
+      statusCode: 200,
+      body: [],
+    }).as('offersActive');
+
+    visitHome();
+    waitInitialMonitorPoll();
+
+    cy.get('.toast-content').should('not.exist');
+
+    cy.get('[data-testid=notification-bell]').click();
+    cy.get('[data-testid=notification-item]')
+      .should('contain.text', 'Opcioni ugovor za AAPL')
+      .and('contain.text', 'ističe');
+  });
+});

--- a/cypress/e2e/otc-notifications.cy.ts
+++ b/cypress/e2e/otc-notifications.cy.ts
@@ -2,7 +2,13 @@
  * Celina 4 / F11: OTC notifikacije — test po test (mock API, bez backend-a).
  *
  * Zahtev: `npm start` sa najnovijim kodom (topbar data-testid=notification-bell).
+ *
+ * Poll interval u E2E: 5000 ms (dev minimum) — ne 500 ms (previše agresivno).
+ * Produkcija uvek koristi 30 s, `__OTC_POLL_MS` se ignoriše u production build-u.
  */
+
+/** Usklađeno sa OTC_NOTIFICATION_POLL_MS_DEV_MIN u monitor servisu. */
+const E2E_OTC_POLL_MS = 5000;
 
 const MOCK_JWT_BUYER =
   'eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjk5OTk5OTk5OTksImlkIjo3N30.mock';
@@ -67,7 +73,7 @@ function stubOtcPortal(): void {
 function visitHome(): void {
   cy.visit('/home', {
     onBeforeLoad(win) {
-      win.__OTC_POLL_MS = 500;
+      win.__OTC_POLL_MS = E2E_OTC_POLL_MS;
       win.localStorage.setItem('authToken', MOCK_JWT_BUYER);
       win.localStorage.setItem('loggedUser', JSON.stringify(OTC_USER));
     },
@@ -77,19 +83,29 @@ function visitHome(): void {
 function visitOtc(): void {
   cy.visit('/otc', {
     onBeforeLoad(win) {
-      win.__OTC_POLL_MS = 500;
+      win.__OTC_POLL_MS = E2E_OTC_POLL_MS;
       win.localStorage.setItem('authToken', MOCK_JWT_BUYER);
       win.localStorage.setItem('loggedUser', JSON.stringify(OTC_USER));
     },
   });
 }
 
+/** Prvi kompletan poll (offers + contracts). */
 function waitInitialMonitorPoll(): void {
-  cy.wait(['@offersActive', '@contractsActive']);
+  cy.wait('@offersActive', { timeout: 20000 });
+  cy.wait('@contractsActive', { timeout: 20000 });
 }
 
+/** Sledeći poll ponuda (2. GET na offers/active). Sa exhaustMap u monitoru može biti posle 5–10s. */
 function waitSecondOfferPoll(): void {
-  cy.wait('@offersActive', { timeout: 15000 });
+  cy.wait('@offersActive', { timeout: 25000 });
+}
+
+/** Tri poziva na interbank 500 (initial + 2× retry u OtcService, ~6s). */
+function waitInterbank500Retries(): void {
+  cy.wait('@negotiations500', { timeout: 20000 });
+  cy.wait('@negotiations500', { timeout: 20000 });
+  cy.wait('@negotiations500', { timeout: 20000 });
 }
 
 describe('OTC notifikacije (F11)', () => {
@@ -270,5 +286,190 @@ describe('OTC notifikacije (F11)', () => {
     cy.get('[data-testid=notification-item]')
       .should('contain.text', 'Opcioni ugovor za AAPL')
       .and('contain.text', 'ističe');
+  });
+
+  describe('greške i otpornost', () => {
+    it('7 — API 500 na OTC poll: aplikacija i zvonce rade (fallback na prazan inbox)', () => {
+      cy.intercept('GET', '**/api/interbank/otc/negotiations', { statusCode: 500, body: {} });
+      cy.intercept('GET', '**/otc/offers/active', { statusCode: 500, body: {} }).as('offers500');
+      cy.intercept('GET', '**/otc/contracts/my**', { statusCode: 500, body: {} }).as('contracts500');
+
+      visitHome();
+      cy.wait(['@offers500', '@contracts500']);
+
+      cy.get('app-topbar', { timeout: 10000 }).should('be.visible');
+      cy.get('[data-testid=notification-bell]').should('be.visible').click();
+      cy.get('[data-testid=notification-menu]').should('be.visible');
+      cy.contains('[data-testid=notification-menu]', 'Nema novih obaveštenja.').should(
+        'be.visible',
+      );
+    });
+
+    it('7b — negotiations 500, lokalne ponude OK: monitor i dalje radi', () => {
+      cy.intercept('GET', '**/api/interbank/otc/negotiations', {
+        statusCode: 500,
+        body: {},
+      }).as('negotiations500');
+
+      let poll = 0;
+      cy.intercept('GET', '**/otc/offers/active', (req) => {
+        poll += 1;
+        const body =
+          poll === 1
+            ? [{ ...BASE_OFFER, status: 'PENDING_SELLER', modifiedBy: '77' }]
+            : [
+                {
+                  ...BASE_OFFER,
+                  status: 'PENDING_BUYER',
+                  pricePerStock: 165,
+                  modifiedBy: '88',
+                },
+              ];
+        req.reply({ statusCode: 200, body });
+      }).as('offersActive');
+
+      visitHome();
+      cy.wait('@offersActive', { timeout: 20000 });
+      waitInterbank500Retries();
+      cy.wait('@contractsActive', { timeout: 20000 });
+
+      waitSecondOfferPoll();
+
+      cy.contains('.toast-content', 'kontraponudu za AAPL', { timeout: 15000 }).should(
+        'be.visible',
+      );
+    });
+
+    it('8 — mrežna greška pa uspešan poll: monitor nastavlja bez pada', () => {
+      let offerCalls = 0;
+      cy.intercept('GET', '**/otc/offers/active', (req) => {
+        offerCalls += 1;
+        if (offerCalls < 3) {
+          req.destroy();
+          return;
+        }
+        req.reply({
+          statusCode: 200,
+          body: [{ ...BASE_OFFER, status: 'PENDING_SELLER', modifiedBy: '77' }],
+        });
+      }).as('offersFlaky');
+
+      visitHome();
+
+      cy.wait('@offersFlaky', { timeout: 15000 });
+      cy.wait('@offersFlaky', { timeout: 15000 });
+      cy.wait('@offersFlaky', { timeout: 15000 });
+
+      cy.get('[data-testid=notification-bell]', { timeout: 10000 }).should('be.visible').click();
+      cy.get('[data-testid=notification-menu]').should('be.visible');
+      cy.contains('[data-testid=notification-menu]', 'Nema novih obaveštenja.').should(
+        'be.visible',
+      );
+    });
+
+    it('9 — 1000 aktivnih ponuda: UI ostaje odzivan (inbox max 50)', () => {
+      const manyOffers = Array.from({ length: 1000 }, (_, i) => ({
+        ...BASE_OFFER,
+        id: i + 1,
+        stockTicker: `T${i}`,
+        buyerId: 77,
+        sellerId: 88,
+        status: 'PENDING_SELLER' as const,
+        modifiedBy: '77',
+      }));
+
+      let poll = 0;
+      cy.intercept('GET', '**/otc/offers/active', (req) => {
+        poll += 1;
+        const body =
+          poll === 1
+            ? manyOffers
+            : manyOffers.map((o, i) =>
+                i === 0
+                  ? {
+                      ...o,
+                      status: 'PENDING_BUYER' as const,
+                      pricePerStock: 160,
+                      modifiedBy: '88',
+                    }
+                  : o,
+              );
+        req.reply({ statusCode: 200, body });
+      }).as('offersActive');
+
+      const started = Date.now();
+      visitHome();
+      waitInitialMonitorPoll();
+      waitSecondOfferPoll();
+
+      cy.get('[data-testid=notification-bell]', { timeout: 10000 }).should('be.visible').click();
+      cy.get('[data-testid=notification-menu]').should('be.visible');
+      cy.get('[data-testid=notification-item]').should('have.length', 1);
+      cy.get('[data-testid=notification-item]').should('contain.text', 'kontraponudu');
+
+      cy.then(() => {
+        expect(Date.now() - started).to.be.lessThan(20000);
+      });
+    });
+  });
+
+  describe('pristupačnost (a11y)', () => {
+    function stubInboxWithContractExpiry(): void {
+      const soon = settlementInDays(2);
+      cy.intercept('GET', '**/otc/contracts/my**', {
+        statusCode: 200,
+        body: [
+          {
+            id: 9,
+            offerId: 1,
+            stockTicker: 'AAPL',
+            buyerId: 77,
+            sellerId: 88,
+            amount: 10,
+            pricePerStock: 150,
+            settlementDate: soon,
+            status: 'ACTIVE',
+            createdAt: '2026-01-01T10:00:00',
+          },
+        ],
+      }).as('contractsActive');
+      cy.intercept('GET', '**/otc/offers/active', { statusCode: 200, body: [] }).as('offersActive');
+    }
+
+    it('10 — tastatura: Enter otvara meni, strelica dole fokusira stavku, Escape zatvara', () => {
+      stubInboxWithContractExpiry();
+      visitHome();
+      waitInitialMonitorPoll();
+
+      cy.get('[data-testid=notification-bell]').focus();
+      cy.focused().should('have.attr', 'data-testid', 'notification-bell');
+      cy.focused().type('{enter}');
+
+      cy.get('[data-testid=notification-menu]').should('be.visible');
+      cy.get('[data-testid=notification-bell]').should('have.attr', 'aria-expanded', 'true');
+
+      cy.get('body').type('{downarrow}');
+      cy.focused().should('have.attr', 'data-testid', 'notification-item');
+
+      cy.get('body').type('{esc}');
+      cy.get('[data-testid=notification-menu]').should('not.exist');
+      cy.get('[data-testid=notification-bell]').should('have.attr', 'aria-expanded', 'false');
+    });
+
+    it('11 — ARIA atributi na zvoncu i meniju', () => {
+      visitHome();
+      waitInitialMonitorPoll();
+
+      cy.get('[data-testid=notification-bell]')
+        .should('have.attr', 'aria-label')
+        .and('match', /Notifikacije/);
+      cy.get('[data-testid=notification-bell]').should('have.attr', 'aria-haspopup', 'menu');
+
+      cy.get('[data-testid=notification-bell]').click();
+      cy.get('[data-testid=notification-menu]')
+        .should('have.attr', 'role', 'menu')
+        .and('have.attr', 'aria-label', 'Notifikaciona lista');
+      cy.get('[data-testid=notification-bell]').should('have.attr', 'aria-expanded', 'true');
+    });
   });
 });

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -127,10 +127,10 @@ const routes: Routes = [
     canActivate: [authGuard],
   },
   {
-  path: 'stock-exchange',
-  component: ExchangeListComponent,
-  canActivate: [authGuard, roleGuard],
-  data: { roles: ['ADMIN', 'SUPERVISOR'] } 
+    path: 'stock-exchange',
+    component: ExchangeListComponent,
+    canActivate: [authGuard, roleGuard],
+    data: { roles: ['ADMIN', 'SUPERVISOR'] },
   },
   {
     path: 'exchange',
@@ -233,7 +233,7 @@ const routes: Routes = [
   {
     path: 'orders/create/:direction/:listingId',
     component: CreateOrderComponent,
-    canActivate: [authGuard]
+    canActivate: [authGuard],
   },
   {
     // PR_03 C3.8: portal za marzne racune (lazy-loaded).
@@ -259,7 +259,7 @@ const routes: Routes = [
   {
     path: '**',
     component: NotFoundComponent,
-  }
+  },
 ];
 
 @NgModule({

--- a/src/app/core/layout/app-shell/app-shell.component.spec.ts
+++ b/src/app/core/layout/app-shell/app-shell.component.spec.ts
@@ -3,16 +3,20 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { Router } from '@angular/router';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { AppShellComponent } from './app-shell.component';
+import { OtcNotificationMonitorService } from '../../../features/otc/services/otc-notification-monitor.service';
 
 describe('AppShellComponent', () => {
   let fixture: ComponentFixture<AppShellComponent>;
   let component: AppShellComponent;
 
   beforeEach(async () => {
+    const otcMonitor = jasmine.createSpyObj('OtcNotificationMonitorService', ['start', 'stop']);
+
     await TestBed.configureTestingModule({
       declarations: [AppShellComponent],
       imports: [RouterTestingModule],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [{ provide: OtcNotificationMonitorService, useValue: otcMonitor }],
     }).compileComponents();
     fixture = TestBed.createComponent(AppShellComponent);
     component = fixture.componentInstance;

--- a/src/app/core/layout/app-shell/app-shell.component.spec.ts
+++ b/src/app/core/layout/app-shell/app-shell.component.spec.ts
@@ -8,9 +8,10 @@ import { OtcNotificationMonitorService } from '../../../features/otc/services/ot
 describe('AppShellComponent', () => {
   let fixture: ComponentFixture<AppShellComponent>;
   let component: AppShellComponent;
+  let otcMonitor: jasmine.SpyObj<OtcNotificationMonitorService>;
 
   beforeEach(async () => {
-    const otcMonitor = jasmine.createSpyObj('OtcNotificationMonitorService', ['start', 'stop']);
+    otcMonitor = jasmine.createSpyObj('OtcNotificationMonitorService', ['start', 'stop']);
 
     await TestBed.configureTestingModule({
       declarations: [AppShellComponent],
@@ -48,5 +49,13 @@ describe('AppShellComponent', () => {
     spyOnProperty(router, 'url', 'get').and.returnValue('/');
     fixture.detectChanges();
     expect(component.isAuthRoute).toBe(true);
+  });
+
+  it('stops OTC monitor on destroy', () => {
+    const router = TestBed.inject(Router);
+    spyOnProperty(router, 'url', 'get').and.returnValue('/home');
+    fixture.detectChanges();
+    fixture.destroy();
+    expect(otcMonitor.stop).toHaveBeenCalled();
   });
 });

--- a/src/app/core/layout/app-shell/app-shell.component.ts
+++ b/src/app/core/layout/app-shell/app-shell.component.ts
@@ -3,6 +3,8 @@ import { NavigationEnd, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 
+import { OtcNotificationMonitorService } from '../../../features/otc/services/otc-notification-monitor.service';
+
 /** Rute koje renderuju samo router-outlet (bez sidebar/topbar shell-a). */
 const AUTH_ROUTE_PATTERN =
   /^\/(login|forgot-password|reset-password|activate|landing)($|[?#/])/;
@@ -23,10 +25,14 @@ export class AppShellComponent implements OnInit, OnDestroy {
   isAuthRoute = false;
   private sub?: Subscription;
 
-  constructor(private router: Router) {}
+  constructor(
+    private router: Router,
+    private otcNotificationMonitor: OtcNotificationMonitorService,
+  ) {}
 
   ngOnInit(): void {
     this.isAuthRoute = this.computeIsAuth(this.router.url);
+    this.syncOtcMonitor();
     this.sub = this.router.events
       .pipe(
         filter((e) => e instanceof NavigationEnd),
@@ -34,11 +40,21 @@ export class AppShellComponent implements OnInit, OnDestroy {
       )
       .subscribe((url) => {
         this.isAuthRoute = this.computeIsAuth(url);
+        this.syncOtcMonitor();
       });
   }
 
   ngOnDestroy(): void {
     this.sub?.unsubscribe();
+    this.otcNotificationMonitor.stop();
+  }
+
+  private syncOtcMonitor(): void {
+    if (this.isAuthRoute) {
+      this.otcNotificationMonitor.stop();
+    } else {
+      this.otcNotificationMonitor.start();
+    }
   }
 
   private computeIsAuth(url: string): boolean {

--- a/src/app/core/layout/topbar/topbar.component.html
+++ b/src/app/core/layout/topbar/topbar.component.html
@@ -47,9 +47,43 @@
       </div>
     </div>
 
-    <button type="button" class="z-btn-icon" aria-label="Notifikacije">
-      <lucide-icon name="bell" [size]="16"></lucide-icon>
-    </button>
+    <div class="relative">
+      <button type="button" class="z-btn-icon relative"
+              data-testid="notification-bell"
+              (click)="toggleNotificationMenu()"
+              aria-label="Notifikacije"
+              [attr.aria-expanded]="notificationMenuOpen">
+        <lucide-icon name="bell" [size]="16"></lucide-icon>
+        <span *ngIf="unreadNotificationCount > 0"
+              class="absolute -top-0.5 -right-0.5 min-w-[16px] h-4 px-1 rounded-full bg-destructive text-destructive-foreground text-[10px] font-bold flex items-center justify-center leading-none"
+              aria-hidden="true">
+          {{ unreadNotificationCount > 9 ? '9+' : unreadNotificationCount }}
+        </span>
+      </button>
+      <div *ngIf="notificationMenuOpen"
+           data-testid="notification-menu"
+           role="menu"
+           class="absolute right-0 top-full mt-1 z-50 w-[min(360px,calc(100vw-2rem))] max-h-[min(420px,70vh)] overflow-y-auto py-1 bg-card border border-border rounded-lg shadow-lg">
+        <div class="px-3 py-2 border-b border-border">
+          <p class="text-sm font-semibold text-foreground">Notifikacije</p>
+          <p class="text-xs text-muted-foreground">OTC pregovori i ugovori</p>
+        </div>
+        <button *ngIf="notifications.length === 0" type="button" disabled
+                class="w-full px-3 py-6 text-sm text-muted-foreground text-center border-0 bg-transparent cursor-default">
+          Nema novih obaveštenja.
+        </button>
+        <button *ngFor="let n of notifications" type="button" role="menuitem"
+                data-testid="notification-item"
+                (click)="openNotification(n)"
+                class="w-full text-left px-3 py-2.5 text-sm border-0 bg-transparent cursor-pointer hover:bg-accent/40 border-b border-border/60 last:border-b-0"
+                [class.font-medium]="!n.read"
+                [class.text-foreground]="!n.read"
+                [class.text-muted-foreground]="n.read">
+          <span class="block leading-snug">{{ n.message }}</span>
+          <span class="block text-[10px] text-muted-foreground mt-1">{{ n.createdAt | date:'dd.MM.yyyy HH:mm' }}</span>
+        </button>
+      </div>
+    </div>
 
     <div class="relative">
       <button type="button" (click)="toggleAvatarMenu()"

--- a/src/app/core/layout/topbar/topbar.component.html
+++ b/src/app/core/layout/topbar/topbar.component.html
@@ -48,37 +48,54 @@
     </div>
 
     <div class="relative">
+      <button *ngIf="notificationMenuOpen"
+              type="button"
+              class="fixed inset-0 z-40 cursor-default border-0 bg-transparent p-0"
+              aria-label="Zatvori notifikacije"
+              tabindex="-1"
+              (click)="toggleNotificationMenu()"></button>
+
       <button type="button" class="z-btn-icon relative"
               data-testid="notification-bell"
               (click)="toggleNotificationMenu()"
-              aria-label="Notifikacije"
-              [attr.aria-expanded]="notificationMenuOpen">
-        <lucide-icon name="bell" [size]="16"></lucide-icon>
+              [attr.aria-label]="notificationBellAriaLabel()"
+              [attr.aria-expanded]="notificationMenuOpen"
+              [attr.aria-controls]="notificationMenuOpen ? 'notification-menu' : null"
+              aria-haspopup="menu">
+        <lucide-icon name="bell" [size]="16" aria-hidden="true"></lucide-icon>
         <span *ngIf="unreadNotificationCount > 0"
-              class="absolute -top-0.5 -right-0.5 min-w-[16px] h-4 px-1 rounded-full bg-destructive text-destructive-foreground text-[10px] font-bold flex items-center justify-center leading-none"
-              aria-hidden="true">
+              role="status"
+              [attr.aria-label]="unreadBadgeAriaLabel()"
+              class="absolute -top-0.5 -right-0.5 min-w-[16px] h-4 px-1 rounded-full bg-destructive text-destructive-foreground text-[10px] font-bold flex items-center justify-center leading-none">
           {{ unreadNotificationCount > 9 ? '9+' : unreadNotificationCount }}
         </span>
       </button>
       <div *ngIf="notificationMenuOpen"
+           id="notification-menu"
            data-testid="notification-menu"
            role="menu"
+           aria-label="Notifikaciona lista"
            class="absolute right-0 top-full mt-1 z-50 w-[min(360px,calc(100vw-2rem))] max-h-[min(420px,70vh)] overflow-y-auto py-1 bg-card border border-border rounded-lg shadow-lg">
         <div class="px-3 py-2 border-b border-border">
           <p class="text-sm font-semibold text-foreground">Notifikacije</p>
           <p class="text-xs text-muted-foreground">OTC pregovori i ugovori</p>
         </div>
         <button *ngIf="notifications.length === 0" type="button" disabled
+                role="menuitem"
+                aria-label="Nema novih obaveštenja"
                 class="w-full px-3 py-6 text-sm text-muted-foreground text-center border-0 bg-transparent cursor-default">
           Nema novih obaveštenja.
         </button>
-        <button *ngFor="let n of notifications" type="button" role="menuitem"
+        <button *ngFor="let n of notifications; trackBy: trackByNotificationId"
+                type="button" role="menuitem"
                 data-testid="notification-item"
-                (click)="openNotification(n)"
                 class="w-full text-left px-3 py-2.5 text-sm border-0 bg-transparent cursor-pointer hover:bg-accent/40 border-b border-border/60 last:border-b-0"
                 [class.font-medium]="!n.read"
                 [class.text-foreground]="!n.read"
-                [class.text-muted-foreground]="n.read">
+                [class.text-muted-foreground]="n.read"
+                [attr.aria-label]="n.message"
+                (click)="openNotification(n)"
+                (keydown)="onNotificationMenuKeydown($event, n)">
           <span class="block leading-snug">{{ n.message }}</span>
           <span class="block text-[10px] text-muted-foreground mt-1">{{ n.createdAt | date:'dd.MM.yyyy HH:mm' }}</span>
         </button>

--- a/src/app/core/layout/topbar/topbar.component.spec.ts
+++ b/src/app/core/layout/topbar/topbar.component.spec.ts
@@ -1,15 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { BehaviorSubject } from 'rxjs';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TopbarComponent } from './topbar.component';
 import { LucideIconComponent } from '../../../shared/icons/lucide-icon.component';
 import { ThemeService } from '../../services/theme.service';
 import { AuthService } from '../../services/auth.service';
+import { AppNotificationService } from '../../../shared/services/app-notification.service';
 
 describe('TopbarComponent', () => {
   let fixture: ComponentFixture<TopbarComponent>;
   let component: TopbarComponent;
   let themeService: jasmine.SpyObj<ThemeService>;
   let authService: jasmine.SpyObj<AuthService>;
+  let appNotifications: jasmine.SpyObj<AppNotificationService>;
 
   beforeEach(async () => {
     themeService = jasmine.createSpyObj('ThemeService', ['setTheme'], {
@@ -20,6 +23,13 @@ describe('TopbarComponent', () => {
       email: 'aleksa.mojovic@banka.com',
       permissions: [],
     });
+    appNotifications = jasmine.createSpyObj('AppNotificationService', [
+      'markAllRead',
+      'markRead',
+    ], {
+      snapshot: [],
+      notifications$: new BehaviorSubject([]),
+    });
 
     await TestBed.configureTestingModule({
       declarations: [TopbarComponent],
@@ -27,6 +37,7 @@ describe('TopbarComponent', () => {
       providers: [
         { provide: ThemeService, useValue: themeService },
         { provide: AuthService, useValue: authService },
+        { provide: AppNotificationService, useValue: appNotifications },
       ],
     }).compileComponents();
 

--- a/src/app/core/layout/topbar/topbar.component.spec.ts
+++ b/src/app/core/layout/topbar/topbar.component.spec.ts
@@ -1,11 +1,26 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BehaviorSubject } from 'rxjs';
+import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TopbarComponent } from './topbar.component';
 import { LucideIconComponent } from '../../../shared/icons/lucide-icon.component';
 import { ThemeService } from '../../services/theme.service';
 import { AuthService } from '../../services/auth.service';
+import { AppNotification } from '../../../shared/models/app-notification.model';
 import { AppNotificationService } from '../../../shared/services/app-notification.service';
+import { OtcService } from '../../../features/otc/services/otc.service';
+
+function notification(id: string, read = false): AppNotification {
+  return {
+    id,
+    category: 'OTC',
+    kind: 'OTC_COUNTER_OFFER',
+    message: `Poruka ${id}`,
+    createdAt: new Date().toISOString(),
+    read,
+    dedupeKey: id,
+  };
+}
 
 describe('TopbarComponent', () => {
   let fixture: ComponentFixture<TopbarComponent>;
@@ -13,8 +28,11 @@ describe('TopbarComponent', () => {
   let themeService: jasmine.SpyObj<ThemeService>;
   let authService: jasmine.SpyObj<AuthService>;
   let appNotifications: jasmine.SpyObj<AppNotificationService>;
+  let otcService: jasmine.SpyObj<OtcService>;
+  let notificationsSubject: BehaviorSubject<AppNotification[]>;
 
   beforeEach(async () => {
+    notificationsSubject = new BehaviorSubject<AppNotification[]>([]);
     themeService = jasmine.createSpyObj('ThemeService', ['setTheme'], {
       current: 'system' as const,
     });
@@ -26,10 +44,13 @@ describe('TopbarComponent', () => {
     appNotifications = jasmine.createSpyObj('AppNotificationService', [
       'markAllRead',
       'markRead',
+      'hydrateFromStorage',
+      'clear',
     ], {
       snapshot: [],
-      notifications$: new BehaviorSubject([]),
+      notifications$: notificationsSubject.asObservable(),
     });
+    otcService = jasmine.createSpyObj('OtcService', ['clearPollCache']);
 
     await TestBed.configureTestingModule({
       declarations: [TopbarComponent],
@@ -38,6 +59,7 @@ describe('TopbarComponent', () => {
         { provide: ThemeService, useValue: themeService },
         { provide: AuthService, useValue: authService },
         { provide: AppNotificationService, useValue: appNotifications },
+        { provide: OtcService, useValue: otcService },
       ],
     }).compileComponents();
 
@@ -141,18 +163,112 @@ describe('TopbarComponent', () => {
     expect(component.themeMenuOpen).toBe(false);
   });
 
-  it('closeMenus closes both menus', () => {
+  it('closeMenus closes all dropdown menus', () => {
     component.themeMenuOpen = true;
     component.avatarMenuOpen = true;
+    component.notificationMenuOpen = true;
     component.closeMenus();
     expect(component.themeMenuOpen).toBe(false);
     expect(component.avatarMenuOpen).toBe(false);
+    expect(component.notificationMenuOpen).toBe(false);
   });
 
-  it('logout calls AuthService.logout (which itself redirects to /login)', () => {
+  it('logout clears notifications and calls AuthService.logout', () => {
     fixture.detectChanges();
     component.logout();
+    expect(appNotifications.clear).toHaveBeenCalled();
+    expect(otcService.clearPollCache).toHaveBeenCalled();
     expect(authService.logout).toHaveBeenCalled();
+  });
+
+  describe('notifications', () => {
+    beforeEach(() => {
+      fixture.detectChanges();
+    });
+
+    it('toggleNotificationMenu() otvara i zatvara meni', () => {
+      expect(component.notificationMenuOpen).toBe(false);
+
+      component.toggleNotificationMenu();
+      expect(component.notificationMenuOpen).toBe(true);
+
+      component.toggleNotificationMenu();
+      expect(component.notificationMenuOpen).toBe(false);
+    });
+
+    it('toggleNotificationMenu() zatvara theme i avatar meni', () => {
+      component.themeMenuOpen = true;
+      component.avatarMenuOpen = true;
+
+      component.toggleNotificationMenu();
+
+      expect(component.notificationMenuOpen).toBe(true);
+      expect(component.themeMenuOpen).toBe(false);
+      expect(component.avatarMenuOpen).toBe(false);
+    });
+
+    it('unreadNotificationCount broji samo nepročitane', () => {
+      notificationsSubject.next([
+        notification('a'),
+        notification('b'),
+        notification('c', true),
+      ]);
+
+      expect(component.unreadNotificationCount).toBe(2);
+    });
+
+    it('notificationBellAriaLabel uključuje broj nepročitanih', () => {
+      notificationsSubject.next([notification('a'), notification('b')]);
+
+      expect(component.notificationBellAriaLabel()).toContain('2 nova obaveštenja');
+    });
+
+    it('openNotification() zatvara meni i poziva markRead', () => {
+      const n = notification('x', false);
+      component.notificationMenuOpen = true;
+
+      component.openNotification(n);
+
+      expect(component.notificationMenuOpen).toBe(false);
+      expect(appNotifications.markRead).toHaveBeenCalledWith('x');
+    });
+
+    it('openNotification() navigira kada postoji route', () => {
+      const router = TestBed.inject(Router);
+      spyOn(router, 'navigateByUrl');
+      const n = { ...notification('y'), route: '/otc' };
+
+      component.openNotification(n);
+
+      expect(router.navigateByUrl).toHaveBeenCalledWith('/otc');
+    });
+
+    it('Escape zatvara notification meni', () => {
+      component.notificationMenuOpen = true;
+      component.onKeydown(new KeyboardEvent('keydown', { key: 'Escape' }));
+      expect(component.notificationMenuOpen).toBe(false);
+    });
+
+    it('ArrowDown fokusira prvu stavku u notification meniju', () => {
+      notificationsSubject.next([notification('a'), notification('b')]);
+      component.notificationMenuOpen = true;
+      fixture.detectChanges();
+
+      const focusSpy = spyOn<any>(component, 'focusNotificationMenuItem').and.callThrough();
+      component.onKeydown(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+
+      expect(focusSpy).toHaveBeenCalledWith(0);
+    });
+
+    it('prestaje da prima notifications$ posle ngOnDestroy', () => {
+      notificationsSubject.next([notification('1')]);
+      expect(component.notifications.length).toBe(1);
+
+      fixture.destroy();
+
+      notificationsSubject.next([notification('1'), notification('2')]);
+      expect(component.notifications.length).toBe(1);
+    });
   });
 
   it('breadcrumb is empty array for root URL', () => {

--- a/src/app/core/layout/topbar/topbar.component.ts
+++ b/src/app/core/layout/topbar/topbar.component.ts
@@ -5,6 +5,8 @@ import { filter } from 'rxjs/operators';
 
 import { AuthService } from '../../services/auth.service';
 import { Theme, ThemeService } from '../../services/theme.service';
+import { AppNotification } from '../../../shared/models/app-notification.model';
+import { AppNotificationService } from '../../../shared/services/app-notification.service';
 
 type ThemeIcon = 'sun' | 'moon' | 'monitor';
 
@@ -48,8 +50,11 @@ export class TopbarComponent implements OnInit, OnDestroy {
   breadcrumb: string[] = [];
   themeMenuOpen = false;
   avatarMenuOpen = false;
+  notificationMenuOpen = false;
+  notifications: AppNotification[] = [];
   userInitials = '';
   private sub?: Subscription;
+  private notificationSub?: Subscription;
 
   readonly themes: Theme[] = ['system', 'light', 'dark'];
 
@@ -57,6 +62,7 @@ export class TopbarComponent implements OnInit, OnDestroy {
     public theme: ThemeService,
     private auth: AuthService,
     private router: Router,
+    private appNotifications: AppNotificationService,
   ) {}
 
   ngOnInit(): void {
@@ -67,10 +73,34 @@ export class TopbarComponent implements OnInit, OnDestroy {
       .subscribe((e) => {
         this.refreshBreadcrumb((e as NavigationEnd).urlAfterRedirects);
       });
+
+    this.notifications = this.appNotifications.snapshot;
+    this.notificationSub = this.appNotifications.notifications$.subscribe((items) => {
+      this.notifications = items;
+    });
   }
 
   ngOnDestroy(): void {
     this.sub?.unsubscribe();
+    this.notificationSub?.unsubscribe();
+  }
+
+  get unreadNotificationCount(): number {
+    return this.notifications.filter((n) => !n.read).length;
+  }
+
+  toggleNotificationMenu(): void {
+    const next = !this.notificationMenuOpen;
+    this.closeMenus();
+    this.notificationMenuOpen = next;
+  }
+
+  openNotification(n: AppNotification): void {
+    this.notificationMenuOpen = false;
+    this.appNotifications.markRead(n.id);
+    if (n.route) {
+      this.router.navigateByUrl(n.route);
+    }
   }
 
   setTheme(t: Theme): void {
@@ -97,6 +127,7 @@ export class TopbarComponent implements OnInit, OnDestroy {
   closeMenus(): void {
     this.themeMenuOpen = false;
     this.avatarMenuOpen = false;
+    this.notificationMenuOpen = false;
   }
 
   logout(): void {

--- a/src/app/core/layout/topbar/topbar.component.ts
+++ b/src/app/core/layout/topbar/topbar.component.ts
@@ -1,12 +1,13 @@
 import { Component, HostListener, OnDestroy, OnInit } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
-import { Subscription } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { Subject } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 import { AuthService } from '../../services/auth.service';
 import { Theme, ThemeService } from '../../services/theme.service';
 import { AppNotification } from '../../../shared/models/app-notification.model';
 import { AppNotificationService } from '../../../shared/services/app-notification.service';
+import { OtcService } from '../../../features/otc/services/otc.service';
 
 type ThemeIcon = 'sun' | 'moon' | 'monitor';
 
@@ -30,8 +31,8 @@ const COMMAND_PALETTE_EVENT = 'banka:open-command-palette';
  * Sticky horizontalna traka iznad glavnog sadrzaja. Sadrzi:
  *   - levo: route breadcrumb derived iz `Router.url`.
  *   - desno: `Pretrazi` trigger (otvara command palette kroz globalni event),
- *     theme toggle dropdown (3 opcije: Sistem / Svetla / Tamna), bell icon
- *     placeholder, avatar krug sa user inicijalima + dropdown (Profil / Odjava).
+ *     theme toggle dropdown (3 opcije: Sistem / Svetla / Tamna), notifikacije (zvonce),
+ *     avatar krug sa user inicijalima + dropdown (Profil / Odjava).
  *
  * Ctrl+K / Cmd+K hotkey otvara command palette preko `window.dispatchEvent`
  * (`banka:open-command-palette`) — Task 8 ce dodati listener u
@@ -53,8 +54,8 @@ export class TopbarComponent implements OnInit, OnDestroy {
   notificationMenuOpen = false;
   notifications: AppNotification[] = [];
   userInitials = '';
-  private sub?: Subscription;
-  private notificationSub?: Subscription;
+  private notificationMenuFocusIndex = -1;
+  private readonly destroy$ = new Subject<void>();
 
   readonly themes: Theme[] = ['system', 'light', 'dark'];
 
@@ -63,36 +64,67 @@ export class TopbarComponent implements OnInit, OnDestroy {
     private auth: AuthService,
     private router: Router,
     private appNotifications: AppNotificationService,
+    private otcService: OtcService,
   ) {}
 
   ngOnInit(): void {
     this.refreshBreadcrumb(this.router.url);
     this.userInitials = this.computeInitials();
-    this.sub = this.router.events
-      .pipe(filter((e) => e instanceof NavigationEnd))
+    this.router.events
+      .pipe(
+        filter((e) => e instanceof NavigationEnd),
+        takeUntil(this.destroy$),
+      )
       .subscribe((e) => {
         this.refreshBreadcrumb((e as NavigationEnd).urlAfterRedirects);
       });
 
+    this.appNotifications.hydrateFromStorage();
     this.notifications = this.appNotifications.snapshot;
-    this.notificationSub = this.appNotifications.notifications$.subscribe((items) => {
-      this.notifications = items;
-    });
+    this.appNotifications.notifications$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((items) => {
+        this.notifications = items;
+      });
   }
 
   ngOnDestroy(): void {
-    this.sub?.unsubscribe();
-    this.notificationSub?.unsubscribe();
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
   get unreadNotificationCount(): number {
     return this.notifications.filter((n) => !n.read).length;
   }
 
+  notificationBellAriaLabel(): string {
+    const count = this.unreadNotificationCount;
+    if (count === 0) return 'Notifikacije';
+    if (count === 1) return 'Notifikacije, 1 novo obaveštenje';
+    return `Notifikacije, ${count} nova obaveštenja`;
+  }
+
+  unreadBadgeAriaLabel(): string {
+    const count = this.unreadNotificationCount;
+    return count === 1 ? '1 novo obaveštenje' : `${count} novih obaveštenja`;
+  }
+
+  trackByNotificationId(_index: number, n: AppNotification): string {
+    return n.id;
+  }
+
+  onNotificationMenuKeydown(event: KeyboardEvent, n: AppNotification): void {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.openNotification(n);
+    }
+  }
+
   toggleNotificationMenu(): void {
     const next = !this.notificationMenuOpen;
     this.closeMenus();
     this.notificationMenuOpen = next;
+    this.notificationMenuFocusIndex = -1;
   }
 
   openNotification(n: AppNotification): void {
@@ -128,9 +160,12 @@ export class TopbarComponent implements OnInit, OnDestroy {
     this.themeMenuOpen = false;
     this.avatarMenuOpen = false;
     this.notificationMenuOpen = false;
+    this.notificationMenuFocusIndex = -1;
   }
 
   logout(): void {
+    this.appNotifications.clear();
+    this.otcService.clearPollCache();
     /* `AuthService.logout()` vec navigira na /login (auth.service.ts:188), tako
        da ne treba dodatni `router.navigate`. */
     this.auth.logout();
@@ -146,10 +181,39 @@ export class TopbarComponent implements OnInit, OnDestroy {
 
   @HostListener('document:keydown', ['$event'])
   onKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Escape') {
+      if (this.notificationMenuOpen || this.themeMenuOpen || this.avatarMenuOpen) {
+        this.closeMenus();
+        return;
+      }
+    }
+
+    if (this.notificationMenuOpen && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
+      e.preventDefault();
+      this.notificationMenuFocusIndex += e.key === 'ArrowDown' ? 1 : -1;
+      this.focusNotificationMenuItem(this.notificationMenuFocusIndex);
+      return;
+    }
+
     if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
       e.preventDefault();
       this.openCommandPalette();
     }
+  }
+
+  private focusNotificationMenuItem(index: number): void {
+    const menu = document.getElementById('notification-menu');
+    if (!menu) return;
+
+    const items = Array.from(
+      menu.querySelectorAll<HTMLElement>('[role="menuitem"]:not([disabled])'),
+    );
+    if (items.length === 0) return;
+
+    const normalized =
+      ((index % items.length) + items.length) % items.length;
+    items[normalized].focus();
+    this.notificationMenuFocusIndex = normalized;
   }
 
   private refreshBreadcrumb(url: string): void {

--- a/src/app/features/otc/components/otc-contracts/otc-contracts.component.html
+++ b/src/app/features/otc/components/otc-contracts/otc-contracts.component.html
@@ -12,6 +12,19 @@
       </a>
     </div>
 
+    <div *ngIf="expiringSoonContracts.length > 0"
+         class="z-alert z-alert-warning mb-6"
+         data-testid="otc-expiry-warning"
+         role="status">
+      <p class="font-semibold text-sm">Ugovori koji uskoro ističu</p>
+      <ul class="mt-2 text-sm space-y-1 list-disc list-inside">
+        <li *ngFor="let c of expiringSoonContracts">
+          {{ c.stockTicker }} — za {{ daysUntilExpiry(c) }} {{ daysUntilExpiry(c) === 1 ? 'dan' : 'dana' }}
+          (settlement {{ c.settlementDate | slice:0:10 }})
+        </li>
+      </ul>
+    </div>
+
     <div class="z-card p-4 mb-6">
       <div class="flex items-center gap-4 flex-wrap">
         <label class="z-label mb-0 whitespace-nowrap">Filter po statusu</label>

--- a/src/app/features/otc/components/otc-contracts/otc-contracts.component.html
+++ b/src/app/features/otc/components/otc-contracts/otc-contracts.component.html
@@ -12,18 +12,35 @@
       </a>
     </div>
 
-    <div *ngIf="expiringSoonContracts.length > 0"
-         class="z-alert z-alert-warning mb-6"
-         data-testid="otc-expiry-warning"
-         role="status">
-      <p class="font-semibold text-sm">Ugovori koji uskoro ističu</p>
-      <ul class="mt-2 text-sm space-y-1 list-disc list-inside">
-        <li *ngFor="let c of expiringSoonContracts">
-          {{ c.stockTicker }} — za {{ daysUntilExpiry(c) }} {{ daysUntilExpiry(c) === 1 ? 'dan' : 'dana' }}
-          (settlement {{ c.settlementDate | slice:0:10 }})
-        </li>
-      </ul>
-    </div>
+    <ng-container *ngIf="expiringSoonContracts$ | async as expiringSoon">
+      <div *ngIf="expiringSoon.length > 0 && !expiryAlertDismissed"
+           class="z-alert z-alert-warning mb-6 relative pr-10"
+           data-testid="otc-expiry-warning"
+           role="alert"
+           aria-live="assertive"
+           aria-atomic="true"
+           aria-labelledby="otc-expiry-alert-title">
+        <button type="button"
+                class="absolute top-2 right-2 z-btn-icon text-muted-foreground hover:text-foreground"
+                aria-label="Zatvori upozorenje"
+                (click)="dismissExpiryAlert()">
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <p id="otc-expiry-alert-title" class="font-semibold text-sm">Ugovori koji uskoro ističu</p>
+        <ul class="mt-2 text-sm space-y-1 list-disc list-inside"
+            role="list"
+            aria-label="Lista ugovora koji uskoro ističu">
+          <li *ngFor="let c of expiringSoon; trackBy: trackByContractId" role="listitem">
+            <span>{{ c.stockTicker }}</span>
+            — ističe za
+            <span [attr.aria-label]="expiryDaysAriaLabel(c)">
+              <span aria-hidden="true">{{ daysUntilExpiry(c) }} {{ daysUntilExpiry(c) === 1 ? 'dan' : 'dana' }}</span>
+            </span>
+            (settlement {{ c.settlementDate | slice:0:10 }})
+          </li>
+        </ul>
+      </div>
+    </ng-container>
 
     <div class="z-card p-4 mb-6">
       <div class="flex items-center gap-4 flex-wrap">
@@ -48,8 +65,8 @@
           <option value="banka2">Banka 2</option>
         </select>
 
-        <span class="text-xs text-muted-foreground">
-          Prikazano {{ visibleContracts.length }} od {{ contracts.length }}
+        <span class="text-xs text-muted-foreground" *ngIf="visibleContracts$ | async as visible">
+          Prikazano {{ visible.length }} od {{ contracts.length }}
         </span>
       </div>
     </div>
@@ -59,6 +76,7 @@
     <app-state *ngIf="error && !loading" mode="error" [text]="error"></app-state>
 
     <ng-container *ngIf="!loading && !error">
+      <ng-container *ngIf="visibleContracts$ | async as visibleContracts">
       <app-state *ngIf="visibleContracts.length === 0"
                  mode="empty" title="Nema ugovora za izabrani filter"
                  text="Promeniti filter ili poslati novu ponudu da bi se kreirao prvi ugovor."></app-state>
@@ -136,6 +154,7 @@
           </table>
         </div>
       </div>
+      </ng-container>
     </ng-container>
   </div>
 </div>

--- a/src/app/features/otc/components/otc-contracts/otc-contracts.component.ts
+++ b/src/app/features/otc/components/otc-contracts/otc-contracts.component.ts
@@ -6,6 +6,10 @@ import { OtcService } from '../../services/otc.service';
 import { StockPriceService } from '../../services/stock-price.service';
 import { OptionContract, OptionContractStatus } from '../../models/otc.model';
 import { AuthService } from '../../../../core/services/auth.service';
+import {
+  daysUntilSettlement,
+  OTC_EXPIRY_WARNING_DAYS,
+} from '../../services/otc-notification-diff';
 
 interface OptionContractView {
   id: number;
@@ -113,6 +117,19 @@ export class OtcContractsComponent implements OnInit, OnDestroy {
     if (this.bankFilter === 'all') return this.contracts;
     if (this.bankFilter === 'banka2') return this.contracts.filter(c => !!c.interbank);
     return this.contracts.filter(c => !c.interbank);
+  }
+
+  /** Celina 4: ugovori koji ističu za N dana ili manje (aktivni, settlement u budućnosti). */
+  get expiringSoonContracts(): OptionContractView[] {
+    return this.visibleContracts.filter((c) => {
+      if (c.status !== 'ACTIVE') return false;
+      const days = daysUntilSettlement(c.settlementDate);
+      return days != null && days > 0 && days <= OTC_EXPIRY_WARNING_DAYS;
+    });
+  }
+
+  daysUntilExpiry(c: OptionContractView): number | null {
+    return daysUntilSettlement(c.settlementDate);
   }
 
   setBankFilter(mode: OtcContractFilterMode): void {

--- a/src/app/features/otc/components/otc-contracts/otc-contracts.component.ts
+++ b/src/app/features/otc/components/otc-contracts/otc-contracts.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
-import { Subscription } from 'rxjs';
+import { BehaviorSubject, combineLatest, Subscription } from 'rxjs';
+import { map, shareReplay } from 'rxjs/operators';
 
 import { OtcService } from '../../services/otc.service';
 import { StockPriceService } from '../../services/stock-price.service';
@@ -73,6 +74,29 @@ export class OtcContractsComponent implements OnInit, OnDestroy {
   /** PR_33 Phase B: filter banaka (intra/inter-bank). */
   bankFilter: OtcContractFilterMode = 'all';
 
+  /** Korisnik je zatvorio banner za ugovore koji ističu (reset na sledeći load). */
+  expiryAlertDismissed = false;
+
+  private readonly contractsSource = new BehaviorSubject<OptionContractView[]>([]);
+  private readonly bankFilterSource = new BehaviorSubject<OtcContractFilterMode>('all');
+
+  /** Memoizovano — ne računa se na svaki change detection ciklus. */
+  readonly expiringSoonContracts$ = combineLatest([
+    this.contractsSource,
+    this.bankFilterSource,
+  ]).pipe(
+    map(([contracts, mode]) => this.buildExpiringSoon(contracts, mode)),
+    shareReplay(1),
+  );
+
+  readonly visibleContracts$ = combineLatest([
+    this.contractsSource,
+    this.bankFilterSource,
+  ]).pipe(
+    map(([contracts, mode]) => this.filterVisible(contracts, mode)),
+    shareReplay(1),
+  );
+
   private priceSub?: Subscription;
 
   constructor(
@@ -91,6 +115,7 @@ export class OtcContractsComponent implements OnInit, OnDestroy {
   }
 
   load(): void {
+    this.expiryAlertDismissed = false;
     this.loading = true;
     this.error = null;
     const filter = this.statusFilter.value;
@@ -98,42 +123,40 @@ export class OtcContractsComponent implements OnInit, OnDestroy {
     this.otcService.myContracts(status).subscribe({
       next: items => {
         this.contracts = items.map(c => this.toView(c));
+        this.emitContracts();
         this.loading = false;
         this.subscribeLivePrices();
       },
       error: err => {
         this.error = err?.error?.message || 'Greska pri ucitavanju ugovora.';
         this.contracts = [];
+        this.emitContracts();
         this.loading = false;
       }
     });
   }
 
-  /**
-   * PR_33 Phase B: vraca contracts filtrirane po `bankFilter`-u.
-   * 'all' → svi; 'local' → samo intra-bank; 'banka2' → samo cross-bank.
-   */
-  get visibleContracts(): OptionContractView[] {
-    if (this.bankFilter === 'all') return this.contracts;
-    if (this.bankFilter === 'banka2') return this.contracts.filter(c => !!c.interbank);
-    return this.contracts.filter(c => !c.interbank);
-  }
-
-  /** Celina 4: ugovori koji ističu za N dana ili manje (aktivni, settlement u budućnosti). */
-  get expiringSoonContracts(): OptionContractView[] {
-    return this.visibleContracts.filter((c) => {
-      if (c.status !== 'ACTIVE') return false;
-      const days = daysUntilSettlement(c.settlementDate);
-      return days != null && days > 0 && days <= OTC_EXPIRY_WARNING_DAYS;
-    });
-  }
-
   daysUntilExpiry(c: OptionContractView): number | null {
-    return daysUntilSettlement(c.settlementDate);
+    return daysUntilSettlement(c?.settlementDate);
+  }
+
+  expiryDaysAriaLabel(c: OptionContractView): string {
+    const days = this.daysUntilExpiry(c);
+    if (days == null) return 'Nepoznat broj dana do isteka';
+    return days === 1 ? '1 dan do isteka' : `${days} dana do isteka`;
+  }
+
+  trackByContractId(_index: number, c: OptionContractView): number {
+    return c.id;
+  }
+
+  dismissExpiryAlert(): void {
+    this.expiryAlertDismissed = true;
   }
 
   setBankFilter(mode: OtcContractFilterMode): void {
     this.bankFilter = mode;
+    this.bankFilterSource.next(mode);
   }
 
   exercise(c: OptionContractView): void {
@@ -176,7 +199,39 @@ export class OtcContractsComponent implements OnInit, OnDestroy {
         const sign = c.counterpartyRole === 'SELLER' ? 1 : -1;
         return { ...c, liveProfit: sign * profitPerShare * c.amount };
       });
+      this.emitContracts();
     });
+  }
+
+  private emitContracts(): void {
+    this.contractsSource.next(this.contracts);
+  }
+
+  private filterVisible(
+    contracts: OptionContractView[],
+    mode: OtcContractFilterMode,
+  ): OptionContractView[] {
+    if (mode === 'all') return contracts;
+    if (mode === 'banka2') return contracts.filter((c) => !!c.interbank);
+    return contracts.filter((c) => !c.interbank);
+  }
+
+  /** Celina 4: aktivni ugovori koji ističu za ≤ OTC_EXPIRY_WARNING_DAYS. */
+  private buildExpiringSoon(
+    contracts: OptionContractView[],
+    mode: OtcContractFilterMode,
+  ): OptionContractView[] {
+    return this.filterVisible(contracts, mode)
+      .filter((c) => {
+        if (c.status !== 'ACTIVE') return false;
+        const days = daysUntilSettlement(c.settlementDate);
+        return days != null && days > 0 && days <= OTC_EXPIRY_WARNING_DAYS;
+      })
+      .sort(
+        (a, b) =>
+          (daysUntilSettlement(a.settlementDate) ?? 99) -
+          (daysUntilSettlement(b.settlementDate) ?? 99),
+      );
   }
 
   private toView(c: OptionContract): OptionContractView {

--- a/src/app/features/otc/services/otc-etag-cache.spec.ts
+++ b/src/app/features/otc/services/otc-etag-cache.spec.ts
@@ -1,0 +1,43 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { OtcEtagCache } from './otc-etag-cache';
+
+describe('OtcEtagCache', () => {
+  let http: HttpClient;
+  let httpMock: HttpTestingController;
+  let cache: OtcEtagCache;
+
+  const url = 'http://localhost/otc/offers/active';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [HttpClientTestingModule] });
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+    cache = new OtcEtagCache(http);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('stores ETag from 200 response', () => {
+    const body = [{ id: 1 }];
+    cache.getJson<typeof body>(url).subscribe((res) => expect(res).toEqual(body));
+
+    const req = httpMock.expectOne(url);
+    expect(req.request.headers.has('If-None-Match')).toBe(false);
+    req.flush(body, { headers: new HttpHeaders({ ETag: '"v1"' }) });
+  });
+
+  it('sends If-None-Match and returns cached body on 304', () => {
+    const body = [{ id: 1 }];
+
+    cache.getJson(url).subscribe();
+    httpMock.expectOne(url).flush(body, { headers: new HttpHeaders({ ETag: '"v1"' }) });
+
+    cache.getJson<typeof body>(url).subscribe((res) => expect(res).toEqual(body));
+    const req2 = httpMock.expectOne(url);
+    expect(req2.request.headers.get('If-None-Match')).toBe('"v1"');
+    req2.flush(null, { status: 304, statusText: 'Not Modified' });
+  });
+});

--- a/src/app/features/otc/services/otc-etag-cache.ts
+++ b/src/app/features/otc/services/otc-etag-cache.ts
@@ -1,0 +1,70 @@
+import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
+import { Observable, of, throwError } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+
+/**
+ * Jednostavan ETag keš za GET JSON endpoint-e (F11 poll / OTC lista).
+ * Ako server vrati 304 Not Modified, vraća poslednji uspešan odgovor.
+ */
+export class OtcEtagCache {
+  private readonly etags = new Map<string, string>();
+  private readonly bodies = new Map<string, unknown>();
+
+  constructor(private readonly http: HttpClient) {}
+
+  getJson<T>(url: string): Observable<T> {
+    let headers = new HttpHeaders();
+    const etag = this.etags.get(url);
+    if (etag) {
+      headers = headers.set('If-None-Match', etag);
+    }
+
+    return this.http.get<T>(url, { observe: 'response', headers }).pipe(
+      map((res) => {
+        this.store(url, res.headers.get('ETag') ?? res.headers.get('etag'), res.body);
+        return res.body as T;
+      }),
+      catchError((err: HttpErrorResponse) => {
+        if (err.status === 304) {
+          const cached = this.bodies.get(url);
+          if (cached !== undefined) {
+            return of(cached as T);
+          }
+        }
+        return throwError(() => err);
+      }),
+    );
+  }
+
+  invalidateUrl(url: string): void {
+    this.etags.delete(url);
+    this.bodies.delete(url);
+  }
+
+  /** Npr. posle accept/counter — sledeći poll mora dohvatiti sveže podatke. */
+  invalidateByPrefix(urlPrefix: string): void {
+    for (const key of [...this.etags.keys()]) {
+      if (key.startsWith(urlPrefix) || key.includes(urlPrefix)) {
+        this.invalidateUrl(key);
+      }
+    }
+  }
+
+  clear(): void {
+    this.etags.clear();
+    this.bodies.clear();
+  }
+
+  hasCached(url: string): boolean {
+    return this.bodies.has(url);
+  }
+
+  private store(url: string, etag: string | null, body: unknown): void {
+    if (etag) {
+      this.etags.set(url, etag);
+    }
+    if (body !== undefined && body !== null) {
+      this.bodies.set(url, body);
+    }
+  }
+}

--- a/src/app/features/otc/services/otc-notification-diff.spec.ts
+++ b/src/app/features/otc/services/otc-notification-diff.spec.ts
@@ -1,0 +1,91 @@
+import { OtcOffer } from '../models/otc.model';
+import {
+  detectContractExpiryNotifications,
+  detectOfferNotifications,
+  daysUntilSettlement,
+  toOfferSnapshot,
+} from './otc-notification-diff';
+
+function offer(partial: Partial<OtcOffer> & Pick<OtcOffer, 'id' | 'stockTicker' | 'buyerId' | 'sellerId'>): OtcOffer {
+  return {
+    amount: 10,
+    pricePerStock: 100,
+    premium: 50,
+    settlementDate: '2027-06-01',
+    status: 'PENDING_BUYER',
+    modifiedBy: '2',
+    lastModified: '',
+    ...partial,
+  };
+}
+
+describe('otc-notification-diff', () => {
+  it('detects counter-offer when terms change and it is user turn', () => {
+    const before = toOfferSnapshot(
+      offer({ id: 1, stockTicker: 'AAPL', buyerId: 1, sellerId: 2, pricePerStock: 100 }),
+    );
+    const prev = new Map([[before.key, before]]);
+    const current = [
+      offer({
+        id: 1,
+        stockTicker: 'AAPL',
+        buyerId: 1,
+        sellerId: 2,
+        status: 'PENDING_BUYER',
+        pricePerStock: 110,
+      }),
+    ];
+
+    const events = detectOfferNotifications(prev, current, 1, false);
+    expect(events.some((e) => e.kind === 'OTC_COUNTER_OFFER')).toBe(true);
+  });
+
+  it('does not emit on initial poll', () => {
+    const current = [offer({ id: 1, stockTicker: 'AAPL', buyerId: 1, sellerId: 2 })];
+    const events = detectOfferNotifications(new Map(), current, 1, true);
+    expect(events.length).toBe(0);
+  });
+
+  it('detects withdrawn offer removed from active list', () => {
+    const before = toOfferSnapshot(
+      offer({ id: 5, stockTicker: 'MSFT', buyerId: 1, sellerId: 3, status: 'PENDING_SELLER' }),
+    );
+    const prev = new Map([[before.key, before]]);
+    const events = detectOfferNotifications(prev, [], 1, false);
+    expect(events.some((e) => e.kind === 'OTC_OFFER_WITHDRAWN')).toBe(true);
+  });
+
+  it('detects contract expiring within warning window', () => {
+    const soon = new Date();
+    soon.setDate(soon.getDate() + 2);
+    const iso = soon.toISOString().substring(0, 10);
+
+    const events = detectContractExpiryNotifications(
+      [
+        {
+          id: 9,
+          offerId: 1,
+          stockTicker: 'AAPL',
+          buyerId: 1,
+          sellerId: 2,
+          amount: 10,
+          pricePerStock: 100,
+          settlementDate: iso,
+          status: 'ACTIVE',
+          createdAt: '',
+        },
+      ],
+      1,
+    );
+
+    expect(events.length).toBe(1);
+    expect(events[0].kind).toBe('OTC_CONTRACT_EXPIRING');
+  });
+
+  it('daysUntilSettlement returns positive days for future date', () => {
+    const future = new Date();
+    future.setDate(future.getDate() + 5);
+    const days = daysUntilSettlement(future.toISOString().substring(0, 10));
+    expect(days).toBe(5);
+  });
+});

--- a/src/app/features/otc/services/otc-notification-diff.spec.ts
+++ b/src/app/features/otc/services/otc-notification-diff.spec.ts
@@ -1,4 +1,4 @@
-import { OtcOffer } from '../models/otc.model';
+import { OptionContract, OtcOffer } from '../models/otc.model';
 import {
   detectContractExpiryNotifications,
   detectOfferNotifications,
@@ -6,7 +6,9 @@ import {
   toOfferSnapshot,
 } from './otc-notification-diff';
 
-function offer(partial: Partial<OtcOffer> & Pick<OtcOffer, 'id' | 'stockTicker' | 'buyerId' | 'sellerId'>): OtcOffer {
+function offer(
+  partial: Partial<OtcOffer> & Pick<OtcOffer, 'id' | 'stockTicker' | 'buyerId' | 'sellerId'>,
+): OtcOffer {
   return {
     amount: 10,
     pricePerStock: 100,
@@ -19,73 +21,219 @@ function offer(partial: Partial<OtcOffer> & Pick<OtcOffer, 'id' | 'stockTicker' 
   };
 }
 
+function contract(
+  partial: Partial<OptionContract> &
+    Pick<OptionContract, 'id' | 'stockTicker' | 'buyerId' | 'sellerId'>,
+): OptionContract {
+  return {
+    offerId: 1,
+    amount: 10,
+    pricePerStock: 100,
+    settlementDate: '2027-06-01',
+    status: 'ACTIVE',
+    createdAt: '',
+    ...partial,
+  };
+}
+
 describe('otc-notification-diff', () => {
-  it('detects counter-offer when terms change and it is user turn', () => {
-    const before = toOfferSnapshot(
-      offer({ id: 1, stockTicker: 'AAPL', buyerId: 1, sellerId: 2, pricePerStock: 100 }),
-    );
-    const prev = new Map([[before.key, before]]);
-    const current = [
-      offer({
-        id: 1,
-        stockTicker: 'AAPL',
-        buyerId: 1,
-        sellerId: 2,
-        status: 'PENDING_BUYER',
-        pricePerStock: 110,
-      }),
-    ];
-
-    const events = detectOfferNotifications(prev, current, 1, false);
-    expect(events.some((e) => e.kind === 'OTC_COUNTER_OFFER')).toBe(true);
-  });
-
-  it('does not emit on initial poll', () => {
-    const current = [offer({ id: 1, stockTicker: 'AAPL', buyerId: 1, sellerId: 2 })];
-    const events = detectOfferNotifications(new Map(), current, 1, true);
-    expect(events.length).toBe(0);
-  });
-
-  it('detects withdrawn offer removed from active list', () => {
-    const before = toOfferSnapshot(
-      offer({ id: 5, stockTicker: 'MSFT', buyerId: 1, sellerId: 3, status: 'PENDING_SELLER' }),
-    );
-    const prev = new Map([[before.key, before]]);
-    const events = detectOfferNotifications(prev, [], 1, false);
-    expect(events.some((e) => e.kind === 'OTC_OFFER_WITHDRAWN')).toBe(true);
-  });
-
-  it('detects contract expiring within warning window', () => {
-    const soon = new Date();
-    soon.setDate(soon.getDate() + 2);
-    const iso = soon.toISOString().substring(0, 10);
-
-    const events = detectContractExpiryNotifications(
-      [
-        {
-          id: 9,
-          offerId: 1,
+  describe('detectOfferNotifications', () => {
+    it('detects counter-offer when terms change and it is user turn', () => {
+      const before = toOfferSnapshot(
+        offer({ id: 1, stockTicker: 'AAPL', buyerId: 1, sellerId: 2, pricePerStock: 100 }),
+      );
+      const prev = new Map([[before.key, before]]);
+      const current = [
+        offer({
+          id: 1,
           stockTicker: 'AAPL',
           buyerId: 1,
           sellerId: 2,
-          amount: 10,
-          pricePerStock: 100,
-          settlementDate: iso,
-          status: 'ACTIVE',
-          createdAt: '',
-        },
-      ],
-      1,
-    );
+          status: 'PENDING_BUYER',
+          pricePerStock: 110,
+        }),
+      ];
 
-    expect(events.length).toBe(1);
-    expect(events[0].kind).toBe('OTC_CONTRACT_EXPIRING');
+      const events = detectOfferNotifications(prev, current, 1, false);
+      expect(events.some((e) => e.kind === 'OTC_COUNTER_OFFER')).toBe(true);
+    });
+
+    it('detects offer accepted', () => {
+      const before = toOfferSnapshot(
+        offer({ id: 2, stockTicker: 'MSFT', buyerId: 1, sellerId: 3, status: 'PENDING_BUYER' }),
+      );
+      const prev = new Map([[before.key, before]]);
+      const current = [
+        offer({ id: 2, stockTicker: 'MSFT', buyerId: 1, sellerId: 3, status: 'ACCEPTED' }),
+      ];
+
+      const events = detectOfferNotifications(prev, current, 1, false);
+      expect(events.some((e) => e.kind === 'OTC_OFFER_ACCEPTED')).toBe(true);
+    });
+
+    it('detects offer rejected', () => {
+      const before = toOfferSnapshot(
+        offer({ id: 3, stockTicker: 'GOOG', buyerId: 1, sellerId: 4, status: 'PENDING_SELLER' }),
+      );
+      const prev = new Map([[before.key, before]]);
+      const current = [
+        offer({ id: 3, stockTicker: 'GOOG', buyerId: 1, sellerId: 4, status: 'REJECTED' }),
+      ];
+
+      const events = detectOfferNotifications(prev, current, 1, false);
+      expect(events.some((e) => e.kind === 'OTC_OFFER_REJECTED')).toBe(true);
+    });
+
+    it('detects withdrawn offer removed from active list', () => {
+      const before = toOfferSnapshot(
+        offer({ id: 5, stockTicker: 'MSFT', buyerId: 1, sellerId: 3, status: 'PENDING_SELLER' }),
+      );
+      const prev = new Map([[before.key, before]]);
+      const events = detectOfferNotifications(prev, [], 1, false);
+      expect(events.some((e) => e.kind === 'OTC_OFFER_WITHDRAWN')).toBe(true);
+    });
+
+    it('does not emit on initial poll', () => {
+      const current = [offer({ id: 1, stockTicker: 'AAPL', buyerId: 1, sellerId: 2 })];
+      const events = detectOfferNotifications(new Map(), current, 1, true);
+      expect(events.length).toBe(0);
+    });
+
+    it('handles null prev and null current', () => {
+      expect(detectOfferNotifications(null, null, 1, false)).toEqual([]);
+    });
+
+    it('handles empty prev map and empty current array', () => {
+      expect(detectOfferNotifications(new Map(), [], 1, false)).toEqual([]);
+    });
+
+    it('returns empty when userId is null', () => {
+      const current = [offer({ id: 1, stockTicker: 'AAPL', buyerId: 1, sellerId: 2 })];
+      expect(detectOfferNotifications(new Map(), current, null, false)).toEqual([]);
+    });
+
+    it('skips invalid offer entries without throwing', () => {
+      const before = toOfferSnapshot(
+        offer({ id: 1, stockTicker: 'AAPL', buyerId: 1, sellerId: 2, status: 'PENDING_SELLER' }),
+      );
+      const prev = new Map([[before.key, before]]);
+      const current = [
+        null,
+        undefined,
+        offer({
+          id: 1,
+          stockTicker: 'AAPL',
+          buyerId: 1,
+          sellerId: 2,
+          status: 'PENDING_BUYER',
+          pricePerStock: 110,
+        }),
+        { id: 2, stockTicker: 'X', buyerId: 1, sellerId: 2 } as OtcOffer,
+      ] as unknown as OtcOffer[];
+
+      const events = detectOfferNotifications(prev, current, 1, false);
+      expect(events.some((e) => e.kind === 'OTC_COUNTER_OFFER')).toBe(true);
+      expect(events.length).toBe(1);
+    });
+
+    it('handles large arrays efficiently (10000 offers)', () => {
+      const prev = new Map<string, ReturnType<typeof toOfferSnapshot>>();
+      const current: OtcOffer[] = [];
+      for (let i = 0; i < 10_000; i++) {
+        const o = offer({ id: i, stockTicker: 'TCK', buyerId: 1, sellerId: 2 });
+        const snap = toOfferSnapshot(o);
+        prev.set(snap.key, snap);
+        current.push(o);
+      }
+
+      const start = performance.now();
+      detectOfferNotifications(prev, current, 1, false);
+      const duration = performance.now() - start;
+
+      expect(duration).toBeLessThan(100);
+    });
   });
 
-  it('daysUntilSettlement returns positive days for future date', () => {
-    const future = new Date();
-    future.setDate(future.getDate() + 5);
-    const days = daysUntilSettlement(future.toISOString().substring(0, 10));
-    expect(days).toBe(5);
+  describe('detectContractExpiryNotifications', () => {
+    it('detects contract expiring within warning window', () => {
+      const soon = new Date();
+      soon.setDate(soon.getDate() + 2);
+      const iso = soon.toISOString().substring(0, 10);
+
+      const events = detectContractExpiryNotifications(
+        [contract({ id: 9, stockTicker: 'AAPL', buyerId: 1, sellerId: 2, settlementDate: iso })],
+        1,
+      );
+
+      expect(events.length).toBe(1);
+      expect(events[0].kind).toBe('OTC_CONTRACT_EXPIRING');
+    });
+
+    it('handles settlement today as 0 days (no notification — ističe danas)', () => {
+      const today = new Date().toISOString().split('T')[0];
+
+      expect(daysUntilSettlement(today)).toBe(0);
+
+      const events = detectContractExpiryNotifications(
+        [contract({ id: 10, stockTicker: 'AAPL', buyerId: 1, sellerId: 2, settlementDate: today })],
+        1,
+      );
+
+      expect(events.length).toBe(0);
+    });
+
+    it('notifies for settlement tomorrow (1 day left)', () => {
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      const iso = tomorrow.toISOString().substring(0, 10);
+
+      const events = detectContractExpiryNotifications(
+        [contract({ id: 11, stockTicker: 'AAPL', buyerId: 1, sellerId: 2, settlementDate: iso })],
+        1,
+      );
+
+      expect(events.length).toBe(1);
+      expect(events[0].message).toContain('1 dan');
+    });
+
+    it('returns empty when contracts list is null', () => {
+      expect(detectContractExpiryNotifications(null, 1)).toEqual([]);
+    });
+
+    it('returns empty for empty contracts array', () => {
+      expect(detectContractExpiryNotifications([], 1)).toEqual([]);
+    });
+
+    it('skips contracts where user is not participant', () => {
+      const soon = new Date();
+      soon.setDate(soon.getDate() + 2);
+      const iso = soon.toISOString().substring(0, 10);
+
+      const events = detectContractExpiryNotifications(
+        [contract({ id: 12, stockTicker: 'AAPL', buyerId: 99, sellerId: 88, settlementDate: iso })],
+        1,
+      );
+
+      expect(events.length).toBe(0);
+    });
+  });
+
+  describe('daysUntilSettlement', () => {
+    it('returns positive days for future date', () => {
+      const future = new Date();
+      future.setDate(future.getDate() + 5);
+      const days = daysUntilSettlement(future.toISOString().substring(0, 10));
+      expect(days).toBe(5);
+    });
+
+    it('returns null for invalid or missing date', () => {
+      expect(daysUntilSettlement(undefined)).toBeNull();
+      expect(daysUntilSettlement('')).toBeNull();
+      expect(daysUntilSettlement('not-a-date')).toBeNull();
+    });
+
+    it('returns 0 for past settlement (not negative)', () => {
+      expect(daysUntilSettlement('2000-01-01')).toBe(0);
+    });
   });
 });

--- a/src/app/features/otc/services/otc-notification-diff.ts
+++ b/src/app/features/otc/services/otc-notification-diff.ts
@@ -1,0 +1,182 @@
+import { OptionContract, OtcOffer } from '../models/otc.model';
+
+/** Days before settlement when users are warned (spec: npr. 3 dana). */
+export const OTC_EXPIRY_WARNING_DAYS = 3;
+
+export type OtcNotificationKind =
+  | 'OTC_COUNTER_OFFER'
+  | 'OTC_OFFER_ACCEPTED'
+  | 'OTC_OFFER_REJECTED'
+  | 'OTC_OFFER_WITHDRAWN'
+  | 'OTC_CONTRACT_EXPIRING';
+
+export interface DetectedOtcNotification {
+  kind: OtcNotificationKind;
+  dedupeKey: string;
+  message: string;
+  route?: string;
+}
+
+export interface OfferSnapshot {
+  key: string;
+  stockTicker: string;
+  status: string;
+  amount: number;
+  pricePerStock: number;
+  premium: number;
+  settlementDate: string;
+  modifiedBy: string;
+  buyerId: number;
+  sellerId: number;
+}
+
+export function offerSnapshotKey(o: OtcOffer): string {
+  return o.interbank && o.localId ? `ib:${o.localId}` : `local:${o.id}`;
+}
+
+export function toOfferSnapshot(o: OtcOffer): OfferSnapshot {
+  return {
+    key: offerSnapshotKey(o),
+    stockTicker: o.stockTicker,
+    status: o.status,
+    amount: o.amount,
+    pricePerStock: o.pricePerStock,
+    premium: o.premium,
+    settlementDate: o.settlementDate,
+    modifiedBy: o.modifiedBy,
+    buyerId: o.buyerId,
+    sellerId: o.sellerId,
+  };
+}
+
+export function isUsersTurn(o: OfferSnapshot, userId: number | null): boolean {
+  if (userId == null) return false;
+  if (o.status === 'PENDING_SELLER') return userId === o.sellerId;
+  if (o.status === 'PENDING_BUYER') return userId === o.buyerId;
+  return false;
+}
+
+export function isParticipant(o: OfferSnapshot, userId: number | null): boolean {
+  if (userId == null) return false;
+  return userId === o.buyerId || userId === o.sellerId;
+}
+
+function termsChanged(a: OfferSnapshot, b: OfferSnapshot): boolean {
+  return (
+    a.amount !== b.amount ||
+    a.pricePerStock !== b.pricePerStock ||
+    a.premium !== b.premium ||
+    a.settlementDate !== b.settlementDate ||
+    a.modifiedBy !== b.modifiedBy
+  );
+}
+
+function pendingStatuses(): Set<string> {
+  return new Set(['PENDING_BUYER', 'PENDING_SELLER']);
+}
+
+export function detectOfferNotifications(
+  prev: Map<string, OfferSnapshot>,
+  current: OtcOffer[],
+  userId: number | null,
+  isInitial: boolean,
+): DetectedOtcNotification[] {
+  if (isInitial || userId == null) return [];
+
+  const out: DetectedOtcNotification[] = [];
+  const currentMap = new Map(current.map((o) => [offerSnapshotKey(o), toOfferSnapshot(o)]));
+
+  for (const [key, snap] of currentMap) {
+    const before = prev.get(key);
+    if (!before) continue;
+
+    if (snap.status === 'ACCEPTED' && before.status !== 'ACCEPTED' && isParticipant(snap, userId)) {
+      out.push({
+        kind: 'OTC_OFFER_ACCEPTED',
+        dedupeKey: `offer:${key}:accepted`,
+        message: `Ponuda za ${snap.stockTicker} je prihvaćena.`,
+        route: '/otc',
+      });
+      continue;
+    }
+
+    if (snap.status === 'REJECTED' && before.status !== 'REJECTED' && isParticipant(snap, userId)) {
+      out.push({
+        kind: 'OTC_OFFER_REJECTED',
+        dedupeKey: `offer:${key}:rejected`,
+        message: `Ponuda za ${snap.stockTicker} je odbijena.`,
+        route: '/otc',
+      });
+      continue;
+    }
+
+    if (
+      pendingStatuses().has(snap.status) &&
+      isUsersTurn(snap, userId) &&
+      (!isUsersTurn(before, userId) || termsChanged(before, snap))
+    ) {
+      out.push({
+        kind: 'OTC_COUNTER_OFFER',
+        dedupeKey: `offer:${key}:counter:${snap.modifiedBy}:${snap.amount}:${snap.pricePerStock}`,
+        message: `Druga strana je poslala kontraponudu za ${snap.stockTicker}.`,
+        route: '/otc',
+      });
+    }
+  }
+
+  for (const [key, before] of prev) {
+    if (currentMap.has(key)) continue;
+    if (!pendingStatuses().has(before.status) || !isParticipant(before, userId)) continue;
+    out.push({
+      kind: 'OTC_OFFER_WITHDRAWN',
+      dedupeKey: `offer:${key}:withdrawn`,
+      message: `Druga strana je odustala od ponude za ${before.stockTicker}.`,
+      route: '/otc',
+    });
+  }
+
+  return out;
+}
+
+export function daysUntilSettlement(settlementDate: string): number | null {
+  const raw = settlementDate?.includes('T')
+    ? settlementDate.substring(0, 10)
+    : settlementDate;
+  if (!raw) return null;
+  const settlement = new Date(`${raw}T00:00:00`);
+  if (Number.isNaN(settlement.getTime())) return null;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return Math.ceil((settlement.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+export function detectContractExpiryNotifications(
+  contracts: OptionContract[],
+  userId: number | null,
+  warningDays: number = OTC_EXPIRY_WARNING_DAYS,
+): DetectedOtcNotification[] {
+  if (userId == null) return [];
+
+  const out: DetectedOtcNotification[] = [];
+  for (const c of contracts) {
+    if (c.status !== 'ACTIVE') continue;
+    if (c.buyerId !== userId && c.sellerId !== userId) continue;
+
+    const days = daysUntilSettlement(c.settlementDate);
+    if (days == null || days <= 0 || days > warningDays) continue;
+
+    const dateLabel = c.settlementDate?.includes('T')
+      ? c.settlementDate.substring(0, 10)
+      : c.settlementDate;
+
+    out.push({
+      kind: 'OTC_CONTRACT_EXPIRING',
+      dedupeKey: `contract:${c.id}:expiry:${dateLabel}`,
+      message: `Opcioni ugovor za ${c.stockTicker} ističe za ${days} ${
+        days === 1 ? 'dan' : 'dana'
+      } (settlement: ${dateLabel}).`,
+      route: '/otc',
+    });
+  }
+  return out;
+}

--- a/src/app/features/otc/services/otc-notification-diff.ts
+++ b/src/app/features/otc/services/otc-notification-diff.ts
@@ -1,8 +1,14 @@
 import { OptionContract, OtcOffer } from '../models/otc.model';
 
+/**
+ * OTC in-app notification diff utilities (F11).
+ * Compares successive poll snapshots and emits dedupe-ready notification events.
+ */
+
 /** Days before settlement when users are warned (spec: npr. 3 dana). */
 export const OTC_EXPIRY_WARNING_DAYS = 3;
 
+/** Kind of OTC event surfaced in the notification inbox / toast. */
 export type OtcNotificationKind =
   | 'OTC_COUNTER_OFFER'
   | 'OTC_OFFER_ACCEPTED'
@@ -10,6 +16,7 @@ export type OtcNotificationKind =
   | 'OTC_OFFER_WITHDRAWN'
   | 'OTC_CONTRACT_EXPIRING';
 
+/** A single notification produced by diffing offers or contracts. */
 export interface DetectedOtcNotification {
   kind: OtcNotificationKind;
   dedupeKey: string;
@@ -17,6 +24,7 @@ export interface DetectedOtcNotification {
   route?: string;
 }
 
+/** Normalized offer fields used for O(n) Map-based comparison between polls. */
 export interface OfferSnapshot {
   key: string;
   stockTicker: string;
@@ -30,10 +38,56 @@ export interface OfferSnapshot {
   sellerId: number;
 }
 
+/**
+ * Type guard: offer has the minimum fields required for diffing and notifications.
+ *
+ * @param o - Offer candidate (may be null/undefined)
+ * @returns `true` when the offer can be compared safely
+ */
+export function isValidOffer(o: OtcOffer | null | undefined): o is OtcOffer {
+  return (
+    o != null &&
+    o.id != null &&
+    !!o.status &&
+    !!o.stockTicker &&
+    o.buyerId != null &&
+    o.sellerId != null
+  );
+}
+
+/**
+ * Type guard: contract has the minimum fields required for expiry warnings.
+ *
+ * @param c - Contract candidate (may be null/undefined)
+ * @returns `true` when the contract can be evaluated for expiry
+ */
+export function isValidContract(c: OptionContract | null | undefined): c is OptionContract {
+  return (
+    c != null &&
+    c.id != null &&
+    !!c.stockTicker &&
+    !!c.status &&
+    c.buyerId != null &&
+    c.sellerId != null
+  );
+}
+
+/**
+ * Stable key for an offer across polls (local id vs inter-bank localId).
+ *
+ * @param o - Valid OTC offer
+ * @returns `local:{id}` or `ib:{localId}` for inter-bank rows
+ */
 export function offerSnapshotKey(o: OtcOffer): string {
   return o.interbank && o.localId ? `ib:${o.localId}` : `local:${o.id}`;
 }
 
+/**
+ * Builds a compact snapshot for Map-based diffing.
+ *
+ * @param o - Valid OTC offer
+ * @returns Snapshot keyed by {@link offerSnapshotKey}
+ */
 export function toOfferSnapshot(o: OtcOffer): OfferSnapshot {
   return {
     key: offerSnapshotKey(o),
@@ -49,6 +103,12 @@ export function toOfferSnapshot(o: OtcOffer): OfferSnapshot {
   };
 }
 
+/**
+ * Whether the given user must act on a pending offer (buyer or seller turn).
+ *
+ * @param o - Offer snapshot
+ * @param userId - Logged-in user id, or null when unknown
+ */
 export function isUsersTurn(o: OfferSnapshot, userId: number | null): boolean {
   if (userId == null) return false;
   if (o.status === 'PENDING_SELLER') return userId === o.sellerId;
@@ -56,6 +116,12 @@ export function isUsersTurn(o: OfferSnapshot, userId: number | null): boolean {
   return false;
 }
 
+/**
+ * Whether the user is buyer or seller on the offer.
+ *
+ * @param o - Offer snapshot
+ * @param userId - Logged-in user id, or null when unknown
+ */
 export function isParticipant(o: OfferSnapshot, userId: number | null): boolean {
   if (userId == null) return false;
   return userId === o.buyerId || userId === o.sellerId;
@@ -71,23 +137,54 @@ function termsChanged(a: OfferSnapshot, b: OfferSnapshot): boolean {
   );
 }
 
-function pendingStatuses(): Set<string> {
-  return new Set(['PENDING_BUYER', 'PENDING_SELLER']);
-}
+const PENDING_STATUSES = new Set(['PENDING_BUYER', 'PENDING_SELLER']);
 
+/**
+ * Detects offer-related notifications by comparing the previous poll snapshot to the current list.
+ * Uses Map-based diffing keyed by {@link offerSnapshotKey} for O(n) performance.
+ *
+ * Emits events when the current user is a participant and:
+ * - **Counter-offer** — pending offer becomes their turn, or terms change while it is their turn
+ * - **Accepted / rejected** — terminal status transition
+ * - **Withdrawn** — offer disappeared from the active list while still pending
+ *
+ * @param prev - Previous offer snapshots by key (may be null/empty)
+ * @param current - Current active offers from the latest poll (may be null)
+ * @param userId - Logged-in user id; no events when null
+ * @param isInitial - When true (first poll after start), skips all events to avoid noise
+ * @returns Dedupe-ready notification descriptors (empty when inputs are invalid or initial poll)
+ *
+ * @throws None — returns an empty array on invalid or missing input
+ *
+ * @example
+ * const prev = new Map([[key, toOfferSnapshot(oldOffer)]]);
+ * const events = detectOfferNotifications(prev, currentOffers, userId, false);
+ * events
+ *   .filter((e) => e.kind === 'OTC_COUNTER_OFFER')
+ *   .forEach((e) => console.log(e.message));
+ */
 export function detectOfferNotifications(
-  prev: Map<string, OfferSnapshot>,
-  current: OtcOffer[],
+  prev: Map<string, OfferSnapshot> | null | undefined,
+  current: OtcOffer[] | null | undefined,
   userId: number | null,
   isInitial: boolean,
 ): DetectedOtcNotification[] {
   if (isInitial || userId == null) return [];
 
+  const safePrev = prev ?? new Map<string, OfferSnapshot>();
+  const safeCurrent = (current ?? []).filter(isValidOffer);
+  if (!safePrev.size && !safeCurrent.length) return [];
+
   const out: DetectedOtcNotification[] = [];
-  const currentMap = new Map(current.map((o) => [offerSnapshotKey(o), toOfferSnapshot(o)]));
+  const currentMap = new Map(
+    safeCurrent.map((o) => {
+      const snap = toOfferSnapshot(o);
+      return [snap.key, snap] as const;
+    }),
+  );
 
   for (const [key, snap] of currentMap) {
-    const before = prev.get(key);
+    const before = safePrev.get(key);
     if (!before) continue;
 
     if (snap.status === 'ACCEPTED' && before.status !== 'ACCEPTED' && isParticipant(snap, userId)) {
@@ -111,7 +208,7 @@ export function detectOfferNotifications(
     }
 
     if (
-      pendingStatuses().has(snap.status) &&
+      PENDING_STATUSES.has(snap.status) &&
       isUsersTurn(snap, userId) &&
       (!isUsersTurn(before, userId) || termsChanged(before, snap))
     ) {
@@ -124,9 +221,9 @@ export function detectOfferNotifications(
     }
   }
 
-  for (const [key, before] of prev) {
+  for (const [key, before] of safePrev) {
     if (currentMap.has(key)) continue;
-    if (!pendingStatuses().has(before.status) || !isParticipant(before, userId)) continue;
+    if (!PENDING_STATUSES.has(before.status) || !isParticipant(before, userId)) continue;
     out.push({
       kind: 'OTC_OFFER_WITHDRAWN',
       dedupeKey: `offer:${key}:withdrawn`,
@@ -138,28 +235,66 @@ export function detectOfferNotifications(
   return out;
 }
 
-export function daysUntilSettlement(settlementDate: string): number | null {
-  const raw = settlementDate?.includes('T')
-    ? settlementDate.substring(0, 10)
-    : settlementDate;
-  if (!raw) return null;
-  const settlement = new Date(`${raw}T00:00:00`);
-  if (Number.isNaN(settlement.getTime())) return null;
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  return Math.ceil((settlement.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+/**
+ * Number of calendar days until settlement (≥ 0).
+ *
+ * @param settlementDate - ISO date or `YYYY-MM-DD` string (may include time)
+ * @returns Whole days until settlement, or `null` when the date is missing or invalid
+ *
+ * @throws None — returns `null` on parse errors
+ *
+ * @example
+ * daysUntilSettlement('2026-12-01'); // e.g. 225
+ * daysUntilSettlement('invalid');    // null
+ */
+export function daysUntilSettlement(settlementDate: string | null | undefined): number | null {
+  try {
+    if (!settlementDate) return null;
+
+    const raw = settlementDate.includes('T')
+      ? settlementDate.substring(0, 10)
+      : settlementDate;
+    if (!raw) return null;
+
+    const settlement = new Date(`${raw}T00:00:00`);
+    if (Number.isNaN(settlement.getTime())) return null;
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const days = Math.ceil(
+      (settlement.getTime() - today.getTime()) / (1000 * 60 * 60 * 24),
+    );
+    return Math.max(days, 0);
+  } catch {
+    return null;
+  }
 }
 
+/**
+ * Detects active contracts approaching settlement for the current user.
+ *
+ * @param contracts - Active contracts from poll (may be null)
+ * @param userId - Logged-in user id; no events when null
+ * @param warningDays - Notify when settlement is within this many days (default: {@link OTC_EXPIRY_WARNING_DAYS})
+ * @returns Expiry warnings for contracts where `0 < daysUntilSettlement ≤ warningDays`
+ *
+ * @throws None — returns an empty array on invalid input
+ *
+ * @example
+ * const warnings = detectContractExpiryNotifications(contracts, userId);
+ * warnings.forEach((w) => console.log(w.message));
+ */
 export function detectContractExpiryNotifications(
-  contracts: OptionContract[],
+  contracts: OptionContract[] | null | undefined,
   userId: number | null,
   warningDays: number = OTC_EXPIRY_WARNING_DAYS,
 ): DetectedOtcNotification[] {
-  if (userId == null) return [];
+  if (userId == null || !contracts?.length) return [];
 
   const out: DetectedOtcNotification[] = [];
   for (const c of contracts) {
-    if (c.status !== 'ACTIVE') continue;
+    if (!isValidContract(c) || c.status !== 'ACTIVE') continue;
     if (c.buyerId !== userId && c.sellerId !== userId) continue;
 
     const days = daysUntilSettlement(c.settlementDate);

--- a/src/app/features/otc/services/otc-notification-monitor.service.spec.ts
+++ b/src/app/features/otc/services/otc-notification-monitor.service.spec.ts
@@ -1,0 +1,153 @@
+import { TestBed, discardPeriodicTasks, fakeAsync, tick } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+
+import { environment } from '../../../../environments/environment';
+import { AuthService } from '../../../core/services/auth.service';
+import { AppNotificationService } from '../../../shared/services/app-notification.service';
+import { OtcOffer } from '../models/otc.model';
+import { OtcService } from './otc.service';
+import {
+  OtcNotificationMonitorService,
+  OTC_NOTIFICATION_POLL_MS_DEFAULT,
+  resolveOtcNotificationPollMs,
+} from './otc-notification-monitor.service';
+
+const SAMPLE_OFFER: OtcOffer = {
+  id: 1,
+  stockTicker: 'AAPL',
+  buyerId: 77,
+  sellerId: 88,
+  amount: 10,
+  pricePerStock: 150,
+  premium: 50,
+  settlementDate: '2027-12-31',
+  status: 'PENDING_SELLER',
+  modifiedBy: '77',
+  lastModified: '',
+};
+
+describe('resolveOtcNotificationPollMs', () => {
+  const originalOverride = window.__OTC_POLL_MS;
+  const originalProduction = environment.production;
+
+  afterEach(() => {
+    environment.production = originalProduction;
+    if (originalOverride == null) {
+      delete window.__OTC_POLL_MS;
+    } else {
+      window.__OTC_POLL_MS = originalOverride;
+    }
+  });
+
+  it('returns default 30s when no override', () => {
+    environment.production = false;
+    delete window.__OTC_POLL_MS;
+    expect(resolveOtcNotificationPollMs()).toBe(OTC_NOTIFICATION_POLL_MS_DEFAULT);
+  });
+
+  it('ignores __OTC_POLL_MS in production', () => {
+    environment.production = true;
+    window.__OTC_POLL_MS = 500;
+    expect(resolveOtcNotificationPollMs()).toBe(OTC_NOTIFICATION_POLL_MS_DEFAULT);
+  });
+
+  it('enforces minimum 5s for dev override (blocks aggressive 500ms)', () => {
+    environment.production = false;
+    window.__OTC_POLL_MS = 500;
+    expect(resolveOtcNotificationPollMs()).toBe(5000);
+  });
+
+  it('allows override at or above 5s in non-production', () => {
+    environment.production = false;
+    window.__OTC_POLL_MS = 8000;
+    expect(resolveOtcNotificationPollMs()).toBe(8000);
+  });
+});
+
+describe('OtcNotificationMonitorService — network resilience', () => {
+  let service: OtcNotificationMonitorService;
+  let otcService: jasmine.SpyObj<OtcService>;
+  let notifications: jasmine.SpyObj<AppNotificationService>;
+
+  beforeEach(() => {
+    const auth = jasmine.createSpyObj<AuthService>('AuthService', [
+      'getToken',
+      'getLoggedUser',
+      'getUserIdFromToken',
+    ]);
+    auth.getToken.and.returnValue('token');
+    auth.getLoggedUser.and.returnValue({
+      email: 'otc@test.com',
+      permissions: ['CLIENT_TRADING'],
+    });
+    auth.getUserIdFromToken.and.returnValue(77);
+
+    otcService = jasmine.createSpyObj<OtcService>('OtcService', [
+      'getActiveOffers',
+      'myContracts',
+    ]);
+    otcService.myContracts.and.returnValue(of([]));
+
+    notifications = jasmine.createSpyObj<AppNotificationService>(
+      'AppNotificationService',
+      ['push'],
+    );
+
+    TestBed.configureTestingModule({
+      providers: [
+        OtcNotificationMonitorService,
+        { provide: OtcService, useValue: otcService },
+        { provide: AuthService, useValue: auth },
+        { provide: AppNotificationService, useValue: notifications },
+      ],
+    });
+
+    service = TestBed.inject(OtcNotificationMonitorService);
+    environment.production = false;
+    window.__OTC_POLL_MS = 100;
+  });
+
+  afterEach(fakeAsync(() => {
+    service.stop();
+    delete window.__OTC_POLL_MS;
+    discardPeriodicTasks();
+  }));
+
+  it('ne gasi polling posle greške u getActiveOffers (retry pa sledeći ciklus)', fakeAsync(() => {
+    let calls = 0;
+    otcService.getActiveOffers.and.callFake(() => {
+      calls += 1;
+      if (calls === 1) {
+        return throwError(() => new Error('negotiations network error'));
+      }
+      return of([SAMPLE_OFFER]);
+    });
+
+    service.start();
+    tick(0);
+    tick(2000);
+    tick(4000);
+    tick(8000);
+
+    expect(calls).toBeGreaterThan(1);
+    expect(service['pollSub']).toBeTruthy();
+
+    service.stop();
+    discardPeriodicTasks();
+  }));
+
+  it('nastavlja poll sa praznom listom ponuda (simulacija negotiations fallback)', fakeAsync(() => {
+    otcService.getActiveOffers.and.returnValue(of([]));
+
+    service.start();
+    tick(0);
+    tick(100);
+
+    expect(otcService.getActiveOffers).toHaveBeenCalled();
+    expect(service['pollSub']).toBeTruthy();
+    expect(notifications.push).not.toHaveBeenCalled();
+
+    service.stop();
+    discardPeriodicTasks();
+  }));
+});

--- a/src/app/features/otc/services/otc-notification-monitor.service.ts
+++ b/src/app/features/otc/services/otc-notification-monitor.service.ts
@@ -1,0 +1,130 @@
+import { Injectable, OnDestroy } from '@angular/core';
+import { forkJoin, of, Subscription, timer } from 'rxjs';
+import { catchError, switchMap } from 'rxjs/operators';
+
+import { AuthService } from '../../../core/services/auth.service';
+import { AppNotificationService } from '../../../shared/services/app-notification.service';
+import { OtcService } from './otc.service';
+import {
+  detectContractExpiryNotifications,
+  detectOfferNotifications,
+  OfferSnapshot,
+  toOfferSnapshot,
+} from './otc-notification-diff';
+
+declare global {
+  interface Window {
+    /** Samo za Cypress E2E — ubrzava poll (npr. 500). */
+    __OTC_POLL_MS?: number;
+  }
+}
+
+const POLL_INTERVAL_MS =
+  typeof window !== 'undefined' && window.__OTC_POLL_MS != null
+    ? window.__OTC_POLL_MS
+    : 30_000;
+const OTC_PERMISSIONS = [
+  'OTC_TRADE',
+  'CLIENT_TRADING',
+  'TRADE_UNLIMITED',
+  'SECURITIES_TRADE_UNLIMITED',
+  'SECURITIES_TRADE_LIMITED',
+];
+
+/**
+ * Celina 4 — OTC notifikacije u aplikaciji.
+ * Prati aktivne ponude i ugovore; email obaveštenja šalje backend preko notification-service-a.
+ */
+@Injectable({ providedIn: 'root' })
+export class OtcNotificationMonitorService implements OnDestroy {
+  private pollSub?: Subscription;
+  private offerSnapshot = new Map<string, OfferSnapshot>();
+  private contractExpiryNotified = new Set<string>();
+  private initialPollDone = false;
+
+  constructor(
+    private otcService: OtcService,
+    private auth: AuthService,
+    private notifications: AppNotificationService,
+  ) {}
+
+  start(): void {
+    if (this.pollSub || !this.canMonitor()) return;
+
+    this.pollSub = timer(0, POLL_INTERVAL_MS)
+      .pipe(switchMap(() => this.pollOnce()))
+      .subscribe();
+  }
+
+  stop(): void {
+    this.pollSub?.unsubscribe();
+    this.pollSub = undefined;
+    this.offerSnapshot.clear();
+    this.contractExpiryNotified.clear();
+    this.initialPollDone = false;
+  }
+
+  ngOnDestroy(): void {
+    this.stop();
+  }
+
+  private canMonitor(): boolean {
+    if (!this.auth.getToken()) return false;
+    const user = this.auth.getLoggedUser();
+    if (!user?.permissions?.length) return false;
+    return user.permissions.some((p) => OTC_PERMISSIONS.includes(p));
+  }
+
+  private pollOnce() {
+    return forkJoin({
+      offers: this.otcService.getActiveOffers().pipe(catchError(() => of([]))),
+      contracts: this.otcService.myContracts('ACTIVE').pipe(catchError(() => of([]))),
+    }).pipe(
+      switchMap(({ offers, contracts }) => {
+        const userId = this.auth.getUserIdFromToken();
+        const isInitial = !this.initialPollDone;
+
+        const offerEvents = detectOfferNotifications(
+          this.offerSnapshot,
+          offers,
+          userId,
+          isInitial,
+        );
+
+        const contractEvents = detectContractExpiryNotifications(contracts, userId).filter(
+          (n) => {
+            if (this.contractExpiryNotified.has(n.dedupeKey)) return false;
+            this.contractExpiryNotified.add(n.dedupeKey);
+            return true;
+          },
+        );
+
+        for (const item of offerEvents) {
+          this.notifications.push({
+            category: 'OTC',
+            kind: item.kind,
+            message: item.message,
+            dedupeKey: item.dedupeKey,
+            route: item.route,
+            showToast: true,
+          });
+        }
+
+        for (const item of contractEvents) {
+          this.notifications.push({
+            category: 'OTC',
+            kind: item.kind,
+            message: item.message,
+            dedupeKey: item.dedupeKey,
+            route: item.route,
+            showToast: !isInitial,
+          });
+        }
+
+        this.offerSnapshot = new Map(offers.map((o) => [toOfferSnapshot(o).key, toOfferSnapshot(o)]));
+        this.initialPollDone = true;
+        return of(null);
+      }),
+    );
+  }
+}

--- a/src/app/features/otc/services/otc-notification-monitor.service.ts
+++ b/src/app/features/otc/services/otc-notification-monitor.service.ts
@@ -1,7 +1,8 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { forkJoin, of, Subscription, timer } from 'rxjs';
-import { catchError, switchMap } from 'rxjs/operators';
+import { catchError, exhaustMap, retry, switchMap } from 'rxjs/operators';
 
+import { environment } from '../../../../environments/environment';
 import { AuthService } from '../../../core/services/auth.service';
 import { AppNotificationService } from '../../../shared/services/app-notification.service';
 import { OtcService } from './otc.service';
@@ -12,17 +13,34 @@ import {
   toOfferSnapshot,
 } from './otc-notification-diff';
 
+/** Produkcija: 30s. Manji interval samo u dev/E2E, nikad ispod 5s u dev-u. */
+export const OTC_NOTIFICATION_POLL_MS_DEFAULT = 30_000;
+const OTC_NOTIFICATION_POLL_MS_DEV_MIN = 5_000;
+
 declare global {
   interface Window {
-    /** Samo za Cypress E2E — ubrzava poll (npr. 500). */
+    /**
+     * Samo non-production (npr. Cypress). U produkciji se ignoriše.
+     * Preporuka: ≥ 5000 ms. E2E može koristiti 5000 da ubrza test bez 500 ms spam-a.
+     */
     __OTC_POLL_MS?: number;
   }
 }
 
-const POLL_INTERVAL_MS =
-  typeof window !== 'undefined' && window.__OTC_POLL_MS != null
-    ? window.__OTC_POLL_MS
-    : 30_000;
+/** Real-time preko WebSocket-a — buduće poboljšanje; trenutno HTTP poll. */
+export function resolveOtcNotificationPollMs(): number {
+  if (environment.production) {
+    return OTC_NOTIFICATION_POLL_MS_DEFAULT;
+  }
+
+  const override =
+    typeof window !== 'undefined' ? window.__OTC_POLL_MS : undefined;
+  if (override == null || !Number.isFinite(override) || override <= 0) {
+    return OTC_NOTIFICATION_POLL_MS_DEFAULT;
+  }
+
+  return Math.max(OTC_NOTIFICATION_POLL_MS_DEV_MIN, override);
+}
 const OTC_PERMISSIONS = [
   'OTC_TRADE',
   'CLIENT_TRADING',
@@ -34,6 +52,10 @@ const OTC_PERMISSIONS = [
 /**
  * Celina 4 — OTC notifikacije u aplikaciji.
  * Prati aktivne ponude i ugovore; email obaveštenja šalje backend preko notification-service-a.
+ *
+ * Otpornost na mrežne greške:
+ * - `OtcService.getActiveOffers()` retry + fallback ako `/api/interbank/otc/negotiations` padne.
+ * - `pollOnce()` retry (3×, exponential backoff) + catchError — monitor se ne gasi.
  */
 @Injectable({ providedIn: 'root' })
 export class OtcNotificationMonitorService implements OnDestroy {
@@ -49,10 +71,28 @@ export class OtcNotificationMonitorService implements OnDestroy {
   ) {}
 
   start(): void {
-    if (this.pollSub || !this.canMonitor()) return;
+    this.pollSub?.unsubscribe();
+    this.pollSub = undefined;
 
-    this.pollSub = timer(0, POLL_INTERVAL_MS)
-      .pipe(switchMap(() => this.pollOnce()))
+    if (!this.canMonitor()) return;
+
+    // exhaustMap: ne prekidaj poll koji još traje (npr. interbank retry ~6s) — switchMap bi
+    // otkazao poll pre ažuriranja snapshot-a i isInitial bi ostao true.
+    this.pollSub = timer(0, resolveOtcNotificationPollMs())
+      .pipe(
+        exhaustMap(() =>
+          this.pollOnce().pipe(
+            retry({
+              count: 3,
+              delay: (_err, retryCount) => timer(2 ** retryCount * 1000),
+            }),
+            catchError((err) => {
+              console.error('OTC notification poll failed:', err);
+              return of(null);
+            }),
+          ),
+        ),
+      )
       .subscribe();
   }
 
@@ -121,7 +161,12 @@ export class OtcNotificationMonitorService implements OnDestroy {
           });
         }
 
-        this.offerSnapshot = new Map(offers.map((o) => [toOfferSnapshot(o).key, toOfferSnapshot(o)]));
+        this.offerSnapshot = new Map(
+          offers.map((o) => {
+            const snap = toOfferSnapshot(o);
+            return [snap.key, snap] as const;
+          }),
+        );
         this.initialPollDone = true;
         return of(null);
       }),

--- a/src/app/features/otc/services/otc.service.spec.ts
+++ b/src/app/features/otc/services/otc.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { OtcService } from './otc.service';
@@ -156,7 +156,7 @@ describe('OtcService — inter-bank wrapper (PR_33 Phase B)', () => {
     httpMock.expectOne(interbankUrl).flush(interbankNegs);
   });
 
-  it('getActiveOffers() ne pada ako inter-bank API vrati 500', done => {
+  it('getActiveOffers() ne pada ako inter-bank API vrati 500', fakeAsync(() => {
     const localOffers: OtcOffer[] = [
       {
         id: 1, stockTicker: 'X', buyerId: 1, sellerId: 2, amount: 1,
@@ -164,12 +164,70 @@ describe('OtcService — inter-bank wrapper (PR_33 Phase B)', () => {
         status: 'PENDING_BUYER', modifiedBy: '1', lastModified: '',
       },
     ];
-    service.getActiveOffers().subscribe(merged => {
-      expect(merged.length).toBe(1);
-      expect(merged[0].interbank).toBe(false);
-      done();
-    });
+    let merged: OtcOffer[] = [];
+    service.getActiveOffers().subscribe((res) => (merged = res));
+
     httpMock.expectOne(`${localUrl}/offers/active`).flush(localOffers);
-    httpMock.expectOne(interbankUrl).flush({ msg: 'down' }, { status: 500, statusText: 'Server Error' });
+    httpMock
+      .expectOne(interbankUrl)
+      .flush({ msg: 'down' }, { status: 500, statusText: 'Server Error' });
+    tick(2000);
+    httpMock
+      .expectOne(interbankUrl)
+      .flush({ msg: 'down' }, { status: 500, statusText: 'Server Error' });
+    tick(4000);
+    httpMock
+      .expectOne(interbankUrl)
+      .flush({ msg: 'down' }, { status: 500, statusText: 'Server Error' });
+
+    expect(merged.length).toBe(1);
+    expect(merged[0].interbank).toBe(false);
+  }));
+});
+
+describe('OtcService — ETag caching (F11)', () => {
+  let service: OtcService;
+  let httpMock: HttpTestingController;
+
+  const localUrl = `${environment.apiUrl}/otc`;
+  const activeUrl = `${localUrl}/offers/active`;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [OtcService],
+    });
+    service = TestBed.inject(OtcService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('activeForCurrentUser šalje If-None-Match i koristi keš na 304', () => {
+    const body: OtcOffer[] = [
+      {
+        id: 1,
+        stockTicker: 'X',
+        buyerId: 1,
+        sellerId: 2,
+        amount: 1,
+        pricePerStock: 10,
+        premium: 1,
+        settlementDate: '2026-12-01',
+        status: 'PENDING_BUYER',
+        modifiedBy: '1',
+        lastModified: '',
+      },
+    ];
+
+    service.activeForCurrentUser().subscribe((res) => expect(res).toEqual(body));
+    httpMock
+      .expectOne(activeUrl)
+      .flush(body, { headers: { ETag: '"offers-v1"' } });
+
+    service.activeForCurrentUser().subscribe((res) => expect(res).toEqual(body));
+    const req2 = httpMock.expectOne(activeUrl);
+    expect(req2.request.headers.get('If-None-Match')).toBe('"offers-v1"');
+    req2.flush(null, { status: 304, statusText: 'Not Modified' });
   });
 });

--- a/src/app/features/otc/services/otc.service.ts
+++ b/src/app/features/otc/services/otc.service.ts
@@ -1,7 +1,9 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, forkJoin, of } from 'rxjs';
-import { catchError, map } from 'rxjs/operators';
+import { Observable, forkJoin, of, timer } from 'rxjs';
+import { catchError, map, retry, tap } from 'rxjs/operators';
+
+import { OtcEtagCache } from './otc-etag-cache';
 
 import { environment } from 'src/environments/environment';
 import {
@@ -31,27 +33,44 @@ const BANKA2_LABEL = 'Banka 2';
 export class OtcService {
   private readonly baseUrl = `${environment.apiUrl}/otc`;
   private readonly interbankUrl = `${environment.apiUrl}/api/interbank/otc/negotiations`;
+  private readonly activeOffersUrl = `${this.baseUrl}/offers/active`;
+  private readonly etagCache: OtcEtagCache;
 
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient) {
+    this.etagCache = new OtcEtagCache(http);
+  }
+
+  /** Briše ETag keš (npr. pri odjavi). */
+  clearPollCache(): void {
+    this.etagCache.clear();
+  }
 
   createOffer(req: CreateOtcOfferRequest): Observable<OtcOffer> {
-    return this.http.post<OtcOffer>(`${this.baseUrl}/offers`, req);
+    return this.http.post<OtcOffer>(`${this.baseUrl}/offers`, req).pipe(
+      tap(() => this.invalidateOfferPollCache()),
+    );
   }
 
   counterOffer(offerId: number, req: CounterOfferRequest): Observable<OtcOffer> {
-    return this.http.post<OtcOffer>(`${this.baseUrl}/offers/${offerId}/counter`, req);
+    return this.http.post<OtcOffer>(`${this.baseUrl}/offers/${offerId}/counter`, req).pipe(
+      tap(() => this.invalidateOfferPollCache()),
+    );
   }
 
   accept(offerId: number): Observable<OtcOffer> {
-    return this.http.post<OtcOffer>(`${this.baseUrl}/offers/${offerId}/accept`, null);
+    return this.http.post<OtcOffer>(`${this.baseUrl}/offers/${offerId}/accept`, null).pipe(
+      tap(() => this.invalidateOfferPollCache()),
+    );
   }
 
   reject(offerId: number): Observable<OtcOffer> {
-    return this.http.post<OtcOffer>(`${this.baseUrl}/offers/${offerId}/reject`, null);
+    return this.http.post<OtcOffer>(`${this.baseUrl}/offers/${offerId}/reject`, null).pipe(
+      tap(() => this.invalidateOfferPollCache()),
+    );
   }
 
   activeForCurrentUser(): Observable<OtcOffer[]> {
-    return this.http.get<OtcOffer[]>(`${this.baseUrl}/offers/active`);
+    return this.etagCache.getJson<OtcOffer[]>(this.activeOffersUrl);
   }
 
   getPublicStocks(): Observable<OtcPublicStockGroup[]> {
@@ -75,11 +94,15 @@ export class OtcService {
   }
 
   withdrawOffer(offerId: number): Observable<void> {
-    return this.http.post<void>(`${this.baseUrl}/offers/${offerId}/withdraw`, null);
+    return this.http.post<void>(`${this.baseUrl}/offers/${offerId}/withdraw`, null).pipe(
+      tap(() => this.invalidateOfferPollCache()),
+    );
   }
 
   exercise(contractId: number): Observable<void> {
-    return this.http.post<void>(`${this.baseUrl}/contracts/${contractId}/exercise`, null);
+    return this.http.post<void>(`${this.baseUrl}/contracts/${contractId}/exercise`, null).pipe(
+      tap(() => this.etagCache.invalidateByPrefix(`${this.baseUrl}/contracts/my`)),
+    );
   }
 
   /**
@@ -90,7 +113,7 @@ export class OtcService {
     const url = status
       ? `${this.baseUrl}/contracts/my?status=${status}`
       : `${this.baseUrl}/contracts/my`;
-    return this.http.get<OptionContract[]>(url);
+    return this.etagCache.getJson<OptionContract[]>(url);
   }
 
   // ------------------------------------------------------------------
@@ -101,7 +124,7 @@ export class OtcService {
   // ------------------------------------------------------------------
 
   getInterbankNegotiations(): Observable<InterbankNegotiationView[]> {
-    return this.http.get<InterbankNegotiationView[]>(this.interbankUrl);
+    return this.etagCache.getJson<InterbankNegotiationView[]>(this.interbankUrl);
   }
 
   /**
@@ -115,22 +138,36 @@ export class OtcService {
   }
 
   createInterbankNegotiation(req: CreateInterbankNegotiationRequest): Observable<InterbankNegotiationView> {
-    return this.http.post<InterbankNegotiationView>(this.interbankUrl, req);
+    return this.http.post<InterbankNegotiationView>(this.interbankUrl, req).pipe(
+      tap(() => this.invalidateOfferPollCache()),
+    );
   }
 
   counterInterbankNegotiation(
     localId: string,
     req: CounterInterbankNegotiationRequest,
   ): Observable<void> {
-    return this.http.put<void>(`${this.interbankUrl}/${localId}/counter`, req);
+    return this.http.put<void>(`${this.interbankUrl}/${localId}/counter`, req).pipe(
+      tap(() => this.invalidateOfferPollCache()),
+    );
   }
 
   acceptInterbankNegotiation(localId: string): Observable<void> {
-    return this.http.post<void>(`${this.interbankUrl}/${localId}/accept`, null);
+    return this.http.post<void>(`${this.interbankUrl}/${localId}/accept`, null).pipe(
+      tap(() => this.invalidateOfferPollCache()),
+    );
   }
 
   deleteInterbankNegotiation(localId: string): Observable<void> {
-    return this.http.delete<void>(`${this.interbankUrl}/${localId}`);
+    return this.http.delete<void>(`${this.interbankUrl}/${localId}`).pipe(
+      tap(() => this.invalidateOfferPollCache()),
+    );
+  }
+
+  private invalidateOfferPollCache(): void {
+    this.etagCache.invalidateUrl(this.activeOffersUrl);
+    this.etagCache.invalidateUrl(this.interbankUrl);
+    this.etagCache.invalidateByPrefix(`${this.baseUrl}/contracts/my`);
   }
 
   /**
@@ -147,7 +184,11 @@ export class OtcService {
       catchError(() => of([] as OtcOffer[])),
     );
     const interbank$ = this.getInterbankNegotiations().pipe(
-      map(items => items.map(n => this.toOfferFromNegotiation(n))),
+      retry({
+        count: 2,
+        delay: (_err, retryCount) => timer(2 ** retryCount * 1000),
+      }),
+      map((items) => items.map((n) => this.toOfferFromNegotiation(n))),
       catchError(() => of([] as OtcOffer[])),
     );
     return forkJoin([local$, interbank$]).pipe(

--- a/src/app/shared/models/app-notification.model.ts
+++ b/src/app/shared/models/app-notification.model.ts
@@ -1,0 +1,20 @@
+export type AppNotificationCategory = 'OTC';
+
+export type AppNotificationKind =
+  | 'OTC_COUNTER_OFFER'
+  | 'OTC_OFFER_ACCEPTED'
+  | 'OTC_OFFER_REJECTED'
+  | 'OTC_OFFER_WITHDRAWN'
+  | 'OTC_CONTRACT_EXPIRING';
+
+export interface AppNotification {
+  id: string;
+  category: AppNotificationCategory;
+  kind: AppNotificationKind;
+  message: string;
+  createdAt: string;
+  read: boolean;
+  route?: string;
+  /** Stable key for deduplication (e.g. offer id or contract id). */
+  dedupeKey: string;
+}

--- a/src/app/shared/services/app-notification.service.spec.ts
+++ b/src/app/shared/services/app-notification.service.spec.ts
@@ -1,0 +1,142 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AuthService } from '../../core/services/auth.service';
+import { AppNotificationService } from './app-notification.service';
+import { ToastService } from './toast.service';
+
+describe('AppNotificationService', () => {
+  let service: AppNotificationService;
+  let toast: jasmine.SpyObj<ToastService>;
+  let auth: jasmine.SpyObj<AuthService>;
+
+  const baseParams = {
+    category: 'OTC' as const,
+    kind: 'OTC_COUNTER_OFFER' as const,
+    message: 'Druga strana je poslala kontraponudu za AAPL.',
+    dedupeKey: 'offer:1:counter',
+    showToast: false,
+  };
+
+  beforeEach(() => {
+    toast = jasmine.createSpyObj('ToastService', ['info']);
+    auth = jasmine.createSpyObj('AuthService', ['getUserIdFromToken']);
+    auth.getUserIdFromToken.and.returnValue(77);
+
+    TestBed.configureTestingModule({
+      providers: [
+        AppNotificationService,
+        { provide: ToastService, useValue: toast },
+        { provide: AuthService, useValue: auth },
+      ],
+    });
+
+    service = TestBed.inject(AppNotificationService);
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('push() dodaje notifikaciju', () => {
+    service.push(baseParams);
+
+    expect(service.snapshot.length).toBe(1);
+    expect(service.snapshot[0].message).toBe(baseParams.message);
+    expect(service.snapshot[0].read).toBe(false);
+    expect(service.unreadCount).toBe(1);
+  });
+
+  it('push() poziva toast.info kada je showToast uključen', () => {
+    service.push({ ...baseParams, dedupeKey: 'toast-key', showToast: true });
+
+    expect(toast.info).toHaveBeenCalledWith(baseParams.message);
+  });
+
+  it('ne dodaje duplikat sa istim dedupeKey u roku od 1h', () => {
+    service.push(baseParams);
+    service.push({ ...baseParams, message: 'Druga poruka' });
+
+    expect(service.snapshot.length).toBe(1);
+  });
+
+  it('ograničava inbox na najviše 50 notifikacija', () => {
+    for (let i = 0; i < 55; i++) {
+      service.push({
+        ...baseParams,
+        dedupeKey: `offer:${i}:counter`,
+        message: `Poruka ${i}`,
+      });
+    }
+
+    expect(service.snapshot.length).toBe(50);
+    expect(service.snapshot[0].message).toBe('Poruka 54');
+    expect(service.snapshot[49].message).toBe('Poruka 5');
+  });
+
+  it('markRead() označava notifikaciju kao pročitanu', () => {
+    service.push(baseParams);
+    const id = service.snapshot[0].id;
+
+    service.markRead(id);
+
+    expect(service.snapshot[0].read).toBe(true);
+    expect(service.unreadCount).toBe(0);
+  });
+
+  it('markAllRead() označava sve kao pročitane', () => {
+    service.push({ ...baseParams, dedupeKey: 'k1' });
+    service.push({ ...baseParams, dedupeKey: 'k2', message: 'Druga' });
+
+    service.markAllRead();
+
+    expect(service.snapshot.every((n) => n.read)).toBe(true);
+    expect(service.unreadCount).toBe(0);
+  });
+
+  it('clear() briše sve notifikacije i localStorage', () => {
+    service.push(baseParams);
+    expect(localStorage.getItem('app-notifications:77')).toBeTruthy();
+
+    service.clear();
+
+    expect(service.snapshot).toEqual([]);
+    expect(localStorage.getItem('app-notifications:77')).toBeNull();
+  });
+
+  it('notifications$ prestaje da emituje posle unsubscribe', () => {
+    const emissions: number[] = [];
+    const sub = service.notifications$.subscribe((list) => emissions.push(list.length));
+
+    service.push(baseParams);
+    service.push({ ...baseParams, dedupeKey: 'druga' });
+
+    sub.unsubscribe();
+
+    const countAfterUnsub = emissions.length;
+    service.push({ ...baseParams, dedupeKey: 'treca' });
+
+    expect(emissions.length).toBe(countAfterUnsub);
+    expect(service.snapshot.length).toBe(3);
+  });
+
+  it('hydrateFromStorage() učitava sačuvane notifikacije', () => {
+    const stored = [
+      {
+        id: 'stored-1',
+        category: 'OTC',
+        kind: 'OTC_CONTRACT_EXPIRING',
+        message: 'Sačuvano',
+        createdAt: new Date().toISOString(),
+        read: false,
+        dedupeKey: 'contract:1:expiry',
+      },
+    ];
+    localStorage.setItem('app-notifications:77', JSON.stringify(stored));
+
+    service.hydrateFromStorage();
+
+    expect(service.snapshot.length).toBe(1);
+    expect(service.snapshot[0].message).toBe('Sačuvano');
+  });
+});

--- a/src/app/shared/services/app-notification.service.ts
+++ b/src/app/shared/services/app-notification.service.ts
@@ -1,0 +1,77 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+import {
+  AppNotification,
+  AppNotificationCategory,
+  AppNotificationKind,
+} from '../models/app-notification.model';
+import { ToastService } from './toast.service';
+
+const MAX_NOTIFICATIONS = 50;
+const DEDUPE_WINDOW_MS = 60 * 60 * 1000;
+
+@Injectable({ providedIn: 'root' })
+export class AppNotificationService {
+  private readonly itemsSubject = new BehaviorSubject<AppNotification[]>([]);
+  readonly notifications$ = this.itemsSubject.asObservable();
+
+  constructor(private toast: ToastService) {}
+
+  get snapshot(): AppNotification[] {
+    return this.itemsSubject.value;
+  }
+
+  get unreadCount(): number {
+    return this.snapshot.filter((n) => !n.read).length;
+  }
+
+  push(params: {
+    category: AppNotificationCategory;
+    kind: AppNotificationKind;
+    message: string;
+    dedupeKey: string;
+    route?: string;
+    showToast?: boolean;
+  }): void {
+    const now = Date.now();
+    const existing = this.snapshot.find(
+      (n) =>
+        n.dedupeKey === params.dedupeKey &&
+        now - new Date(n.createdAt).getTime() < DEDUPE_WINDOW_MS,
+    );
+    if (existing) return;
+
+    const notification: AppNotification = {
+      id: `${params.kind}-${now}-${Math.random().toString(36).slice(2, 8)}`,
+      category: params.category,
+      kind: params.kind,
+      message: params.message,
+      createdAt: new Date().toISOString(),
+      read: false,
+      route: params.route,
+      dedupeKey: params.dedupeKey,
+    };
+
+    const next = [notification, ...this.snapshot].slice(0, MAX_NOTIFICATIONS);
+    this.itemsSubject.next(next);
+
+    if (params.showToast !== false) {
+      this.toast.info(params.message);
+    }
+  }
+
+  markRead(id: string): void {
+    this.itemsSubject.next(
+      this.snapshot.map((n) => (n.id === id ? { ...n, read: true } : n)),
+    );
+  }
+
+  markAllRead(): void {
+    this.itemsSubject.next(this.snapshot.map((n) => ({ ...n, read: true })));
+  }
+
+  clear(): void {
+    this.itemsSubject.next([]);
+  }
+}

--- a/src/app/shared/services/app-notification.service.ts
+++ b/src/app/shared/services/app-notification.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 
+import { AuthService } from '../../core/services/auth.service';
 import {
   AppNotification,
   AppNotificationCategory,
@@ -10,13 +11,17 @@ import { ToastService } from './toast.service';
 
 const MAX_NOTIFICATIONS = 50;
 const DEDUPE_WINDOW_MS = 60 * 60 * 1000;
+const STORAGE_KEY_PREFIX = 'app-notifications';
 
 @Injectable({ providedIn: 'root' })
 export class AppNotificationService {
   private readonly itemsSubject = new BehaviorSubject<AppNotification[]>([]);
   readonly notifications$ = this.itemsSubject.asObservable();
 
-  constructor(private toast: ToastService) {}
+  constructor(
+    private toast: ToastService,
+    private auth: AuthService,
+  ) {}
 
   get snapshot(): AppNotification[] {
     return this.itemsSubject.value;
@@ -24,6 +29,15 @@ export class AppNotificationService {
 
   get unreadCount(): number {
     return this.snapshot.filter((n) => !n.read).length;
+  }
+
+  /** Učitava inbox iz localStorage (po user id) nakon logina. */
+  hydrateFromStorage(): void {
+    if (this.snapshot.length > 0) return;
+    const stored = this.loadFromStorage();
+    if (stored.length > 0) {
+      this.itemsSubject.next(stored);
+    }
   }
 
   push(params: {
@@ -34,6 +48,8 @@ export class AppNotificationService {
     route?: string;
     showToast?: boolean;
   }): void {
+    this.hydrateFromStorage();
+
     const now = Date.now();
     const existing = this.snapshot.find(
       (n) =>
@@ -55,6 +71,7 @@ export class AppNotificationService {
 
     const next = [notification, ...this.snapshot].slice(0, MAX_NOTIFICATIONS);
     this.itemsSubject.next(next);
+    this.persist(next);
 
     if (params.showToast !== false) {
       this.toast.info(params.message);
@@ -62,16 +79,53 @@ export class AppNotificationService {
   }
 
   markRead(id: string): void {
-    this.itemsSubject.next(
-      this.snapshot.map((n) => (n.id === id ? { ...n, read: true } : n)),
-    );
+    const next = this.snapshot.map((n) => (n.id === id ? { ...n, read: true } : n));
+    this.itemsSubject.next(next);
+    this.persist(next);
   }
 
   markAllRead(): void {
-    this.itemsSubject.next(this.snapshot.map((n) => ({ ...n, read: true })));
+    const next = this.snapshot.map((n) => ({ ...n, read: true }));
+    this.itemsSubject.next(next);
+    this.persist(next);
   }
 
   clear(): void {
     this.itemsSubject.next([]);
+    const key = this.storageKey();
+    if (key) {
+      localStorage.removeItem(key);
+    }
+  }
+
+  private storageKey(): string | null {
+    const userId = this.auth.getUserIdFromToken();
+    return userId != null ? `${STORAGE_KEY_PREFIX}:${userId}` : null;
+  }
+
+  private loadFromStorage(): AppNotification[] {
+    const key = this.storageKey();
+    if (!key) return [];
+
+    try {
+      const raw = localStorage.getItem(key);
+      if (!raw) return [];
+      const parsed = JSON.parse(raw) as unknown;
+      if (!Array.isArray(parsed)) return [];
+      return (parsed as AppNotification[]).slice(0, MAX_NOTIFICATIONS);
+    } catch {
+      return [];
+    }
+  }
+
+  private persist(items: AppNotification[]): void {
+    const key = this.storageKey();
+    if (!key) return;
+
+    try {
+      localStorage.setItem(key, JSON.stringify(items.slice(0, MAX_NOTIFICATIONS)));
+    } catch {
+      // Quota exceeded ili privatni režim — inbox ostaje samo u memoriji.
+    }
   }
 }


### PR DESCRIPTION
Implemented in-app notifications for OTC negotiation events:
- counteroffer received
- offer accepted
- offer declined/cancelled
- option contract expiration warning

Added notification service, OTC notification monitor/diff logic, topbar integration, contract expiration warning UI, and tests.

Build passes.