### PR TITLE
feat(otc): turn-check gating za interbank ponude + deep-link ruta

### DIFF
--- a/src/app/features/otc/components/otc-offers/otc-offers.component.html
+++ b/src/app/features/otc/components/otc-offers/otc-offers.component.html
@@ -111,7 +111,14 @@
                     Povuci
                   </button>
 
-                  <span *ngIf="!canAccept(o) && !canCounter(o) && !canReject(o) && !canWithdraw(o)"
+                  <!-- Inter-bank turn hint (kad smo poslednji modifier, cekamo partner banku) -->
+                  <span *ngIf="counterDisabledReason(o) as reason"
+                        class="text-xs text-muted-foreground italic"
+                        [title]="reason">
+                    {{ reason }}
+                  </span>
+
+                  <span *ngIf="!canAccept(o) && !canCounter(o) && !canReject(o) && !canWithdraw(o) && !counterDisabledReason(o)"
                         class="text-xs text-muted-foreground italic">
                     —
                   </span>

--- a/src/app/features/otc/components/otc-offers/otc-offers.component.ts
+++ b/src/app/features/otc/components/otc-offers/otc-offers.component.ts
@@ -10,6 +10,9 @@ import { AuthService } from '../../../../core/services/auth.service';
 
 export type OtcFilterMode = 'all' | 'local' | 'banka2';
 
+/** Routing broj nase banke. Koristi se za turn check u inter-bank ponudama. */
+const MY_ROUTING = 111;
+
 @Component({
   selector: 'app-otc-offers',
   templateUrl: './otc-offers.component.html',
@@ -89,8 +92,27 @@ export class OtcOffersComponent implements OnInit, OnDestroy {
   }
 
   canCounter(offer: OtcOffer): boolean {
-    if (offer.interbank) return true;
+    if (offer.interbank) {
+      // Turn check per protocol §3.3: ne mozemo counter ako smo poslednji modifier.
+      // Backend bi vratio 409 TurnViolationException — disable button proaktivno.
+      if (offer.lastModifierRouting != null && offer.lastModifierRouting === MY_ROUTING) {
+        return false;
+      }
+      return true;
+    }
     return this.canRespond(offer);
+  }
+
+  /**
+   * Hint poruka za inter-bank ponude kad ne mozemo counter — pokazuje se umesto
+   * dugmeta da user razume zasto je akcija nedostupna.
+   */
+  counterDisabledReason(offer: OtcOffer): string | null {
+    if (!offer.interbank) return null;
+    if (offer.lastModifierRouting === MY_ROUTING) {
+      return `Čeka se odgovor partner banke (${offer.counterpartyBankName || 'Banka 2'})`;
+    }
+    return null;
   }
 
   /** Reject is shown when it's the current user's turn to respond. */

--- a/src/app/features/otc/components/otc-portal/otc-portal.component.ts
+++ b/src/app/features/otc/components/otc-portal/otc-portal.component.ts
@@ -1,13 +1,29 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 
 export type OtcTab = 'available-stocks' | 'positions' | 'negotiations' | 'contracts';
+
+const VALID_TABS: OtcTab[] = ['available-stocks', 'positions', 'negotiations', 'contracts'];
 
 @Component({
   selector: 'app-otc-portal',
   templateUrl: './otc-portal.component.html',
 })
-export class OtcPortalComponent {
+export class OtcPortalComponent implements OnInit {
   activeTab: OtcTab = 'available-stocks';
+
+  constructor(private route: ActivatedRoute) {}
+
+  ngOnInit(): void {
+    // Inicijalni tab moze doci iz route data (deep-link `/otc/offers` postavlja
+    // 'negotiations') ili query param (`/otc?tab=contracts`).
+    const dataTab = this.route.snapshot.data?.['initialTab'] as OtcTab | undefined;
+    const queryTab = this.route.snapshot.queryParamMap.get('tab') as OtcTab | null;
+    const requested = queryTab || dataTab;
+    if (requested && VALID_TABS.includes(requested)) {
+      this.activeTab = requested;
+    }
+  }
 
   setTab(tab: OtcTab): void {
     this.activeTab = tab;

--- a/src/app/features/otc/models/otc.model.ts
+++ b/src/app/features/otc/models/otc.model.ts
@@ -15,6 +15,13 @@ export interface OtcOffer {
   modifiedBy: string;
   lastModified: string;
   /**
+   * Routing broj poslednjeg modifikatora pregovora (samo za interbank).
+   * Counter dugme treba da bude disabled kad je `lastModifierRouting === MY_ROUTING`
+   * (111) — partner banka ce inace vratiti 409 TurnViolationException.
+   * Mapira se iz backend `OtcNegotiationDto.lastModifiedBy.routingNumber`.
+   */
+  lastModifierRouting?: number;
+  /**
    * PR_33 Phase B: opciona inter-bank polja.
    * Kad je `interbank=true`, ova ponuda dolazi iz Banka 2 (cross-bank pregovor)
    * i ne postoji u intra-bank `/otc/offers` listi.

--- a/src/app/features/otc/otc.module.ts
+++ b/src/app/features/otc/otc.module.ts
@@ -14,6 +14,10 @@ import { StateComponent } from '../../shared/components/state/state.component';
 
 const routes: Routes = [
   { path: '', component: OtcPortalComponent },
+  // Deep-link alias za "Aktivni pregovori" tab — istorijski URL `/otc/offers`
+  // se koristio u 4 mesta u FE-u (create-offer redirect, contracts link).
+  // Renderuje isti OtcPortalComponent i otvara 'negotiations' tab kroz query param.
+  { path: 'offers', component: OtcPortalComponent, data: { initialTab: 'negotiations' } },
   {
     path: 'create',
     component: OtcCreateOfferComponent,

--- a/src/app/features/otc/services/otc.service.ts
+++ b/src/app/features/otc/services/otc.service.ts
@@ -188,13 +188,19 @@ export class OtcService {
       premium: s.premium.amount,
       settlementDate: s.settlementDate,
       status: s.isOngoing ? 'PENDING_BUYER' : 'ACCEPTED',
-      modifiedBy: `${s.lastModifiedBy.routingNumber}:${s.lastModifiedBy.id}`,
+      modifiedBy: s?.lastModifiedBy
+          ? `${s.lastModifiedBy.routingNumber}:${s.lastModifiedBy.id}`
+          : '',
       lastModified: '',
       interbank: true,
       counterpartyBankCode: n.remoteForeignBankId.routingNumber,
       counterpartyBankName: this.bankNameFor(n.remoteForeignBankId.routingNumber),
       localId: n.localId,
       remoteId: n.remoteForeignBankId.id,
+      // Null-safe: ako backend response ne sadrzi lastModifiedBy (npr. legacy
+      // entity-i pre PR_33), polje ostaje undefined — canCounter ce default na
+      // dozvoljeno umesto da baca TypeError pri renderu cele stranice.
+      lastModifierRouting: s?.lastModifiedBy?.routingNumber,
     };
   }
 


### PR DESCRIPTION
# OTC turn-check gating + deep-link ruta

## Pregled

Frontend dopune za inter-bank OTC flow:

- Turn-check gating na counter dugmetu — sprecava 409 TurnViolationException
  iz partner banke kad smo mi poslednji modifier u pregovoru.
- Nova deep-link ruta `/otc/offers` koja vodi na tab "negotiations" u OTC
  portalu.

## Izmene

### Model i servis

- `OtcOffer` model dobija opciono polje `lastModifierRouting?: number`
  (mapiran iz `OtcNegotiationDto.lastModifiedBy.routingNumber` u inter-bank
  response-u).
- `otc.service.ts`:
  - `toOfferFromNegotiation` mapper postavlja `lastModifierRouting`
    null-safe (`s?.lastModifiedBy?.routingNumber`).
  - `modifiedBy` polje takodje null-safe za legacy entity-je bez
    `lastModifiedBy` podatka.

### Komponenta — `otc-offers`

- `canCounter` za inter-bank ponude sad proverava da nase routing nije
  poslednji modifier (`MY_ROUTING = 111`). Counter dugme je disabled kad
  bi PUT vratio 409.
- Novi helper `counterDisabledReason(offer)` vraca tekstualan hint:
  "Čeka se odgovor partner banke (Banka 2)".
- Template (`otc-offers.component.html`):
  - Dodato `*ngIf="counterDisabledReason(o)"` prikazuje hint poruku.
  - Fallback `—` span uslovljen `!counterDisabledReason(o)` da se ne
    dupli prikaz.

### Ruta

- `otc.module.ts`: dodata ruta
  `{ path: 'offers', component: OtcPortalComponent, data: { initialTab: 'negotiations' } }`.
  Pre ove izmene `/otc/offers` (referencirano iz vise mesta u FE-u kao
  "Nazad na aktivne ponude") nije postojalo — 404 page.
- `otc-portal.component.ts`: `ngOnInit` cita
  `route.snapshot.data.initialTab` (deep-link postavlja 'negotiations')
  i `?tab=X` query param za opcionalan tab izbor.

## Bez izmena

- Build / runtime config — nepromenjen.
- Postojeci OTC flow za intra-bank pregovore — nepromenjen.
- Routing arhitektura — nove izmene su aditivne.

## Test

- Manuelna provera: counter dugme je disabled na inter-bank ponudi cija
  je poslednja modifikacija dosla od nase strane; enabled kad je partner
  poslednji odgovorio.
- `/otc/offers` direktan unos URL-a u browser otvara OTC portal sa
  selektovanim "negotiations" tab-om.
- `?tab=X` query param menja inicijalni tab pri navigaciji.
