### PR TITLE
Implementacija TODO_final specifikacije (Celine 1-4)

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -153,6 +153,16 @@ const routes: Routes = [
     canActivate: [authGuard],
   },
   {
+    // WP-21: in-app notifications page (lazy, standalone).
+    // Every authenticated user has a notification feed — no extra permission.
+    path: 'notifications',
+    loadComponent: () =>
+      import('./features/notifications/notifications.component').then(
+        (m) => m.NotificationsComponent,
+      ),
+    canActivate: [authGuard],
+  },
+  {
     path: '',
     loadChildren: () =>
       import('./features/auth/auth.module').then((m) => m.AuthModule),
@@ -202,6 +212,29 @@ const routes: Routes = [
     // SECURITIES_TRADE_UNLIMITED je preliberalno (i agenti ga mogu imati).
     data: { anyRole: ['SUPERVISOR', 'ADMIN', 'EmployeeAdmin'] },
   },
+  {
+    // WP-23 (Celina 3): system audit log viewer (lazy, standalone).
+    // Restricted to administrators and supervisors — copies the supervisor-only
+    // `tax-tracking` guard shape.
+    path: 'audit-log',
+    loadComponent: () =>
+      import('./features/employee/components/audit-log/audit-log.component').then(
+        (m) => m.AuditLogComponent,
+      ),
+    canActivate: [authGuard, roleGuard],
+    data: { anyRole: ['SUPERVISOR', 'ADMIN'] },
+  },
+  {
+    // WP-23 (Celina 3 — DCA): recurring (standing) orders (lazy, standalone).
+    // Every authenticated trader — clients-with-trading + actuary agents —
+    // can have recurring orders, so authGuard alone gates the route.
+    path: 'recurring-orders',
+    loadComponent: () =>
+      import('./features/recurring-orders/recurring-orders.component').then(
+        (m) => m.RecurringOrdersComponent,
+      ),
+    canActivate: [authGuard],
+  },
 
   {
     path: 'securities',
@@ -234,6 +267,34 @@ const routes: Routes = [
     path: 'orders/create/:direction/:listingId',
     component: CreateOrderComponent,
     canActivate: [authGuard]
+  },
+  {
+    // WP-22 (Celina 3): "Moji orderi" — caller's own order history (lazy, standalone).
+    // Every authenticated trader (client-with-trading + actuary agent) sees their own orders.
+    path: 'orders/my',
+    loadComponent: () =>
+      import('./features/orders/components/my-orders/my-orders.component').then(
+        (m) => m.MyOrdersComponent,
+      ),
+    canActivate: [authGuard],
+  },
+  {
+    // WP-22 (Celina 3): Watchlist management (lazy, standalone).
+    path: 'watchlists',
+    loadComponent: () =>
+      import(
+        './features/watchlist/components/watchlist-page/watchlist-page.component'
+      ).then((m) => m.WatchlistPageComponent),
+    canActivate: [authGuard],
+  },
+  {
+    // WP-22 (Celina 3): Price-alerts management (lazy, standalone).
+    path: 'price-alerts',
+    loadComponent: () =>
+      import(
+        './features/price-alerts/components/price-alerts-page/price-alerts-page.component'
+      ).then((m) => m.PriceAlertsPageComponent),
+    canActivate: [authGuard],
   },
   {
     // PR_03 C3.8: portal za marzne racune (lazy-loaded).

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -12,6 +12,8 @@ import { SidebarComponent } from './core/layout/sidebar/sidebar.component';
 import { TopbarComponent } from './core/layout/topbar/topbar.component';
 import { CommandPaletteComponent } from './core/layout/command-palette/command-palette.component';
 import { LucideIconComponent } from './shared/icons/lucide-icon.component';
+// WP-22 (Celina 3): topbar watchlist quick-access widget (standalone).
+import { WatchlistWidgetComponent } from './features/watchlist/components/watchlist-widget/watchlist-widget.component';
 
 import { EmployeeModule } from './features/employee/employee.module';
 
@@ -44,7 +46,9 @@ import { CommonModule } from '@angular/common';
     // import-a iz StateComponent-a (StateComponent je standalone — ne moze
     // imports-ovati ne-standalone komponentu). Spec-ovi koji ga koriste su
     // takodje azurirani da ga drze u imports umesto declarations.
-    LucideIconComponent
+    LucideIconComponent,
+    // WP-22 (Celina 3): standalone widget renderovan unutar TopbarComponent-a.
+    WatchlistWidgetComponent
   ],
   providers: [
     { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },

--- a/src/app/core/layout/nav-manifest.spec.ts
+++ b/src/app/core/layout/nav-manifest.spec.ts
@@ -39,10 +39,15 @@ describe('NavManifest', () => {
       expect(labels).toContain('Berza');
       expect(labels).not.toContain('Administracija');
     });
-    it('Berza ima svih 5 stavki (akcije/portfolio/margin/OTC/fondovi)', () => {
+    it('Berza ima svih 9 stavki (akcije/portfolio/moji-orderi/watchlist/alarmi/trajni-nalozi/margin/OTC/fondovi)', () => {
       const f = filterNavByPermissions(NAV_MANIFEST, c);
       const berza = f.find(g => g.label === 'Berza');
-      expect(berza?.items.length).toBe(5);
+      expect(berza?.items.length).toBe(9);
+      const routes = berza!.items.map(i => i.route);
+      expect(routes).toContain('/orders/my');
+      expect(routes).toContain('/watchlists');
+      expect(routes).toContain('/price-alerts');
+      expect(routes).toContain('/recurring-orders');
     });
   });
 
@@ -88,13 +93,14 @@ describe('NavManifest', () => {
       expect(labels).toContain('Berza');
       expect(labels).toContain('Administracija');
     });
-    it('Administracija ukljucuje Aktuari, Pregled order, Porez, Profit banke/aktuara, Kursna lista', () => {
+    it('Administracija ukljucuje Aktuari, Pregled order, Porez, Revizioni dnevnik, Profit banke/aktuara, Kursna lista', () => {
       const f = filterNavByPermissions(NAV_MANIFEST, c);
       const adm = f.find(g => g.label === 'Administracija');
       const routes = adm!.items.map(i => i.route);
       expect(routes).toContain('/actuary-management');
       expect(routes).toContain('/orders-overview');
       expect(routes).toContain('/tax-tracking');
+      expect(routes).toContain('/audit-log');
       expect(routes).toContain('/funds/profit-banke');
       expect(routes).toContain('/funds/profit-aktuara');
       expect(routes).toContain('/stock-exchange');
@@ -104,15 +110,17 @@ describe('NavManifest', () => {
 
   describe('Admin (role=ADMIN, perms=[sve gore + EMPLOYEE_MANAGE_ALL])', () => {
     const c = cap(['BANKING_BASIC', 'TRADE_UNLIMITED', 'SECURITIES_TRADE_UNLIMITED', 'SECURITIES_TRADE_LIMITED', 'OTC_TRADE', 'FUND_AGENT_MANAGE', 'CLIENT_MANAGE', 'EMPLOYEE_MANAGE_ALL'], 'ADMIN');
-    it('NE vidi Bankarstvo, vidi Berza + Administracija sa svim 11 stavki', () => {
+    it('NE vidi Bankarstvo, vidi Berza + Administracija sa svim 14 stavki', () => {
       const f = filterNavByPermissions(NAV_MANIFEST, c);
       expect(f.find(g => g.label === 'Bankarstvo')).toBeUndefined();
       const berza = f.find(g => g.label === 'Berza');
-      expect(berza?.items.length).toBe(5);
+      expect(berza?.items.length).toBe(9);
       const adm = f.find(g => g.label === 'Administracija');
-      expect(adm?.items.length).toBe(11);
+      /* Administracija ima 14 stavki; admin sa svim permisijama vidi sve. */
+      expect(adm?.items.length).toBe(14);
       const routes = adm!.items.map(i => i.route);
       expect(routes).toContain('/employees');
+      expect(routes).toContain('/audit-log');
     });
   });
 });

--- a/src/app/core/layout/nav-manifest.ts
+++ b/src/app/core/layout/nav-manifest.ts
@@ -24,7 +24,12 @@ export type NavIcon =
   | 'users'
   | 'shieldcheck'
   | 'receipt'
-  | 'gauge';
+  | 'gauge'
+  // WP-22 (Celina 3): Berza grupa — "Moji orderi" / Watchlist / Cenovni alarmi.
+  | 'star'
+  | 'bell'
+  // WP-23 (Celina 3): "Trajni nalozi" (DCA recurring orders).
+  | 'repeat';
 
 export interface NavItem {
   label: string;
@@ -74,6 +79,14 @@ export const NAV_MANIFEST: NavGroup[] = [
     items: [
       { label: 'Hartije od vrednosti', route: '/securities',  icon: 'trendingup', requiredPermissions: ['SECURITIES_TRADE_UNLIMITED', 'SECURITIES_TRADE_LIMITED', 'TRADE_UNLIMITED', 'CLIENT_TRADING'] },
       { label: 'Moj portfolio',        route: '/portfolio',   icon: 'briefcase',  requiredPermissions: ['SECURITIES_TRADE_UNLIMITED', 'SECURITIES_TRADE_LIMITED', 'TRADE_UNLIMITED', 'CLIENT_TRADING'] },
+      // WP-22 (Celina 3): order history / watchlist / price alerts — isti
+      // auditorijum kao "Hartije od vrednosti" (trgujuci klijenti + aktuari).
+      { label: 'Moji orderi',          route: '/orders/my',   icon: 'receipt',    requiredPermissions: ['SECURITIES_TRADE_UNLIMITED', 'SECURITIES_TRADE_LIMITED', 'TRADE_UNLIMITED', 'CLIENT_TRADING'] },
+      { label: 'Watchlist',            route: '/watchlists',  icon: 'star',       requiredPermissions: ['SECURITIES_TRADE_UNLIMITED', 'SECURITIES_TRADE_LIMITED', 'TRADE_UNLIMITED', 'CLIENT_TRADING'] },
+      { label: 'Cenovni alarmi',       route: '/price-alerts',icon: 'bell',       requiredPermissions: ['SECURITIES_TRADE_UNLIMITED', 'SECURITIES_TRADE_LIMITED', 'TRADE_UNLIMITED', 'CLIENT_TRADING'] },
+      // WP-23 (Celina 3 — DCA): standing orders — isti auditorijum kao ostale
+      // Berza trading stavke (trgujuci klijenti + aktuari).
+      { label: 'Trajni nalozi',        route: '/recurring-orders', icon: 'repeat', requiredPermissions: ['SECURITIES_TRADE_UNLIMITED', 'SECURITIES_TRADE_LIMITED', 'TRADE_UNLIMITED', 'CLIENT_TRADING'] },
       { label: 'Marzni racun',         route: '/margin',      icon: 'gauge',      requiredPermissions: ['SECURITIES_TRADE_UNLIMITED', 'SECURITIES_TRADE_LIMITED', 'TRADE_UNLIMITED', 'CLIENT_TRADING', 'ADMIN'] },
       { label: 'OTC trgovina',         route: '/otc',         icon: 'handshake',  requiredPermissions: ['OTC_TRADE', 'CLIENT_TRADING', 'TRADE_UNLIMITED', 'SECURITIES_TRADE_UNLIMITED', 'SUPERVISOR', 'ADMIN'] },
       { label: 'Fondovi',              route: '/funds',       icon: 'building',   requiredPermissions: ['FUND_AGENT_MANAGE', 'CLIENT_TRADING', 'TRADE_UNLIMITED', 'SECURITIES_TRADE_UNLIMITED', 'SUPERVISOR', 'ADMIN'] },
@@ -91,6 +104,9 @@ export const NAV_MANIFEST: NavGroup[] = [
       { label: 'Aktuari',           route: '/actuary-management',        icon: 'shieldcheck', requiredPermissions: ['FUND_AGENT_MANAGE', 'EMPLOYEE_MANAGE_ALL', 'ADMIN'] },
       { label: 'Pregled order',     route: '/orders-overview',           icon: 'receipt',     requiredPermissions: ['TRADE_UNLIMITED', 'EMPLOYEE_MANAGE_ALL', 'ADMIN'] },
       { label: 'Porez tracking',    route: '/tax-tracking',              icon: 'receipt',     requiredPermissions: ['TRADE_UNLIMITED', 'EMPLOYEE_MANAGE_ALL', 'ADMIN', 'SUPERVISOR'] },
+      // WP-23 (Celina 3): revizioni dnevnik — admin/supervizor, usaglaseno sa
+      // `audit-log` rutom `anyRole: ['SUPERVISOR', 'ADMIN']` (gard cita role string).
+      { label: 'Revizioni dnevnik', route: '/audit-log',                 icon: 'shieldcheck', requiredPermissions: ['ADMIN', 'SUPERVISOR'] },
       { label: 'Krediti admin',     route: '/loan-management',           icon: 'piggybank',   requiredPermissions: ['CLIENT_MANAGE', 'EMPLOYEE_MANAGE_ALL', 'ADMIN'] },
       { label: 'Kartice',           route: '/cards-management',          icon: 'creditcard',  requiredPermissions: ['CLIENT_MANAGE', 'EMPLOYEE_MANAGE_ALL', 'ADMIN'] },
       { label: 'Zahtevi za kredit', route: '/loan-request-management',   icon: 'piggybank',   requiredPermissions: ['CLIENT_MANAGE', 'EMPLOYEE_MANAGE_ALL', 'ADMIN'] },

--- a/src/app/core/layout/sidebar/sidebar.component.spec.ts
+++ b/src/app/core/layout/sidebar/sidebar.component.spec.ts
@@ -6,11 +6,13 @@ import { LucideIconComponent } from '../../../shared/icons/lucide-icon.component
 import { AuthService } from '../../services/auth.service';
 
 /**
- * PR_31 Task 6 specs.
+ * PR_31 Task 6 specs (azurirano W27b: usaglaseno sa redizajniranim NAV_MANIFEST).
  *
- * AuthService API stvarno koristi `getLoggedUser()` koji vraca
- * `{ email, permissions } | null`. Mock-ujemo samo tu metodu i menjamo joj povrat
- * po slucaju.
+ * `SidebarComponent` cita ulogovanog korisnika kroz `AuthService.getLoggedUser()`
+ * i gradi capability set kao `[...permissions, role]` (role string ide u set jer
+ * NAV_MANIFEST gate-uje Bankarstvo po roli 'CLIENT'/'CLIENT_TRADING', a Berza po
+ * 'SECURITIES_TRADE_*'/'TRADE_UNLIMITED'/'CLIENT_TRADING' permisijama). Mock-ujemo
+ * samo `getLoggedUser()` i menjamo joj povrat po slucaju.
  */
 describe('SidebarComponent', () => {
   let fixture: ComponentFixture<SidebarComponent>;
@@ -19,8 +21,10 @@ describe('SidebarComponent', () => {
 
   beforeEach(async () => {
     authMock = {
+      // Default: regularni klijent banke — role 'CLIENT' otkljucava Bankarstvo grupu.
       getLoggedUser: jasmine.createSpy('getLoggedUser').and.returnValue({
         email: 'client@banka.com',
+        role: 'CLIENT',
         permissions: ['BANKING_BASIC'],
       }),
     };
@@ -35,14 +39,14 @@ describe('SidebarComponent', () => {
     component = fixture.componentInstance;
   });
 
-  it('renders Bankarstvo group for client with BANKING_BASIC', () => {
+  it('renders Bankarstvo group for a client (role CLIENT)', () => {
     fixture.detectChanges();
     const html = (fixture.nativeElement as HTMLElement).innerHTML;
     expect(html).toContain('Bankarstvo');
     expect(html).toContain('Pocetna');
   });
 
-  it('hides Berza and Administracija groups when user has only BANKING_BASIC', () => {
+  it('hides Berza and Administracija groups for a plain client', () => {
     fixture.detectChanges();
     const html = (fixture.nativeElement as HTMLElement).innerHTML;
     expect(html).not.toContain('Berza');
@@ -57,13 +61,17 @@ describe('SidebarComponent', () => {
     expect(component.isActive('/exchange')).toBe(false);
   });
 
-  it('shows Berza group for actuary with SECURITIES_TRADE permission', () => {
+  it('shows Berza group for an actuary with SECURITIES_TRADE_UNLIMITED permission', () => {
+    // Aktuar agent: role 'AGENT' (nije u nijednoj nav listi -> Bankarstvo ostaje
+    // skriven) + 'SECURITIES_TRADE_UNLIMITED' permisija koja otkljucava Berza grupu.
     authMock.getLoggedUser.and.returnValue({
       email: 'agent@banka.com',
-      permissions: ['SECURITIES_TRADE'],
+      role: 'AGENT',
+      permissions: ['SECURITIES_TRADE_UNLIMITED'],
     });
     // Re-create da bi ngOnInit ponovo procitao permisije.
     fixture = TestBed.createComponent(SidebarComponent);
+    component = fixture.componentInstance;
     fixture.detectChanges();
     const html = (fixture.nativeElement as HTMLElement).innerHTML;
     expect(html).toContain('Berza');

--- a/src/app/core/layout/topbar/topbar.component.html
+++ b/src/app/core/layout/topbar/topbar.component.html
@@ -47,9 +47,90 @@
       </div>
     </div>
 
-    <button type="button" class="z-btn-icon" aria-label="Notifikacije">
-      <lucide-icon name="bell" [size]="16"></lucide-icon>
-    </button>
+    <div class="relative">
+      <button type="button" (click)="toggleNotificationsMenu()"
+              class="z-btn-icon relative"
+              aria-label="Notifikacije"
+              [attr.aria-expanded]="notificationsMenuOpen">
+        <lucide-icon name="bell" [size]="16"></lucide-icon>
+        <span *ngIf="(unreadCount$ | async) as unread"
+              class="absolute -top-1 -right-1 min-w-[16px] h-4 px-1 flex items-center justify-center rounded-full bg-destructive text-destructive-foreground text-[10px] font-bold leading-none"
+              [attr.aria-label]="unread + ' neprocitanih notifikacija'">
+          {{ unread > 99 ? '99+' : unread }}
+        </span>
+      </button>
+      <!-- Richer panel than the theme/avatar menus: it is a list of cards, not a
+           flat command menu. Same *ngIf open/close + closeMenus() pattern, but no
+           role="menu" — `menu`/`menuitem` forbids the header + <ul> structure. -->
+      <div *ngIf="notificationsMenuOpen"
+           class="absolute right-0 top-full mt-1 z-50 w-[340px] bg-card border border-border rounded-lg shadow-lg overflow-hidden">
+        <div class="flex items-center justify-between px-3 py-2 border-b border-border">
+          <span class="text-sm font-semibold text-foreground">Notifikacije</span>
+          <button type="button"
+                  (click)="markAllNotificationsRead()"
+                  class="text-xs text-primary hover:underline cursor-pointer border-0 bg-transparent">
+            Oznaci sve
+          </button>
+        </div>
+
+        <div *ngIf="notificationsLoading" class="px-3 py-6 text-center text-sm text-muted-foreground">
+          Ucitavanje...
+        </div>
+        <div *ngIf="!notificationsLoading && notificationsError"
+             class="px-3 py-6 text-center text-sm text-destructive">
+          Greska pri ucitavanju notifikacija.
+        </div>
+        <div *ngIf="!notificationsLoading && !notificationsError && notifications.length === 0"
+             class="px-3 py-6 text-center text-sm text-muted-foreground">
+          Nemate nijedno obavestenje.
+        </div>
+
+        <ul *ngIf="!notificationsLoading && !notificationsError && notifications.length > 0"
+            class="max-h-80 overflow-y-auto divide-y divide-border">
+          <li *ngFor="let n of notifications" [class.bg-accent]="!n.read">
+            <button type="button"
+                    (click)="markNotificationRead(n)"
+                    class="w-full text-left flex items-start gap-2 px-3 py-2 cursor-pointer hover:bg-accent/40 border-0 bg-transparent">
+              <span class="mt-1.5 h-2 w-2 flex-shrink-0 rounded-full"
+                    [class.bg-primary]="!n.read"
+                    [class.bg-transparent]="n.read"
+                    aria-hidden="true"></span>
+              <span class="min-w-0 flex-1">
+                <span class="block text-sm font-semibold truncate"
+                      [class.text-muted-foreground]="n.read">{{ n.title }}</span>
+                <span class="block text-xs text-muted-foreground line-clamp-2">{{ n.body }}</span>
+                <span class="block text-[10px] text-muted-foreground/70 mt-0.5">
+                  {{ n.createdAt | date: 'dd.MM.yyyy. HH:mm' }}
+                </span>
+              </span>
+            </button>
+          </li>
+        </ul>
+
+        <a routerLink="/notifications" (click)="closeMenus()"
+           class="block px-3 py-2 text-center text-sm text-primary hover:bg-accent/40 border-t border-border">
+          Prikazi sve
+        </a>
+      </div>
+    </div>
+
+    <!-- WP-22 (Celina 3): watchlist quick-access dropdown. Same *ngIf open/close
+         + closeMenus() pattern as the theme/notification/avatar menus. -->
+    <div class="relative">
+      <button type="button" (click)="toggleWatchlistMenu()"
+              class="z-btn-icon"
+              aria-label="Watchlist"
+              [attr.aria-expanded]="watchlistMenuOpen">
+        <lucide-icon name="star" [size]="16"></lucide-icon>
+      </button>
+      <div *ngIf="watchlistMenuOpen"
+           class="absolute right-0 top-full mt-1 z-50 w-[320px] bg-card border border-border rounded-lg shadow-lg overflow-hidden">
+        <app-watchlist-widget
+          [open]="watchlistMenuOpen"
+          (navigate)="closeMenus()">
+        </app-watchlist-widget>
+      </div>
+    </div>
 
     <div class="relative">
       <button type="button" (click)="toggleAvatarMenu()"

--- a/src/app/core/layout/topbar/topbar.component.spec.ts
+++ b/src/app/core/layout/topbar/topbar.component.spec.ts
@@ -1,15 +1,45 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { BehaviorSubject, of, throwError } from 'rxjs';
 import { TopbarComponent } from './topbar.component';
 import { LucideIconComponent } from '../../../shared/icons/lucide-icon.component';
 import { ThemeService } from '../../services/theme.service';
 import { AuthService } from '../../services/auth.service';
+import { NotificationService } from '../../services/notification.service';
+import { Notification, NotificationPage } from '../../models/notification.model';
+import { WatchlistWidgetComponent } from '../../../features/watchlist/components/watchlist-widget/watchlist-widget.component';
+import { WatchlistService } from '../../../features/watchlist/services/watchlist.service';
+
+function notif(id: number, read = false): Notification {
+  return {
+    id,
+    type: 'PAYMENT',
+    title: `Naslov ${id}`,
+    body: `Telo ${id}`,
+    read,
+    referenceId: null,
+    createdAt: '2026-05-19T10:00:00Z',
+  };
+}
+
+function page(content: Notification[]): NotificationPage {
+  return {
+    content,
+    totalElements: content.length,
+    totalPages: 1,
+    number: 0,
+    size: 8,
+  };
+}
 
 describe('TopbarComponent', () => {
   let fixture: ComponentFixture<TopbarComponent>;
   let component: TopbarComponent;
   let themeService: jasmine.SpyObj<ThemeService>;
   let authService: jasmine.SpyObj<AuthService>;
+  let notificationService: jasmine.SpyObj<NotificationService>;
+  let watchlistService: jasmine.SpyObj<WatchlistService>;
+  let unreadCount$: BehaviorSubject<number>;
 
   beforeEach(async () => {
     themeService = jasmine.createSpyObj('ThemeService', ['setTheme'], {
@@ -20,13 +50,31 @@ describe('TopbarComponent', () => {
       email: 'aleksa.mojovic@banka.com',
       permissions: [],
     });
+    unreadCount$ = new BehaviorSubject<number>(0);
+    notificationService = jasmine.createSpyObj(
+      'NotificationService',
+      ['list', 'markRead', 'markAllRead'],
+      { unreadCount$: unreadCount$.asObservable() },
+    );
+    notificationService.list.and.returnValue(of(page([])));
+    notificationService.markRead.and.returnValue(of(void 0));
+    notificationService.markAllRead.and.returnValue(of(void 0));
+
+    watchlistService = jasmine.createSpyObj('WatchlistService', [
+      'getWatchlists',
+      'getItems',
+    ]);
+    watchlistService.getWatchlists.and.returnValue(of([]));
+    watchlistService.getItems.and.returnValue(of([]));
 
     await TestBed.configureTestingModule({
       declarations: [TopbarComponent],
-      imports: [RouterTestingModule, LucideIconComponent],
+      imports: [RouterTestingModule, LucideIconComponent, WatchlistWidgetComponent],
       providers: [
         { provide: ThemeService, useValue: themeService },
         { provide: AuthService, useValue: authService },
+        { provide: NotificationService, useValue: notificationService },
+        { provide: WatchlistService, useValue: watchlistService },
       ],
     }).compileComponents();
 
@@ -130,12 +178,33 @@ describe('TopbarComponent', () => {
     expect(component.themeMenuOpen).toBe(false);
   });
 
-  it('closeMenus closes both menus', () => {
+  it('closeMenus closes every dropdown', () => {
     component.themeMenuOpen = true;
     component.avatarMenuOpen = true;
+    component.notificationsMenuOpen = true;
+    component.watchlistMenuOpen = true;
     component.closeMenus();
     expect(component.themeMenuOpen).toBe(false);
     expect(component.avatarMenuOpen).toBe(false);
+    expect(component.notificationsMenuOpen).toBe(false);
+    expect(component.watchlistMenuOpen).toBe(false);
+  });
+
+  it('toggleWatchlistMenu opens the panel and closes the other menus', () => {
+    component.themeMenuOpen = true;
+    component.avatarMenuOpen = true;
+    component.notificationsMenuOpen = true;
+    component.toggleWatchlistMenu();
+    expect(component.watchlistMenuOpen).toBe(true);
+    expect(component.themeMenuOpen).toBe(false);
+    expect(component.avatarMenuOpen).toBe(false);
+    expect(component.notificationsMenuOpen).toBe(false);
+  });
+
+  it('toggleWatchlistMenu closes the panel on a second click', () => {
+    component.toggleWatchlistMenu();
+    component.toggleWatchlistMenu();
+    expect(component.watchlistMenuOpen).toBe(false);
   });
 
   it('logout calls AuthService.logout (which itself redirects to /login)', () => {
@@ -148,5 +217,69 @@ describe('TopbarComponent', () => {
     fixture.detectChanges();
     /* RouterTestingModule starts at '/'; split('/').filter(Boolean) -> []. */
     expect(component.breadcrumb).toEqual([]);
+  });
+
+  describe('notifications dropdown', () => {
+    it('exposes the service unread-count stream', (done) => {
+      unreadCount$.next(4);
+      component.unreadCount$.subscribe((c) => {
+        expect(c).toBe(4);
+        done();
+      });
+    });
+
+    it('toggleNotificationsMenu opens the panel and loads a preview', () => {
+      notificationService.list.and.returnValue(of(page([notif(1), notif(2)])));
+      component.toggleNotificationsMenu();
+      expect(component.notificationsMenuOpen).toBe(true);
+      expect(notificationService.list).toHaveBeenCalledWith(0, 8);
+      expect(component.notifications.length).toBe(2);
+      expect(component.notificationsLoading).toBe(false);
+    });
+
+    it('toggleNotificationsMenu closes theme/avatar menus when opening', () => {
+      component.themeMenuOpen = true;
+      component.avatarMenuOpen = true;
+      component.toggleNotificationsMenu();
+      expect(component.notificationsMenuOpen).toBe(true);
+      expect(component.themeMenuOpen).toBe(false);
+      expect(component.avatarMenuOpen).toBe(false);
+    });
+
+    it('toggleNotificationsMenu closing again does not refetch', () => {
+      component.toggleNotificationsMenu(); // open -> 1 list call
+      notificationService.list.calls.reset();
+      component.toggleNotificationsMenu(); // close -> no call
+      expect(component.notificationsMenuOpen).toBe(false);
+      expect(notificationService.list).not.toHaveBeenCalled();
+    });
+
+    it('loadNotificationPreview sets the error flag on failure', () => {
+      notificationService.list.and.returnValue(
+        throwError(() => new Error('down')),
+      );
+      component.loadNotificationPreview();
+      expect(component.notificationsError).toBe(true);
+      expect(component.notificationsLoading).toBe(false);
+    });
+
+    it('markNotificationRead flips an unread notification locally', () => {
+      const n = notif(1);
+      component.markNotificationRead(n);
+      expect(notificationService.markRead).toHaveBeenCalledWith(1);
+      expect(n.read).toBe(true);
+    });
+
+    it('markNotificationRead is a no-op for an already-read notification', () => {
+      component.markNotificationRead(notif(1, true));
+      expect(notificationService.markRead).not.toHaveBeenCalled();
+    });
+
+    it('markAllNotificationsRead flips every loaded notification', () => {
+      component.notifications = [notif(1), notif(2), notif(3, true)];
+      component.markAllNotificationsRead();
+      expect(notificationService.markAllRead).toHaveBeenCalled();
+      expect(component.notifications.every((n) => n.read)).toBe(true);
+    });
   });
 });

--- a/src/app/core/layout/topbar/topbar.component.ts
+++ b/src/app/core/layout/topbar/topbar.component.ts
@@ -1,10 +1,15 @@
 import { Component, HostListener, OnDestroy, OnInit } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
-import { Subscription } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
 import { AuthService } from '../../services/auth.service';
 import { Theme, ThemeService } from '../../services/theme.service';
+import { NotificationService } from '../../services/notification.service';
+import { Notification } from '../../models/notification.model';
+
+/** How many notifications the bell dropdown preview shows. */
+const NOTIFICATION_PREVIEW_SIZE = 8;
 
 type ThemeIcon = 'sun' | 'moon' | 'monitor';
 
@@ -48,16 +53,29 @@ export class TopbarComponent implements OnInit, OnDestroy {
   breadcrumb: string[] = [];
   themeMenuOpen = false;
   avatarMenuOpen = false;
+  notificationsMenuOpen = false;
+  /** WP-22 (Celina 3): watchlist quick-access dropdown open flag. */
+  watchlistMenuOpen = false;
   userInitials = '';
   private sub?: Subscription;
 
   readonly themes: Theme[] = ['system', 'light', 'dark'];
 
+  /** Live unread-count for the bell badge (hidden when 0). */
+  readonly unreadCount$: Observable<number>;
+  /** Latest few notifications shown inside the bell dropdown. */
+  notifications: Notification[] = [];
+  notificationsLoading = false;
+  notificationsError = false;
+
   constructor(
     public theme: ThemeService,
     private auth: AuthService,
     private router: Router,
-  ) {}
+    private notificationService: NotificationService,
+  ) {
+    this.unreadCount$ = this.notificationService.unreadCount$;
+  }
 
   ngOnInit(): void {
     this.refreshBreadcrumb(this.router.url);
@@ -94,9 +112,69 @@ export class TopbarComponent implements OnInit, OnDestroy {
     this.avatarMenuOpen = next;
   }
 
+  toggleNotificationsMenu(): void {
+    const next = !this.notificationsMenuOpen;
+    this.closeMenus();
+    this.notificationsMenuOpen = next;
+    /* Lazily fetch the preview each time the panel opens so it is fresh. */
+    if (this.notificationsMenuOpen) {
+      this.loadNotificationPreview();
+    }
+  }
+
+  /**
+   * WP-22 (Celina 3): toggles the watchlist quick-access dropdown.
+   * The {@link WatchlistWidgetComponent} fetches lazily off its `open` input.
+   */
+  toggleWatchlistMenu(): void {
+    const next = !this.watchlistMenuOpen;
+    this.closeMenus();
+    this.watchlistMenuOpen = next;
+  }
+
   closeMenus(): void {
     this.themeMenuOpen = false;
     this.avatarMenuOpen = false;
+    this.notificationsMenuOpen = false;
+    this.watchlistMenuOpen = false;
+  }
+
+  /** Fetches the latest few notifications for the dropdown preview. */
+  loadNotificationPreview(): void {
+    this.notificationsLoading = true;
+    this.notificationsError = false;
+    this.notificationService.list(0, NOTIFICATION_PREVIEW_SIZE).subscribe({
+      next: (page) => {
+        this.notifications = page?.content ?? [];
+        this.notificationsLoading = false;
+      },
+      error: () => {
+        this.notificationsLoading = false;
+        this.notificationsError = true;
+      },
+    });
+  }
+
+  /** Marks one notification read from the dropdown and flips it locally. */
+  markNotificationRead(n: Notification): void {
+    if (n.read) {
+      return;
+    }
+    this.notificationService.markRead(n.id).subscribe({
+      next: () => {
+        n.read = true;
+      },
+      /* Silent: the dropdown is a peripheral surface, no toast noise. */
+      error: () => undefined,
+    });
+  }
+
+  /** Marks every notification read from the dropdown. */
+  markAllNotificationsRead(): void {
+    this.notificationService.markAllRead().subscribe({
+      next: () => this.notifications.forEach((n) => (n.read = true)),
+      error: () => undefined,
+    });
   }
 
   logout(): void {

--- a/src/app/core/models/notification.model.ts
+++ b/src/app/core/models/notification.model.ts
@@ -1,0 +1,41 @@
+/**
+ * WP-21 (Celina 2): in-app notification model.
+ *
+ * Mirrors {@code InAppNotificationDto} returned by `notification-service`
+ * (routed through the gateway at `/notifications`). The backend feed is
+ * scoped to the authenticated caller and ordered newest-first.
+ */
+export interface Notification {
+  id: number;
+  /** Domain category, e.g. `PAYMENT`, `CARD`, `LOAN`, `SECURITY` (free-form). */
+  type: string;
+  title: string;
+  body: string;
+  /** Whether the caller has already read this notification. */
+  read: boolean;
+  /**
+   * Optional id of the domain entity this notification refers to
+   * (e.g. a transaction / loan id). `null` when not applicable.
+   */
+  referenceId: number | null;
+  /** ISO-8601 timestamp string assigned by the backend. */
+  createdAt: string;
+}
+
+/**
+ * Spring Data `Page` envelope as returned by `GET /notifications`.
+ * Only the fields the UI consumes are typed.
+ */
+export interface NotificationPage {
+  content: Notification[];
+  totalElements: number;
+  totalPages: number;
+  /** 0-indexed page number. */
+  number: number;
+  size: number;
+}
+
+/** Shape of `GET /notifications/unread-count`. */
+export interface UnreadCountResponse {
+  count: number;
+}

--- a/src/app/core/services/notification.service.spec.ts
+++ b/src/app/core/services/notification.service.spec.ts
@@ -1,0 +1,262 @@
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+
+import { environment } from 'src/environments/environment';
+import { NotificationService, UNREAD_POLL_INTERVAL_MS } from './notification.service';
+import { Notification, NotificationPage } from '../models/notification.model';
+
+const baseUrl = `${environment.apiUrl}/notifications`;
+const countUrl = `${baseUrl}/unread-count`;
+
+function notif(id: number, read = false): Notification {
+  return {
+    id,
+    type: 'PAYMENT',
+    title: `Naslov ${id}`,
+    body: `Telo ${id}`,
+    read,
+    referenceId: null,
+    createdAt: '2026-05-19T10:00:00Z',
+  };
+}
+
+function page(content: Notification[], totalElements = content.length): NotificationPage {
+  return {
+    content,
+    totalElements,
+    totalPages: Math.max(1, Math.ceil(totalElements / 10)),
+    number: 0,
+    size: 10,
+  };
+}
+
+/**
+ * The service constructor schedules `timer(0, ...)` for the unread-count poll.
+ * To keep that timer inside the fakeAsync test zone (so `tick` controls it),
+ * the service must be injected *inside* the test rather than in `beforeEach`.
+ */
+describe('NotificationService', () => {
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [NotificationService],
+    });
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    /* Every test flushes its own requests and destroys the service; this
+       catches any leak (e.g. an un-ticked poll). */
+    httpMock.verify();
+  });
+
+  function makeService(): NotificationService {
+    return TestBed.inject(NotificationService);
+  }
+
+  describe('list', () => {
+    it('GETs the paged feed with page/size params', fakeAsync(() => {
+      const service = makeService();
+      tick(0); // flush the constructor poll
+      httpMock.expectOne(countUrl).flush({ count: 0 });
+
+      let result: NotificationPage | undefined;
+      service.list(2, 8).subscribe((p) => (result = p));
+
+      const req = httpMock.expectOne(
+        (r) => r.url === baseUrl && r.method === 'GET',
+      );
+      expect(req.request.params.get('page')).toBe('2');
+      expect(req.request.params.get('size')).toBe('8');
+
+      const body = page([notif(1), notif(2)], 12);
+      req.flush(body);
+      expect(result).toEqual(body);
+
+      service.ngOnDestroy();
+    }));
+
+    it('defaults to page 0 size 10', fakeAsync(() => {
+      const service = makeService();
+      tick(0);
+      httpMock.expectOne(countUrl).flush({ count: 0 });
+
+      service.list().subscribe();
+      const req = httpMock.expectOne((r) => r.url === baseUrl);
+      expect(req.request.params.get('page')).toBe('0');
+      expect(req.request.params.get('size')).toBe('10');
+      req.flush(page([]));
+
+      service.ngOnDestroy();
+    }));
+  });
+
+  describe('unreadCount', () => {
+    it('GETs /unread-count and unwraps the count number', fakeAsync(() => {
+      const service = makeService();
+      tick(0);
+      httpMock.expectOne(countUrl).flush({ count: 0 }); // constructor poll
+
+      let count: number | undefined;
+      service.unreadCount().subscribe((c) => (count = c));
+
+      const req = httpMock.expectOne(countUrl);
+      expect(req.request.method).toBe('GET');
+      req.flush({ count: 7 });
+      expect(count).toBe(7);
+
+      service.ngOnDestroy();
+    }));
+
+    it('treats a missing count as 0', fakeAsync(() => {
+      const service = makeService();
+      tick(0);
+      httpMock.expectOne(countUrl).flush({ count: 0 });
+
+      let count: number | undefined;
+      service.unreadCount().subscribe((c) => (count = c));
+      httpMock.expectOne(countUrl).flush({});
+      expect(count).toBe(0);
+
+      service.ngOnDestroy();
+    }));
+  });
+
+  describe('markRead', () => {
+    it('PATCHes /{id}/read and refreshes the unread count', fakeAsync(() => {
+      const service = makeService();
+      tick(0);
+      httpMock.expectOne(countUrl).flush({ count: 0 }); // constructor poll
+
+      service.markRead(42).subscribe();
+
+      const req = httpMock.expectOne(`${baseUrl}/42/read`);
+      expect(req.request.method).toBe('PATCH');
+      req.flush(null);
+
+      /* mark-read triggers a follow-up unread-count refresh. */
+      httpMock.expectOne(countUrl).flush({ count: 3 });
+
+      service.ngOnDestroy();
+    }));
+  });
+
+  describe('markAllRead', () => {
+    it('PATCHes /read-all and refreshes the unread count', fakeAsync(() => {
+      const service = makeService();
+      tick(0);
+      httpMock.expectOne(countUrl).flush({ count: 0 }); // constructor poll
+
+      service.markAllRead().subscribe();
+
+      const req = httpMock.expectOne(`${baseUrl}/read-all`);
+      expect(req.request.method).toBe('PATCH');
+      req.flush(null);
+
+      httpMock.expectOne(countUrl).flush({ count: 0 });
+
+      service.ngOnDestroy();
+    }));
+  });
+
+  describe('unreadCount$ stream', () => {
+    it('starts at 0 before the first poll resolves', fakeAsync(() => {
+      const service = makeService();
+      let emitted: number | undefined;
+      service.unreadCount$.subscribe((c) => (emitted = c));
+      expect(emitted).toBe(0);
+
+      tick(0);
+      httpMock.expectOne(countUrl).flush({ count: 0 });
+      service.ngOnDestroy();
+    }));
+
+    it('the immediate constructor poll pushes the server value', fakeAsync(() => {
+      const service = makeService();
+      const seen: number[] = [];
+      service.unreadCount$.subscribe((c) => seen.push(c));
+
+      tick(0);
+      httpMock.expectOne(countUrl).flush({ count: 5 });
+      expect(seen[seen.length - 1]).toBe(5);
+
+      service.ngOnDestroy();
+    }));
+
+    it('refreshUnreadCount() pushes the latest server value', fakeAsync(() => {
+      const service = makeService();
+      const seen: number[] = [];
+      service.unreadCount$.subscribe((c) => seen.push(c));
+
+      tick(0);
+      httpMock.expectOne(countUrl).flush({ count: 5 });
+      expect(seen[seen.length - 1]).toBe(5);
+
+      service.refreshUnreadCount();
+      httpMock.expectOne(countUrl).flush({ count: 9 });
+      expect(seen[seen.length - 1]).toBe(9);
+
+      service.ngOnDestroy();
+    }));
+
+    it('polls the unread count on the interval', fakeAsync(() => {
+      const service = makeService();
+      const seen: number[] = [];
+      service.unreadCount$.subscribe((c) => seen.push(c));
+
+      tick(0); // immediate poll
+      httpMock.expectOne(countUrl).flush({ count: 1 });
+
+      tick(UNREAD_POLL_INTERVAL_MS);
+      httpMock.expectOne(countUrl).flush({ count: 2 });
+      expect(seen[seen.length - 1]).toBe(2);
+
+      tick(UNREAD_POLL_INTERVAL_MS);
+      httpMock.expectOne(countUrl).flush({ count: 4 });
+      expect(seen[seen.length - 1]).toBe(4);
+
+      service.ngOnDestroy();
+    }));
+
+    it('keeps the last good value when a poll fails', fakeAsync(() => {
+      const service = makeService();
+      const seen: number[] = [];
+      service.unreadCount$.subscribe((c) => seen.push(c));
+
+      tick(0);
+      httpMock.expectOne(countUrl).flush({ count: 6 });
+      expect(seen[seen.length - 1]).toBe(6);
+
+      tick(UNREAD_POLL_INTERVAL_MS);
+      httpMock
+        .expectOne(countUrl)
+        .flush('boom', { status: 500, statusText: 'Server Error' });
+      /* failed poll must not crash the stream nor change the value */
+      expect(seen[seen.length - 1]).toBe(6);
+
+      tick(UNREAD_POLL_INTERVAL_MS);
+      httpMock.expectOne(countUrl).flush({ count: 8 });
+      expect(seen[seen.length - 1]).toBe(8);
+
+      service.ngOnDestroy();
+    }));
+
+    it('stops polling after ngOnDestroy', fakeAsync(() => {
+      const service = makeService();
+      service.unreadCount$.subscribe();
+
+      tick(0);
+      httpMock.expectOne(countUrl).flush({ count: 1 });
+
+      service.ngOnDestroy();
+      tick(UNREAD_POLL_INTERVAL_MS * 2);
+      /* no further poll requests after destroy */
+      httpMock.expectNone(countUrl);
+    }));
+  });
+});

--- a/src/app/core/services/notification.service.ts
+++ b/src/app/core/services/notification.service.ts
@@ -1,0 +1,105 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable, OnDestroy } from '@angular/core';
+import { BehaviorSubject, EMPTY, Observable, Subscription, timer } from 'rxjs';
+import { catchError, map, tap } from 'rxjs/operators';
+
+import { environment } from 'src/environments/environment';
+import {
+  Notification,
+  NotificationPage,
+  UnreadCountResponse,
+} from '../models/notification.model';
+
+/**
+ * Poll cadence for the unread-count badge. Exported so specs can drive the
+ * fake timer deterministically. There is no WebSocket/SSE channel — polling
+ * is the only realtime option available.
+ */
+export const UNREAD_POLL_INTERVAL_MS = 60_000;
+
+/**
+ * WP-21 (Celina 2): in-app notification feed client.
+ *
+ * <p>Wraps the JWT-secured `notification-service` endpoints exposed through
+ * the gateway at `/notifications`. The {@link AuthInterceptor} attaches the
+ * `Authorization` header automatically — callers never set it.
+ *
+ * <p>{@link unreadCount$} is a hot {@link BehaviorSubject} stream that the
+ * topbar bell badge binds to. It is refreshed:
+ *   - immediately on construction,
+ *   - every {@link UNREAD_POLL_INTERVAL_MS} ms via a `timer` poll,
+ *   - eagerly after any `markRead` / `markAllRead` action.
+ * A failed poll is swallowed and the last known value is retained, so a
+ * transient backend hiccup never breaks the stream.
+ */
+@Injectable({ providedIn: 'root' })
+export class NotificationService implements OnDestroy {
+  private readonly baseUrl = `${environment.apiUrl}/notifications`;
+
+  private readonly unreadCountSubject = new BehaviorSubject<number>(0);
+  /** Latest unread-notification count (starts at 0). */
+  readonly unreadCount$: Observable<number> = this.unreadCountSubject.asObservable();
+
+  private readonly pollSub: Subscription;
+
+  constructor(private readonly http: HttpClient) {
+    /* timer(0, period) fires immediately then on every interval. */
+    this.pollSub = timer(0, UNREAD_POLL_INTERVAL_MS).subscribe(() =>
+      this.refreshUnreadCount(),
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.pollSub.unsubscribe();
+  }
+
+  /**
+   * Fetches one page of the caller's notification feed, newest first.
+   * @param page 0-indexed page number.
+   * @param size page size.
+   */
+  list(page = 0, size = 10): Observable<NotificationPage> {
+    const params = new HttpParams()
+      .set('page', String(page))
+      .set('size', String(size));
+    return this.http.get<NotificationPage>(this.baseUrl, { params });
+  }
+
+  /** One-shot fetch of the current unread count. */
+  unreadCount(): Observable<number> {
+    return this.http
+      .get<UnreadCountResponse>(`${this.baseUrl}/unread-count`)
+      .pipe(map((res) => res?.count ?? 0));
+  }
+
+  /**
+   * Marks a single notification as read, then refreshes {@link unreadCount$}.
+   * The refresh is wired with `tap` so it fires for every subscriber exactly
+   * once the PATCH succeeds.
+   */
+  markRead(id: number): Observable<void> {
+    return this.http
+      .patch<void>(`${this.baseUrl}/${id}/read`, {})
+      .pipe(tap(() => this.refreshUnreadCount()));
+  }
+
+  /**
+   * Marks every notification of the caller as read, then refreshes
+   * {@link unreadCount$}.
+   */
+  markAllRead(): Observable<void> {
+    return this.http
+      .patch<void>(`${this.baseUrl}/read-all`, {})
+      .pipe(tap(() => this.refreshUnreadCount()));
+  }
+
+  /**
+   * Re-fetches the unread count and pushes it onto {@link unreadCount$}.
+   * Failures are swallowed — the previous value is kept.
+   */
+  refreshUnreadCount(): void {
+    this.unreadCount()
+      .pipe(catchError(() => EMPTY))
+      .subscribe((count) => this.unreadCountSubject.next(count));
+  }
+}

--- a/src/app/features/auth/components/login/login.component.ts
+++ b/src/app/features/auth/components/login/login.component.ts
@@ -85,14 +85,19 @@ export class LoginComponent {
   /**
    * Mapira HTTP gresku na spec-tacnu poruku iz TestoviCelina1 (Sc 2 i Sc 3):
    * "Korisnik ne postoji" za 404 / USER_NOT_FOUND, "Neispravni unos" za pogresan password.
+   * Brute-force lockout (Celina 1): backend (WP-5) vraca ErrorCode ACCOUNT_LOCKED uz
+   * HTTP 403 posle 5 uzastopnih neuspesnih pokusaja — prikazujemo jasnu poruku sa
+   * uputstvom da se sacuva ili resetuje lozinka. Lockout grana se proverava PRE
+   * generickog 403 -> "Neispravni unos" mapiranja.
    * Ostale greske vracaju backend message ili generican fallback.
    */
   private mapLoginError(error: HttpErrorResponse): string {
     const code = (error.error?.code ?? error.error?.error ?? '').toString().toUpperCase();
     const status = error.status;
-    const lockoutHints = ['USER_LOCKED', 'ACCOUNT_LOCKED', 'TOO_MANY_ATTEMPTS'];
+    const lockoutHints = ['ACCOUNT_LOCKED', 'USER_LOCKED', 'TOO_MANY_ATTEMPTS'];
     if (lockoutHints.includes(code)) {
-      return 'Nalog je privremeno zaključan zbog previše neuspešnih pokušaja.';
+      return 'Nalog je privremeno zaključan zbog više neuspešnih pokušaja. ' +
+        'Pokušajte ponovo kasnije ili resetujte lozinku.';
     }
     if (code === 'USER_NOT_FOUND' || status === 404) {
       return 'Korisnik ne postoji';

--- a/src/app/features/client/components/client-detail/client-detail.component.html
+++ b/src/app/features/client/components/client-detail/client-detail.component.html
@@ -29,12 +29,15 @@
           <div>
             <label class="z-label">Email</label>
             <input type="email" formControlName="email" class="z-input" [class.border-red-500]="clientForm.get('email')?.invalid && clientForm.get('email')?.touched" />
-            <p *ngIf="clientForm.get('email')?.hasError('email') && clientForm.get('email')?.touched" class="text-xs text-red-500 mt-1">Unesite validan email.</p>
+            <p *ngIf="clientForm.get('email')?.touched && clientForm.get('email')?.errors?.['required']" class="text-xs text-red-500 mt-1">Email je obavezan.</p>
+            <p *ngIf="clientForm.get('email')?.touched && clientForm.get('email')?.errors?.['emailFormat']" class="text-xs text-red-500 mt-1">Unesite validan email (npr. ime@banka.rs).</p>
             <p *ngIf="backendEmailError" class="text-xs text-red-500 mt-1">{{ backendEmailError }}</p>
           </div>
           <div>
-            <label class="z-label">Broj telefona</label>
-            <input type="text" formControlName="brojTelefona" class="z-input" />
+            <label for="client-brojTelefona" class="z-label">Broj telefona</label>
+            <input id="client-brojTelefona" type="text" formControlName="brojTelefona" class="z-input" [class.border-red-500]="clientForm.get('brojTelefona')?.invalid && clientForm.get('brojTelefona')?.touched" />
+            <p *ngIf="clientForm.get('brojTelefona')?.touched && clientForm.get('brojTelefona')?.errors?.['required']" class="text-xs text-red-500 mt-1">Broj telefona je obavezan.</p>
+            <p *ngIf="clientForm.get('brojTelefona')?.touched && clientForm.get('brojTelefona')?.errors?.['phoneFormat']" class="text-xs text-red-500 mt-1">Broj telefona sme sadržati samo cifre i znak "+" na početku (8–15 cifara).</p>
           </div>
           <div class="md:col-span-2">
             <label class="z-label">Adresa</label>

--- a/src/app/features/client/components/client-detail/client-detail.component.ts
+++ b/src/app/features/client/components/client-detail/client-detail.component.ts
@@ -5,6 +5,7 @@ import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { ClientDto, ClientService } from '../../services/client.service';
 // PR_31 T11: shared StateComponent za loading/empty/error markup.
 import { StateComponent } from '../../../../shared/components/state/state.component';
+import { emailFormatValidator, phoneNumberValidator } from '../../../../shared/utils/validators';
 @Component({
   selector: 'app-client-detail',
   templateUrl: './client-detail.component.html',
@@ -28,8 +29,8 @@ export class ClientDetailComponent implements OnInit {
     this.clientForm = this.fb.group({
       ime: ['', Validators.required],
       prezime: ['', Validators.required],
-      email: ['', [Validators.required, Validators.email]],
-      brojTelefona: ['', Validators.required],
+      email: ['', [Validators.required, emailFormatValidator]],
+      brojTelefona: ['', [Validators.required, phoneNumberValidator]],
       adresa: ['', Validators.required],
     });
   }

--- a/src/app/features/client/components/portfolio/portfolio.component.html
+++ b/src/app/features/client/components/portfolio/portfolio.component.html
@@ -110,7 +110,8 @@
               </tr>
             </thead>
             <tbody>
-              <tr *ngFor="let holding of holdings; let i = index; trackBy: trackByHolding">
+              <ng-container *ngFor="let holding of holdings; let i = index; trackBy: trackByHolding">
+              <tr>
                 <td>
                   <span class="z-badge" [ngClass]="{
                     'z-badge-green': holding.listingType === 'STOCK',
@@ -132,6 +133,17 @@
                   <div class="flex flex-col gap-3 items-start min-w-[260px]">
                     <button type="button" class="z-btn-outline z-btn-sm" (click)="onSell(holding)">
                       Prodaj
+                    </button>
+
+                    <!-- WP-24: istorija primljenih dividendi za ovu poziciju (akcije). -->
+                    <button
+                      *ngIf="isStock(holding)"
+                      type="button"
+                      class="z-btn-secondary z-btn-sm"
+                      [attr.aria-expanded]="isDividendRowExpanded(holding)"
+                      (click)="toggleDividends(holding)"
+                    >
+                      {{ isDividendRowExpanded(holding) ? 'Sakrij dividende' : 'Dividende' }}
                     </button>
 
                     <div *ngIf="isStock(holding)" class="w-full rounded-lg border border-border bg-muted/20 p-3">
@@ -186,6 +198,80 @@
                   </div>
                 </td>
               </tr>
+
+              <!-- WP-24: panel sa istorijom dividendi — vidljiv kad je red razvijen. -->
+              <tr *ngIf="isStock(holding) && isDividendRowExpanded(holding)" class="dividend-detail-row">
+                <td colspan="7" class="bg-muted/20">
+                  <div class="p-4">
+                    <div class="flex items-center justify-between mb-3 gap-3 flex-wrap">
+                      <p class="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
+                        Primljene dividende — {{ holding.ticker }}
+                      </p>
+                      <span
+                        *ngIf="!dividendsLoading[holding.listingId] && !dividendsError[holding.listingId]
+                               && (dividendsByListing[holding.listingId]?.length ?? 0) > 0"
+                        class="z-badge z-badge-green"
+                      >
+                        Ukupno neto: {{ formatAmount(getDividendTotal(holding.listingId)) }} RSD
+                      </span>
+                    </div>
+
+                    <app-state
+                      *ngIf="dividendsLoading[holding.listingId]"
+                      mode="loading"
+                      text="Ucitavanje dividendi..."
+                    ></app-state>
+
+                    <app-state
+                      *ngIf="dividendsError[holding.listingId]"
+                      mode="error"
+                      text="Greška pri učitavanju dividendi."
+                    ></app-state>
+
+                    <ng-container
+                      *ngIf="!dividendsLoading[holding.listingId] && !dividendsError[holding.listingId]"
+                    >
+                      <app-state
+                        *ngIf="(dividendsByListing[holding.listingId]?.length ?? 0) === 0"
+                        mode="empty"
+                        title="Nema dividendi"
+                        text="Za ovu poziciju nije primljena nijedna dividenda."
+                      ></app-state>
+
+                      <div
+                        *ngIf="(dividendsByListing[holding.listingId]?.length ?? 0) > 0"
+                        class="overflow-x-auto rounded-xl border border-border bg-card"
+                      >
+                        <table class="z-table min-w-[640px]">
+                          <thead>
+                            <tr>
+                              <th>Datum isplate</th>
+                              <th class="text-right">Količina</th>
+                              <th class="text-right">Bruto iznos</th>
+                              <th class="text-right">Porez (RSD)</th>
+                              <th class="text-right">Neto iznos</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr *ngFor="let payout of dividendsByListing[holding.listingId]">
+                              <td class="whitespace-nowrap">{{ formatDate(payout.paymentDate) }}</td>
+                              <td class="text-right">{{ formatAmount(payout.quantity, 0) }}</td>
+                              <td class="text-right whitespace-nowrap">
+                                {{ formatAmount(payout.grossAmount) }} {{ payout.currency }}
+                              </td>
+                              <td class="text-right whitespace-nowrap">{{ formatAmount(payout.taxAmountRsd) }}</td>
+                              <td class="text-right font-semibold whitespace-nowrap">
+                                {{ formatAmount(payout.netAmount) }} {{ payout.currency }}
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </div>
+                    </ng-container>
+                  </div>
+                </td>
+              </tr>
+              </ng-container>
             </tbody>
           </table>
         </div>

--- a/src/app/features/client/components/portfolio/portfolio.component.spec.ts
+++ b/src/app/features/client/components/portfolio/portfolio.component.spec.ts
@@ -1,10 +1,14 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { of, throwError } from 'rxjs';
 import { PortfolioComponent } from './portfolio.component';
 import { PortfolioService } from '../../services/portfolio.service';
 import { AuthService } from '../../../../core/services/auth.service';
 import { ToastService } from '../../../../shared/services/toast.service';
+import { FundService } from '../../../funds/services/fund.service';
 import { PortfolioSummary } from '../../models/portfolio.model';
+import { DividendPayout } from '../../models/dividend.model';
 
 describe('PortfolioComponent', () => {
   let component: PortfolioComponent;
@@ -12,6 +16,7 @@ describe('PortfolioComponent', () => {
   let portfolioServiceSpy: jasmine.SpyObj<PortfolioService>;
   let authServiceSpy: jasmine.SpyObj<AuthService>;
   let toastServiceSpy: jasmine.SpyObj<ToastService>;
+  let fundServiceSpy: jasmine.SpyObj<FundService>;
 
   // PR_31 follow-up: deklarisi kao funkciju koja vraca svez deep-clone, jer testovi mutiraju
   // holding.publicQuantity na ovom objektu — bez clone-a tests dele state preko beforeEach.
@@ -49,36 +54,76 @@ describe('PortfolioComponent', () => {
     monthlyTaxDue: 300,
   }));
 
+  const buildDividends = (): DividendPayout[] => [
+    {
+      id: 1,
+      userId: 7,
+      stockTicker: 'AAPL',
+      listingId: 101,
+      quantity: 10,
+      grossAmount: 24,
+      currency: 'USD',
+      taxAmountRsd: 282,
+      netAmount: 21.6,
+      accountId: 55,
+      paymentDate: '2026-03-15T00:00:00',
+      forBank: false,
+    },
+    {
+      id: 2,
+      userId: 7,
+      stockTicker: 'AAPL',
+      listingId: 101,
+      quantity: 10,
+      grossAmount: 25,
+      currency: 'USD',
+      taxAmountRsd: 294,
+      netAmount: 22.5,
+      accountId: 55,
+      paymentDate: '2026-04-15T00:00:00',
+      forBank: false,
+    },
+  ];
+
   beforeEach(() => {
     portfolioServiceSpy = jasmine.createSpyObj<PortfolioService>(
       'PortfolioService',
-      ['getPortfolio', 'setPublicQuantity', 'exerciseOption'],
+      ['getPortfolio', 'setPublicQuantity', 'exerciseOption', 'getDividends'],
     );
     authServiceSpy = jasmine.createSpyObj<AuthService>(
       'AuthService',
-      ['isActuary', 'getLoggedUser', 'isClient', 'canAccessPortfolio', 'logout'],
+      ['isActuary', 'getLoggedUser', 'isClient', 'canAccessPortfolio', 'logout', 'hasPermission'],
     );
     toastServiceSpy = jasmine.createSpyObj<ToastService>('ToastService', [
       'success',
       'error',
       'info',
     ]);
+    fundServiceSpy = jasmine.createSpyObj<FundService>('FundService', [
+      'supervised',
+      'myPositions',
+    ]);
 
     portfolioServiceSpy.getPortfolio.and.returnValue(of(buildPortfolioSummary()));
+    portfolioServiceSpy.getDividends.and.returnValue(of(buildDividends()));
     authServiceSpy.isActuary.and.returnValue(true);
+    authServiceSpy.hasPermission.and.returnValue(false);
     authServiceSpy.getLoggedUser.and.returnValue({
       email: 'test@test.com',
       permissions: [],
     });
     authServiceSpy.isClient.and.returnValue(true);
     authServiceSpy.canAccessPortfolio.and.returnValue(true);
+    fundServiceSpy.myPositions.and.returnValue(of([]));
+    fundServiceSpy.supervised.and.returnValue(of([]));
 
     TestBed.configureTestingModule({
-      imports: [PortfolioComponent],
+      imports: [PortfolioComponent, HttpClientTestingModule, RouterTestingModule],
       providers: [
         { provide: PortfolioService, useValue: portfolioServiceSpy },
         { provide: AuthService, useValue: authServiceSpy },
         { provide: ToastService, useValue: toastServiceSpy },
+        { provide: FundService, useValue: fundServiceSpy },
       ],
     });
 
@@ -145,5 +190,92 @@ describe('PortfolioComponent', () => {
     expect(component.exercisingOption['MSFT220C-OPTION-1']).toBeFalse();
     expect(console.error).toHaveBeenCalled();
     expect(toastServiceSpy.error).toHaveBeenCalled();
+  });
+
+  // WP-24: dividend-history section.
+  describe('dividend history', () => {
+    it('should lazy-load dividends for a position when its row is first expanded', () => {
+      const holding = component.holdings[0];
+
+      component.toggleDividends(holding);
+
+      expect(component.expandedDividendListingId).toBe(101);
+      expect(portfolioServiceSpy.getDividends).toHaveBeenCalledWith(101);
+      expect(component.dividendsByListing[101].length).toBe(2);
+      expect(component.dividendsLoading[101]).toBeFalse();
+      expect(component.dividendsError[101]).toBeFalse();
+    });
+
+    it('should collapse the row on a second toggle without re-fetching', () => {
+      const holding = component.holdings[0];
+
+      component.toggleDividends(holding);
+      component.toggleDividends(holding);
+
+      expect(component.expandedDividendListingId).toBeNull();
+      expect(portfolioServiceSpy.getDividends).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not re-fetch cached dividends when the row is expanded again', () => {
+      const holding = component.holdings[0];
+
+      component.toggleDividends(holding); // open + fetch
+      component.toggleDividends(holding); // close
+      component.toggleDividends(holding); // re-open, served from cache
+
+      expect(component.expandedDividendListingId).toBe(101);
+      expect(portfolioServiceSpy.getDividends).toHaveBeenCalledTimes(1);
+    });
+
+    it('should flag an error when the dividend fetch fails', () => {
+      portfolioServiceSpy.getDividends.and.returnValue(
+        throwError(() => new Error('dividends failed')),
+      );
+      spyOn(console, 'error');
+      const holding = component.holdings[0];
+
+      component.toggleDividends(holding);
+
+      expect(component.dividendsError[101]).toBeTrue();
+      expect(component.dividendsLoading[101]).toBeFalse();
+      expect(console.error).toHaveBeenCalled();
+    });
+
+    it('should sum the net amounts of a position\'s dividends', () => {
+      const holding = component.holdings[0];
+
+      component.toggleDividends(holding);
+
+      expect(component.getDividendTotal(101)).toBeCloseTo(44.1, 5);
+    });
+
+    it('should return a zero total for a position without dividends', () => {
+      expect(component.getDividendTotal(999)).toBe(0);
+    });
+
+    it('should report a row as expanded only for the matching listingId', () => {
+      const stock = component.holdings[0];
+
+      expect(component.isDividendRowExpanded(stock)).toBeFalse();
+
+      component.toggleDividends(stock);
+
+      expect(component.isDividendRowExpanded(stock)).toBeTrue();
+      expect(component.isDividendRowExpanded(component.holdings[1])).toBeFalse();
+    });
+
+    it('should render the dividend table when a position row is expanded', () => {
+      component.toggleDividends(component.holdings[0]);
+      fixture.detectChanges();
+
+      const detailRow: HTMLElement | null =
+        fixture.nativeElement.querySelector('.dividend-detail-row');
+      expect(detailRow).not.toBeNull();
+      // Nested dividend table — query its own <tbody> directly so the count is
+      // not polluted by the outer holdings table rows.
+      const dividendTbody = detailRow!.querySelector('table > tbody');
+      expect(dividendTbody).not.toBeNull();
+      expect(dividendTbody!.querySelectorAll('tr').length).toBe(2);
+    });
   });
 });

--- a/src/app/features/client/components/portfolio/portfolio.component.ts
+++ b/src/app/features/client/components/portfolio/portfolio.component.ts
@@ -10,6 +10,7 @@ import {
   PortfolioListingType,
   PortfolioSummary,
 } from '../../models/portfolio.model';
+import { DividendPayout } from '../../models/dividend.model';
 import { AuthService } from '../../../../core/services/auth.service';
 import { ToastService } from '../../../../shared/services/toast.service';
 import { StateComponent } from '../../../../shared/components/state/state.component';
@@ -33,6 +34,13 @@ export class PortfolioComponent implements OnInit, OnDestroy {
   draftPublicQuantities: Record<string, number> = {};
   savingPublicQuantity: Record<string, boolean> = {};
   exercisingOption: Record<string, boolean> = {};
+
+  // WP-24: istorija dividendi po poziciji. Drzano po listingId-u, lazy-fetch
+  // kad korisnik prvi put razvije red — izbegava N HTTP poziva na ucitavanju.
+  expandedDividendListingId: number | null = null;
+  dividendsByListing: Record<number, DividendPayout[]> = {};
+  dividendsLoading: Record<number, boolean> = {};
+  dividendsError: Record<number, boolean> = {};
 
   activeTab: 'holdings' | 'funds' = 'holdings';
   isSupervisor = false;
@@ -217,6 +225,57 @@ export class PortfolioComponent implements OnInit, OnDestroy {
     this.router.navigate(['/orders/create', 'SELL', holding.listingId]);
   }
 
+  /**
+   * WP-24: razvija/skuplja panel sa istorijom dividendi za poziciju. Otvoren je
+   * najvise jedan red u isto vreme. Pri prvom otvaranju jedne pozicije povlaci
+   * njenu istoriju (`getDividends(listingId)`) i kesira je.
+   */
+  toggleDividends(holding: PortfolioHolding): void {
+    const listingId = holding.listingId;
+
+    if (this.expandedDividendListingId === listingId) {
+      this.expandedDividendListingId = null;
+      return;
+    }
+
+    this.expandedDividendListingId = listingId;
+
+    if (this.dividendsByListing[listingId] === undefined && !this.dividendsLoading[listingId]) {
+      this.loadDividends(listingId);
+    }
+  }
+
+  loadDividends(listingId: number): void {
+    this.dividendsLoading[listingId] = true;
+    this.dividendsError[listingId] = false;
+
+    this.portfolioService
+      .getDividends(listingId)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (payouts) => {
+          this.dividendsByListing[listingId] = payouts ?? [];
+          this.dividendsLoading[listingId] = false;
+        },
+        error: (error) => {
+          console.error('Error loading dividends:', error);
+          this.dividendsError[listingId] = true;
+          this.dividendsLoading[listingId] = false;
+        },
+      });
+  }
+
+  isDividendRowExpanded(holding: PortfolioHolding): boolean {
+    return this.expandedDividendListingId === holding.listingId;
+  }
+
+  getDividendTotal(listingId: number): number {
+    return (this.dividendsByListing[listingId] ?? []).reduce(
+      (sum, payout) => sum + (payout.netAmount ?? 0),
+      0,
+    );
+  }
+
   isStock(holding: PortfolioHolding): boolean {
     return holding.listingType === 'STOCK';
   }
@@ -260,6 +319,21 @@ export class PortfolioComponent implements OnInit, OnDestroy {
       year: 'numeric',
       hour: '2-digit',
       minute: '2-digit',
+    }).format(date);
+  }
+
+  /** WP-24: datum bez vremena — koristi se za datum isplate dividende. */
+  formatDate(value: string): string {
+    const date = new Date(value);
+
+    if (Number.isNaN(date.getTime())) {
+      return value;
+    }
+
+    return new Intl.DateTimeFormat('sr-RS', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
     }).format(date);
   }
 

--- a/src/app/features/client/models/dividend.model.ts
+++ b/src/app/features/client/models/dividend.model.ts
@@ -1,0 +1,26 @@
+/**
+ * WP-24 (Celina 3 — Isplata dividendi).
+ *
+ * Ogledalo trading-service `DividendPayout` DTO-a koji vraca
+ * `GET /dividends` (i `GET /dividends?listingId={id}`). Svaki red je jedna
+ * isplata dividende za jednu poziciju (akciju) korisnika: bruto iznos u valuti
+ * hartije, porez konvertovan u RSD i neto iznos koji je legao na racun.
+ *
+ * `forBank` je true ako je dividenda isplacena za poziciju koju banka drzi za
+ * sopstveni racun (a ne klijent) — za "Moj portfolio" prikaz uvek je false,
+ * ali polje se mapira radi vernosti DTO-u.
+ */
+export interface DividendPayout {
+  id: number;
+  userId: number;
+  stockTicker: string;
+  listingId: number;
+  quantity: number;
+  grossAmount: number;
+  currency: string;
+  taxAmountRsd: number;
+  netAmount: number;
+  accountId: number;
+  paymentDate: string;
+  forBank: boolean;
+}

--- a/src/app/features/client/services/portfolio.service.spec.ts
+++ b/src/app/features/client/services/portfolio.service.spec.ts
@@ -53,4 +53,24 @@ describe('PortfolioService', () => {
     expect(req.request.body).toEqual({});
     req.flush(null);
   });
+
+  // WP-24: dividend payout history.
+  it('should fetch all dividend payouts when no listingId is given', () => {
+    service.getDividends().subscribe();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/dividends`);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.has('listingId')).toBeFalse();
+    req.flush([]);
+  });
+
+  it('should fetch dividend payouts filtered by listingId', () => {
+    service.getDividends(101).subscribe();
+
+    const req = httpMock.expectOne(
+      (r) => r.url === `${environment.apiUrl}/dividends` && r.params.get('listingId') === '101',
+    );
+    expect(req.request.method).toBe('GET');
+    req.flush([]);
+  });
 });

--- a/src/app/features/client/services/portfolio.service.ts
+++ b/src/app/features/client/services/portfolio.service.ts
@@ -1,15 +1,17 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../../../environments/environment';
 import {
   PortfolioSummary,
   SetPublicQuantityRequest,
 } from '../models/portfolio.model';
+import { DividendPayout } from '../models/dividend.model';
 
 @Injectable({ providedIn: 'root' })
 export class PortfolioService {
   private readonly baseUrl = `${environment.apiUrl}/order/portfolio`;
+  private readonly dividendsUrl = `${environment.apiUrl}/dividends`;
 
   constructor(private readonly http: HttpClient) {}
 
@@ -26,5 +28,18 @@ export class PortfolioService {
 
   exerciseOption(portfolioId: number): Observable<void> {
     return this.http.post<void>(`${this.baseUrl}/${portfolioId}/exercise-option`, {});
+  }
+
+  /**
+   * WP-24: vraca istoriju isplacenih dividendi pozivaocu (JWT identitet —
+   * Authorization header dodaje AuthInterceptor). Bez `listingId` vraca celu
+   * istoriju; sa `listingId` filtrira na jednu poziciju (akciju).
+   */
+  getDividends(listingId?: number): Observable<DividendPayout[]> {
+    let params = new HttpParams();
+    if (listingId != null) {
+      params = params.set('listingId', String(listingId));
+    }
+    return this.http.get<DividendPayout[]>(this.dividendsUrl, { params });
   }
 }

--- a/src/app/features/employee/components/audit-log/audit-log.component.html
+++ b/src/app/features/employee/components/audit-log/audit-log.component.html
@@ -1,0 +1,99 @@
+<!-- WP-23 (Celina 3): system audit log viewer. -->
+<div class="space-y-6">
+  <div class="flex items-center justify-between">
+    <h1 class="text-2xl font-bold text-foreground">Revizioni dnevnik</h1>
+  </div>
+
+  <!-- Filter bar -->
+  <div class="z-card p-5">
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
+      <div>
+        <label class="z-label" for="al-action">Tip akcije</label>
+        <select id="al-action" class="z-select" [(ngModel)]="actionTypeFilter">
+          <option *ngFor="let o of actionOptions" [ngValue]="o.value">{{ o.label }}</option>
+        </select>
+      </div>
+      <div>
+        <label class="z-label" for="al-actor">ID korisnika</label>
+        <input
+          id="al-actor"
+          type="number"
+          min="1"
+          step="1"
+          class="z-input"
+          [(ngModel)]="actorIdFilter"
+          placeholder="npr. 42"
+        />
+      </div>
+      <div>
+        <label class="z-label" for="al-from">Datum od</label>
+        <input id="al-from" type="date" class="z-input" [(ngModel)]="fromDate" />
+      </div>
+      <div>
+        <label class="z-label" for="al-to">Datum do</label>
+        <input id="al-to" type="date" class="z-input" [(ngModel)]="toDate" />
+      </div>
+    </div>
+    <div class="flex justify-end gap-2 mt-4">
+      <button type="button" class="z-btn-outline z-btn-sm" (click)="clearFilters()">Resetuj</button>
+      <button type="button" class="z-btn-primary z-btn-sm" (click)="applyFilters()">Primeni</button>
+    </div>
+  </div>
+
+  <!-- States -->
+  <app-state *ngIf="isLoading" mode="loading" text="Ucitavanje revizionog dnevnika..."></app-state>
+  <app-state *ngIf="!isLoading && error" mode="error" [text]="error"></app-state>
+  <app-state
+    *ngIf="!isLoading && !error && entries.length === 0"
+    mode="empty"
+    icon="shieldcheck"
+    title="Nema zapisa"
+    text="Nema zapisa u revizionom dnevniku za zadate filtere."
+  ></app-state>
+
+  <!-- Audit table -->
+  <div *ngIf="!isLoading && !error && entries.length > 0" class="z-card">
+    <table class="z-table">
+      <thead>
+        <tr>
+          <th>KORISNIK</th>
+          <th>AKCIJA</th>
+          <th>OBJEKAT</th>
+          <th>DETALJI</th>
+          <th>VREME</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let e of entries; trackBy: trackByEntry">
+          <td>
+            <span class="font-semibold">{{ e.actorName }}</span>
+            <span class="block text-xs text-muted-foreground">#{{ e.actorId }}</span>
+          </td>
+          <td>
+            <span class="z-badge z-badge-blue">{{ actionLabel(e.actionType) }}</span>
+          </td>
+          <td>
+            <span class="font-semibold">{{ e.targetType }}</span>
+            <span class="block text-xs text-muted-foreground font-mono tabular-nums">
+              #{{ e.targetId }}
+            </span>
+          </td>
+          <td class="text-muted-foreground">{{ e.details }}</td>
+          <td class="text-muted-foreground whitespace-nowrap">
+            {{ e.createdAt | date: 'dd.MM.yyyy. HH:mm' }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="flex justify-between items-center px-5 py-3 border-t border-border">
+      <span class="text-sm text-muted-foreground">Ukupno: {{ totalElements }}</span>
+      <app-pagination
+        [total]="totalElements"
+        [pageSize]="pageSize"
+        [page]="currentPage + 1"
+        (pageChange)="onPageChange($event - 1)"
+      ></app-pagination>
+    </div>
+  </div>
+</div>

--- a/src/app/features/employee/components/audit-log/audit-log.component.spec.ts
+++ b/src/app/features/employee/components/audit-log/audit-log.component.spec.ts
@@ -1,0 +1,142 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+
+import { AuditLogComponent } from './audit-log.component';
+import { AuditLogService } from '../../services/audit-log.service';
+import { AuditLogEntry, AuditLogPage } from '../../models/audit-log.model';
+
+function entry(id: number, overrides: Partial<AuditLogEntry> = {}): AuditLogEntry {
+  return {
+    id,
+    actorId: 10 + id,
+    actorName: `Actor ${id}`,
+    actionType: 'ORDER_APPROVED',
+    targetType: 'ORDER',
+    targetId: 1000 + id,
+    details: `Detail ${id}`,
+    createdAt: '2026-05-01T10:00:00Z',
+    ...overrides,
+  };
+}
+
+function page(content: AuditLogEntry[], totalElements = content.length): AuditLogPage {
+  return {
+    content,
+    totalElements,
+    totalPages: Math.max(1, Math.ceil(totalElements / 10)),
+    number: 0,
+    size: 10,
+  };
+}
+
+describe('AuditLogComponent', () => {
+  let fixture: ComponentFixture<AuditLogComponent>;
+  let component: AuditLogComponent;
+  let service: jasmine.SpyObj<AuditLogService>;
+
+  beforeEach(async () => {
+    service = jasmine.createSpyObj('AuditLogService', ['getAuditLog']);
+    service.getAuditLog.and.returnValue(of(page([])));
+
+    await TestBed.configureTestingModule({
+      imports: [AuditLogComponent],
+      providers: [{ provide: AuditLogService, useValue: service }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AuditLogComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('creates', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('loads the first page on init', () => {
+    service.getAuditLog.and.returnValue(of(page([entry(1), entry(2)], 2)));
+    fixture.detectChanges();
+
+    expect(service.getAuditLog).toHaveBeenCalledWith({}, 0, 10);
+    expect(component.entries.length).toBe(2);
+    expect(component.totalElements).toBe(2);
+    expect(component.isLoading).toBeFalse();
+  });
+
+  it('sets an error message when the log fails to load', () => {
+    service.getAuditLog.and.returnValue(throwError(() => new Error('network')));
+    fixture.detectChanges();
+
+    expect(component.error).toBe('Greska pri ucitavanju revizionog dnevnika.');
+    expect(component.isLoading).toBeFalse();
+  });
+
+  it('exposes "Sve akcije" plus every audited action type as filter options', () => {
+    /* 8 audited types + the "all" sentinel = 9 select options. */
+    expect(component.actionOptions.length).toBe(9);
+    expect(component.actionOptions[0].value).toBe('');
+  });
+
+  it('applyFilters resets to page 0 and forwards every set filter field', () => {
+    fixture.detectChanges();
+    component.currentPage = 3;
+    component.actionTypeFilter = 'AGENT_LIMIT_CHANGED';
+    component.actorIdFilter = 42;
+    component.fromDate = '2026-01-01';
+    component.toDate = '2026-05-19';
+
+    component.applyFilters();
+
+    expect(component.currentPage).toBe(0);
+    expect(service.getAuditLog).toHaveBeenCalledWith(
+      {
+        actionType: 'AGENT_LIMIT_CHANGED',
+        actorId: 42,
+        from: '2026-01-01',
+        to: '2026-05-19',
+      },
+      0,
+      10,
+    );
+  });
+
+  it('applyFilters omits a non-positive actor id', () => {
+    fixture.detectChanges();
+    component.actorIdFilter = 0;
+    component.applyFilters();
+    expect(service.getAuditLog).toHaveBeenCalledWith({}, 0, 10);
+  });
+
+  it('clearFilters wipes every field and reloads with an empty filter', () => {
+    fixture.detectChanges();
+    component.actionTypeFilter = 'ORDER_DECLINED';
+    component.actorIdFilter = 9;
+    component.fromDate = '2026-01-01';
+    component.toDate = '2026-05-19';
+    service.getAuditLog.calls.reset();
+
+    component.clearFilters();
+
+    expect(component.actionTypeFilter).toBe('');
+    expect(component.actorIdFilter).toBeNull();
+    expect(component.fromDate).toBe('');
+    expect(component.toDate).toBe('');
+    expect(service.getAuditLog).toHaveBeenCalledWith({}, 0, 10);
+  });
+
+  it('onPageChange reloads with the new 0-indexed page', () => {
+    service.getAuditLog.and.returnValue(of(page([], 80)));
+    fixture.detectChanges();
+
+    component.onPageChange(4);
+    expect(component.currentPage).toBe(4);
+    expect(service.getAuditLog).toHaveBeenCalledWith({}, 4, 10);
+  });
+
+  it('actionLabel maps each enum value to a Serbian label', () => {
+    expect(component.actionLabel('ORDER_APPROVED')).toBe('Order odobren');
+    expect(component.actionLabel('TAX_RUN_MANUAL')).toBe('Rucno pokretanje poreza');
+    expect(component.actionLabel('EMPLOYEE_PERMISSIONS_CHANGED')).toBe(
+      'Promena permisija zaposlenog',
+    );
+  });
+});

--- a/src/app/features/employee/components/audit-log/audit-log.component.ts
+++ b/src/app/features/employee/components/audit-log/audit-log.component.ts
@@ -1,0 +1,145 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+import { StateComponent } from '../../../../shared/components/state/state.component';
+import { AppPaginationComponent } from '../../../../shared/components/pagination/pagination.component';
+import { AuditLogService } from '../../services/audit-log.service';
+import {
+  AUDIT_ACTION_LABELS,
+  AUDIT_ACTION_TYPES,
+  AuditActionType,
+  AuditLogEntry,
+  AuditLogFilter,
+  AuditLogPage,
+} from '../../models/audit-log.model';
+
+/**
+ * WP-23 (Celina 3): system Audit Log viewer (`/audit-log`).
+ *
+ * <p>A server-paginated `z-table` of security-relevant administrative actions
+ * — order approvals/declines, actuary-limit changes, employee-permission
+ * changes and tax-run triggers — newest first. A filter bar narrows the list
+ * by action type, acting user and a date range.
+ *
+ * <p>Restricted to administrators and supervisors: the lazy `audit-log` route
+ * is guarded by `roleGuard` with `anyRole: ['SUPERVISOR', 'ADMIN']` (the same
+ * supervisor-only precedent as the `tax-tracking` route). Standalone,
+ * lazy-loaded via `loadComponent` so it stays out of the initial bundle.
+ */
+
+interface ActionOption {
+  value: AuditActionType | '';
+  label: string;
+}
+
+/** Empty sentinel for the "no filter" select option. */
+const ALL = '';
+
+@Component({
+  selector: 'app-audit-log',
+  standalone: true,
+  imports: [CommonModule, FormsModule, StateComponent, AppPaginationComponent],
+  templateUrl: './audit-log.component.html',
+})
+export class AuditLogComponent implements OnInit {
+  entries: AuditLogEntry[] = [];
+  totalElements = 0;
+  pageSize = 10;
+  /** 0-indexed page number (matches the Spring Data `Page` envelope). */
+  currentPage = 0;
+
+  isLoading = true;
+  error: string | null = null;
+
+  /* Filter-bar model. `''` / `null` means "no filter" for that field. */
+  actionTypeFilter: AuditActionType | '' = ALL;
+  actorIdFilter: number | null = null;
+  fromDate = '';
+  toDate = '';
+
+  /** Action-type select options — "Sve akcije" plus every audited type. */
+  readonly actionOptions: ActionOption[] = [
+    { value: ALL, label: 'Sve akcije' },
+    ...AUDIT_ACTION_TYPES.map((t) => ({
+      value: t,
+      label: AUDIT_ACTION_LABELS[t],
+    })),
+  ];
+
+  constructor(private readonly auditLogService: AuditLogService) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.isLoading = true;
+    this.error = null;
+    this.auditLogService
+      .getAuditLog(this.buildFilter(), this.currentPage, this.pageSize)
+      .subscribe({
+        next: (page: AuditLogPage) => {
+          this.entries = page?.content ?? [];
+          this.totalElements = page?.totalElements ?? 0;
+          this.isLoading = false;
+        },
+        error: () => {
+          this.isLoading = false;
+          this.error = 'Greska pri ucitavanju revizionog dnevnika.';
+        },
+      });
+  }
+
+  /** Applies the current filter bar, resetting to the first page. */
+  applyFilters(): void {
+    this.currentPage = 0;
+    this.load();
+  }
+
+  /** Clears every filter field and reloads. */
+  clearFilters(): void {
+    this.actionTypeFilter = ALL;
+    this.actorIdFilter = null;
+    this.fromDate = '';
+    this.toDate = '';
+    this.currentPage = 0;
+    this.load();
+  }
+
+  onPageChange(page: number): void {
+    this.currentPage = page;
+    this.load();
+  }
+
+  /**
+   * Builds the {@link AuditLogFilter} from the filter-bar model. Only fields
+   * that actually have a value are included — an unset field is left off the
+   * object entirely rather than set to `undefined`.
+   */
+  private buildFilter(): AuditLogFilter {
+    const filter: AuditLogFilter = {};
+    if (this.actionTypeFilter) {
+      filter.actionType = this.actionTypeFilter;
+    }
+    if (this.actorIdFilter !== null && this.actorIdFilter > 0) {
+      filter.actorId = this.actorIdFilter;
+    }
+    if (this.fromDate) {
+      filter.from = this.fromDate;
+    }
+    if (this.toDate) {
+      filter.to = this.toDate;
+    }
+    return filter;
+  }
+
+  /** Readable Serbian label for an audited action type. */
+  actionLabel(actionType: AuditActionType): string {
+    return AUDIT_ACTION_LABELS[actionType] ?? actionType;
+  }
+
+  trackByEntry(_: number, entry: AuditLogEntry): number {
+    return entry.id;
+  }
+}

--- a/src/app/features/employee/components/employee-create/employee-create.component.html
+++ b/src/app/features/employee/components/employee-create/employee-create.component.html
@@ -41,6 +41,12 @@
           <div>
             <label for="datumRodjenja" class="z-label">Datum rođenja <span class="text-destructive">*</span></label>
             <input id="datumRodjenja" type="date" formControlName="datumRodjenja" class="z-input" />
+            <p class="z-error" *ngIf="employeeForm.get('datumRodjenja')?.touched && employeeForm.get('datumRodjenja')?.errors?.['required']">
+              Datum rođenja je obavezan.
+            </p>
+            <p class="z-error" *ngIf="employeeForm.get('datumRodjenja')?.touched && employeeForm.get('datumRodjenja')?.errors?.['futureDate']">
+              Datum rođenja ne sme biti u budućnosti.
+            </p>
           </div>
           <div>
             <label for="pol" class="z-label">Pol <span class="text-destructive">*</span></label>
@@ -62,13 +68,22 @@
           <div>
             <label for="email" class="z-label">Email <span class="text-destructive">*</span></label>
             <input id="email" type="email" formControlName="email" placeholder="Unesite email adresu" class="z-input" />
-            <p class="z-error" *ngIf="employeeForm.get('email')?.touched && employeeForm.get('email')?.invalid">
-              Validan email je obavezan.
+            <p class="z-error" *ngIf="employeeForm.get('email')?.touched && employeeForm.get('email')?.errors?.['required']">
+              Email je obavezan.
+            </p>
+            <p class="z-error" *ngIf="employeeForm.get('email')?.touched && employeeForm.get('email')?.errors?.['emailFormat']">
+              Unesite validan email (npr. ime@banka.rs).
             </p>
           </div>
           <div>
             <label for="brojTelefona" class="z-label">Broj telefona <span class="text-destructive">*</span></label>
             <input id="brojTelefona" type="text" formControlName="brojTelefona" placeholder="+381..." class="z-input" />
+            <p class="z-error" *ngIf="employeeForm.get('brojTelefona')?.touched && employeeForm.get('brojTelefona')?.errors?.['required']">
+              Broj telefona je obavezan.
+            </p>
+            <p class="z-error" *ngIf="employeeForm.get('brojTelefona')?.touched && employeeForm.get('brojTelefona')?.errors?.['phoneFormat']">
+              Broj telefona sme sadržati samo cifre i znak "+" na početku (8–15 cifara).
+            </p>
           </div>
           <div class="md:col-span-2">
             <label for="adresa" class="z-label">Adresa</label>

--- a/src/app/features/employee/components/employee-create/employee-create.component.ts
+++ b/src/app/features/employee/components/employee-create/employee-create.component.ts
@@ -4,6 +4,11 @@ import { Router } from '@angular/router';
 import { Subject, takeUntil } from 'rxjs';
 import { EmployeeService } from '../../services/employee.service';
 import { ToastService } from '../../../../shared/services/toast.service';
+import {
+  emailFormatValidator,
+  notFutureDateValidator,
+  phoneNumberValidator,
+} from '../../../../shared/utils/validators';
 
 @Component({
   selector: 'app-employee-create',
@@ -35,10 +40,10 @@ export class EmployeeCreateComponent implements OnInit, OnDestroy {
     this.employeeForm = this.fb.group({
       ime: ['', [Validators.required, Validators.minLength(2)]],
       prezime: ['', [Validators.required, Validators.minLength(2)]],
-      datumRodjenja: ['1990-01-01', Validators.required],
+      datumRodjenja: ['1990-01-01', [Validators.required, notFutureDateValidator]],
       pol: ['M', Validators.required],
-      email: ['', [Validators.required, Validators.email]],
-      brojTelefona: ['', Validators.required],
+      email: ['', [Validators.required, emailFormatValidator]],
+      brojTelefona: ['', [Validators.required, phoneNumberValidator]],
       adresa: [''],
       pozicija: ['', Validators.required],
       departman: ['', Validators.required],

--- a/src/app/features/employee/components/employee-edit/employee-edit.component.html
+++ b/src/app/features/employee/components/employee-edit/employee-edit.component.html
@@ -28,12 +28,48 @@
 
         <div class="grid grid-cols-2 gap-4">
           <div>
-            <label class="z-label">Broj telefona <span class="text-destructive">*</span></label>
-            <input type="text" class="z-input" formControlName="brojTelefona" placeholder="+381..." />
-            <p class="z-error" *ngIf="editForm.get('brojTelefona')?.invalid && editForm.get('brojTelefona')?.touched">
-              Broj telefona je obavezan.
+            <label class="z-label">Email <span class="text-destructive">*</span></label>
+            <input type="email" class="z-input" formControlName="email" placeholder="ime@banka.rs" />
+            <p class="z-error" *ngIf="editForm.get('email')?.touched && editForm.get('email')?.errors?.['required']">
+              Email je obavezan.
+            </p>
+            <p class="z-error" *ngIf="editForm.get('email')?.touched && editForm.get('email')?.errors?.['emailFormat']">
+              Unesite validan email (npr. ime@banka.rs).
             </p>
           </div>
+          <div>
+            <label class="z-label">Broj telefona <span class="text-destructive">*</span></label>
+            <input type="text" class="z-input" formControlName="brojTelefona" placeholder="+381..." />
+            <p class="z-error" *ngIf="editForm.get('brojTelefona')?.touched && editForm.get('brojTelefona')?.errors?.['required']">
+              Broj telefona je obavezan.
+            </p>
+            <p class="z-error" *ngIf="editForm.get('brojTelefona')?.touched && editForm.get('brojTelefona')?.errors?.['phoneFormat']">
+              Broj telefona sme sadržati samo cifre i znak "+" na početku (8–15 cifara).
+            </p>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-2 gap-4">
+          <div>
+            <label for="edit-datumRodjenja" class="z-label">Datum rođenja <span class="text-destructive">*</span></label>
+            <input id="edit-datumRodjenja" type="date" class="z-input" formControlName="datumRodjenja" />
+            <p class="z-error" *ngIf="editForm.get('datumRodjenja')?.touched && editForm.get('datumRodjenja')?.errors?.['required']">
+              Datum rođenja je obavezan.
+            </p>
+            <p class="z-error" *ngIf="editForm.get('datumRodjenja')?.touched && editForm.get('datumRodjenja')?.errors?.['futureDate']">
+              Datum rođenja ne sme biti u budućnosti.
+            </p>
+          </div>
+          <div>
+            <label class="z-label">Pol <span class="text-destructive">*</span></label>
+            <select class="z-select" formControlName="pol">
+              <option value="M">Muški</option>
+              <option value="Z">Ženski</option>
+            </select>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-2 gap-4">
           <div>
             <label class="z-label">Adresa</label>
             <input type="text" class="z-input" formControlName="adresa" placeholder="Adresa" />

--- a/src/app/features/employee/components/employee-edit/employee-edit.component.ts
+++ b/src/app/features/employee/components/employee-edit/employee-edit.component.ts
@@ -1,6 +1,11 @@
 import { Component, EventEmitter, Input, Output, OnChanges, SimpleChanges } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Employee } from '../../models/employee';
+import {
+  emailFormatValidator,
+  notFutureDateValidator,
+  phoneNumberValidator,
+} from '../../../../shared/utils/validators';
 
 @Component({
   selector: 'app-employee-edit-modal',
@@ -18,7 +23,10 @@ export class EmployeeEditComponent implements OnChanges {
     this.editForm = this.fb.group({
       ime: ['', [Validators.required, Validators.minLength(2)]],
       prezime: ['', [Validators.required, Validators.minLength(2)]],
-      brojTelefona: ['', Validators.required],
+      email: ['', [Validators.required, emailFormatValidator]],
+      brojTelefona: ['', [Validators.required, phoneNumberValidator]],
+      datumRodjenja: ['', [Validators.required, notFutureDateValidator]],
+      pol: ['M', Validators.required],
       adresa: [''],
       pozicija: [''],
       departman: [''],
@@ -33,7 +41,10 @@ export class EmployeeEditComponent implements OnChanges {
       this.editForm.patchValue({
         ime: this.employee.ime || '',
         prezime: this.employee.prezime || '',
+        email: this.employee.email || '',
         brojTelefona: this.employee.brojTelefona || '',
+        datumRodjenja: this.employee.datumRodjenja || '',
+        pol: this.employee.pol || 'M',
         adresa: this.employee.adresa || '',
         pozicija: this.employee.pozicija || '',
         departman: this.employee.departman || '',

--- a/src/app/features/employee/models/audit-log.model.ts
+++ b/src/app/features/employee/models/audit-log.model.ts
@@ -1,0 +1,92 @@
+/**
+ * WP-23 (Celina 3): Audit Log model.
+ *
+ * Mirrors the DTOs returned by the JWT-secured audit endpoint exposed through
+ * the gateway at `GET /audit`. The {@link AuthInterceptor} attaches the token;
+ * the endpoint is restricted to administrators and supervisors.
+ *
+ * <p>The audit log records security-relevant administrative actions — order
+ * approvals/declines, actuary-limit changes, employee-permission changes and
+ * tax-run triggers — so that an administrator can review who did what, when.
+ */
+
+/**
+ * One audited action type. Mirrors the backend enum; each value gets a
+ * readable Serbian label via {@link AUDIT_ACTION_LABELS}.
+ */
+export type AuditActionType =
+  | 'ORDER_APPROVED'
+  | 'ORDER_DECLINED'
+  | 'AGENT_LIMIT_CHANGED'
+  | 'AGENT_USED_LIMIT_RESET'
+  | 'AGENT_NEED_APPROVAL_CHANGED'
+  | 'EMPLOYEE_PERMISSIONS_CHANGED'
+  | 'TAX_RUN_MANUAL'
+  | 'TAX_RUN_SCHEDULED';
+
+/** Every audited action type, in display order — drives the filter select. */
+export const AUDIT_ACTION_TYPES: AuditActionType[] = [
+  'ORDER_APPROVED',
+  'ORDER_DECLINED',
+  'AGENT_LIMIT_CHANGED',
+  'AGENT_USED_LIMIT_RESET',
+  'AGENT_NEED_APPROVAL_CHANGED',
+  'EMPLOYEE_PERMISSIONS_CHANGED',
+  'TAX_RUN_MANUAL',
+  'TAX_RUN_SCHEDULED',
+];
+
+/** Readable Serbian label for each audited action type. */
+export const AUDIT_ACTION_LABELS: Record<AuditActionType, string> = {
+  ORDER_APPROVED: 'Order odobren',
+  ORDER_DECLINED: 'Order odbijen',
+  AGENT_LIMIT_CHANGED: 'Promena limita agenta',
+  AGENT_USED_LIMIT_RESET: 'Reset iskoriscenog limita agenta',
+  AGENT_NEED_APPROVAL_CHANGED: 'Promena obaveze odobrenja agenta',
+  EMPLOYEE_PERMISSIONS_CHANGED: 'Promena permisija zaposlenog',
+  TAX_RUN_MANUAL: 'Rucno pokretanje poreza',
+  TAX_RUN_SCHEDULED: 'Zakazano pokretanje poreza',
+};
+
+/** One row of the audit log. */
+export interface AuditLogEntry {
+  id: number;
+  /** Id of the user who performed the action. */
+  actorId: number;
+  /** Display name of the actor — convenience field for the list. */
+  actorName: string;
+  actionType: AuditActionType;
+  /** Type of the entity the action targeted, e.g. `ORDER` / `EMPLOYEE`. */
+  targetType: string;
+  /** Id of the targeted entity. */
+  targetId: number;
+  /** Free-form human-readable detail of the action. */
+  details: string;
+  /** ISO-8601 timestamp of when the action happened. */
+  createdAt: string;
+}
+
+/** Query filter for `GET /audit`. All fields optional. */
+export interface AuditLogFilter {
+  actionType?: AuditActionType;
+  /** Filter by the id of the acting user. */
+  actorId?: number;
+  /** ISO date (`yyyy-MM-dd`) lower bound on the action timestamp. */
+  from?: string;
+  /** ISO date (`yyyy-MM-dd`) upper bound on the action timestamp. */
+  to?: string;
+}
+
+/**
+ * Spring Data `Page` envelope returned by `GET /audit`.
+ *
+ * <p>The plain Spring `Page` shape — paging metadata flattened onto the root
+ * object (`totalElements` / `totalPages` / `number` / `size`).
+ */
+export interface AuditLogPage {
+  content: AuditLogEntry[];
+  totalElements: number;
+  totalPages: number;
+  number: number;
+  size: number;
+}

--- a/src/app/features/employee/services/audit-log.service.spec.ts
+++ b/src/app/features/employee/services/audit-log.service.spec.ts
@@ -1,0 +1,103 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+
+import { environment } from '../../../../environments/environment';
+import { AuditLogService } from './audit-log.service';
+import { AuditLogEntry, AuditLogPage } from '../models/audit-log.model';
+
+const baseUrl = `${environment.apiUrl}/audit`;
+
+function entry(id: number, overrides: Partial<AuditLogEntry> = {}): AuditLogEntry {
+  return {
+    id,
+    actorId: 10 + id,
+    actorName: `Actor ${id}`,
+    actionType: 'ORDER_APPROVED',
+    targetType: 'ORDER',
+    targetId: 1000 + id,
+    details: `Detail ${id}`,
+    createdAt: '2026-05-01T10:00:00Z',
+    ...overrides,
+  };
+}
+
+function page(content: AuditLogEntry[], totalElements = content.length): AuditLogPage {
+  return {
+    content,
+    totalElements,
+    totalPages: Math.max(1, Math.ceil(totalElements / 10)),
+    number: 0,
+    size: 10,
+  };
+}
+
+describe('AuditLogService', () => {
+  let service: AuditLogService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [AuditLogService],
+    });
+    service = TestBed.inject(AuditLogService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('getAuditLog GETs /audit with only page + size when no filter is given', () => {
+    let result: AuditLogPage | undefined;
+    service.getAuditLog({}, 0, 10).subscribe((p) => (result = p));
+
+    const req = httpMock.expectOne(
+      (r) => r.url === baseUrl && r.params.keys().length === 2,
+    );
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.get('page')).toBe('0');
+    expect(req.request.params.get('size')).toBe('10');
+    const body = page([entry(1), entry(2)], 2);
+    req.flush(body);
+    expect(result).toEqual(body);
+  });
+
+  it('getAuditLog forwards every filter field as a query param', () => {
+    service
+      .getAuditLog(
+        {
+          actionType: 'AGENT_LIMIT_CHANGED',
+          actorId: 42,
+          from: '2026-01-01',
+          to: '2026-05-19',
+        },
+        2,
+        25,
+      )
+      .subscribe();
+
+    const req = httpMock.expectOne((r) => r.url === baseUrl);
+    expect(req.request.params.get('page')).toBe('2');
+    expect(req.request.params.get('size')).toBe('25');
+    expect(req.request.params.get('actionType')).toBe('AGENT_LIMIT_CHANGED');
+    expect(req.request.params.get('actorId')).toBe('42');
+    expect(req.request.params.get('from')).toBe('2026-01-01');
+    expect(req.request.params.get('to')).toBe('2026-05-19');
+    req.flush(page([]));
+  });
+
+  it('getAuditLog omits filter params that are unset', () => {
+    service.getAuditLog({ actorId: 7 }, 0, 10).subscribe();
+
+    const req = httpMock.expectOne((r) => r.url === baseUrl);
+    expect(req.request.params.get('actorId')).toBe('7');
+    expect(req.request.params.has('actionType')).toBeFalse();
+    expect(req.request.params.has('from')).toBeFalse();
+    expect(req.request.params.has('to')).toBeFalse();
+    req.flush(page([]));
+  });
+});

--- a/src/app/features/employee/services/audit-log.service.ts
+++ b/src/app/features/employee/services/audit-log.service.ts
@@ -1,0 +1,55 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { environment } from '../../../../environments/environment';
+import { AuditLogFilter, AuditLogPage } from '../models/audit-log.model';
+
+/**
+ * WP-23 (Celina 3): Audit Log client.
+ *
+ * <p>Wraps the JWT-secured audit endpoint exposed through the gateway at
+ * `GET /audit`. The {@link AuthInterceptor} attaches the `Authorization`
+ * header automatically. The endpoint is restricted to administrators and
+ * supervisors; the `audit-log` route is additionally guarded by `roleGuard`
+ * with `anyRole: ['SUPERVISOR', 'ADMIN']`.
+ */
+@Injectable({ providedIn: 'root' })
+export class AuditLogService {
+  private readonly baseUrl = `${environment.apiUrl}/audit`;
+
+  constructor(private readonly http: HttpClient) {}
+
+  /**
+   * Fetches one page of audit-log entries, newest first.
+   *
+   * @param filter optional action-type / actor-id / date-range filter; empty
+   *   or `undefined` fields are not sent as query params.
+   * @param page 0-indexed page number (matches the Spring Data `Page`).
+   * @param size page size.
+   */
+  getAuditLog(
+    filter: AuditLogFilter = {},
+    page = 0,
+    size = 10,
+  ): Observable<AuditLogPage> {
+    let params = new HttpParams()
+      .set('page', String(page))
+      .set('size', String(size));
+
+    if (filter.actionType) {
+      params = params.set('actionType', filter.actionType);
+    }
+    if (filter.actorId !== undefined && filter.actorId !== null) {
+      params = params.set('actorId', String(filter.actorId));
+    }
+    if (filter.from) {
+      params = params.set('from', filter.from);
+    }
+    if (filter.to) {
+      params = params.set('to', filter.to);
+    }
+
+    return this.http.get<AuditLogPage>(this.baseUrl, { params });
+  }
+}

--- a/src/app/features/funds/components/fund-details/fund-details.component.html
+++ b/src/app/features/funds/components/fund-details/fund-details.component.html
@@ -64,6 +64,99 @@
         </dl>
       </section>
 
+      <!-- WP-26: performance metrike (Celina 4 — statistika fondova). -->
+      <section class="z-card p-5 mb-6" data-testid="fund-statistics">
+        <p class="text-xs font-semibold tracking-wider text-muted-foreground uppercase mb-3">
+          Statistika fonda
+        </p>
+
+        <app-state *ngIf="statisticsLoading" mode="loading" text="Ucitavanje metrika..."></app-state>
+        <app-state *ngIf="statisticsError && !statisticsLoading"
+                   mode="error" text="Greska pri ucitavanju metrika."></app-state>
+
+        <ng-container *ngIf="!statisticsLoading && !statisticsError">
+          <!-- Nedovoljno istorijskih snapshot-ova: metrike se ne prikazuju. -->
+          <div *ngIf="!hasMetrics"
+               class="z-callout-info"
+               data-testid="metrics-unavailable">
+            Fond jos uvek nema dovoljno istorijskih podataka za izracunavanje
+            statistike. Metrike ce se pojaviti kada se akumulira dovoljno
+            dnevnih snapshot-ova vrednosti.
+          </div>
+
+          <div *ngIf="hasMetrics"
+               class="grid grid-cols-2 md:grid-cols-4 gap-4"
+               data-testid="metrics-grid">
+            <div class="z-stat-card">
+              <span class="z-stat-label">Godisnji prinos</span>
+              <span class="z-stat-value"
+                    data-testid="stat-annualizedReturn"
+                    [class.text-success]="statistics!.annualizedReturn !== null && statistics!.annualizedReturn! > 0"
+                    [class.text-destructive]="statistics!.annualizedReturn !== null && statistics!.annualizedReturn! < 0">
+                {{ metricPercent(statistics!.annualizedReturn) }}
+              </span>
+              <p class="z-stat-hint">Anualizovani prinos</p>
+            </div>
+            <div class="z-stat-card">
+              <span class="z-stat-label">Reward/Variability</span>
+              <span class="z-stat-value" data-testid="stat-rewardToVariability">
+                {{ metricRatio(statistics!.rewardToVariability) }}
+              </span>
+              <p class="z-stat-hint">Prinos po jedinici rizika</p>
+            </div>
+            <div class="z-stat-card">
+              <span class="z-stat-label">Maks. pad</span>
+              <span class="z-stat-value"
+                    data-testid="stat-maxDrawdown"
+                    [class.text-destructive]="statistics!.maxDrawdown !== null && statistics!.maxDrawdown !== 0">
+                {{ metricPercent(statistics!.maxDrawdown) }}
+              </span>
+              <p class="z-stat-hint">Najveci pad vrednosti</p>
+            </div>
+            <div class="z-stat-card">
+              <span class="z-stat-label">Volatilnost</span>
+              <span class="z-stat-value" data-testid="stat-volatility">
+                {{ metricPercent(statistics!.volatility) }}
+              </span>
+              <p class="z-stat-hint">Standardna devijacija prinosa</p>
+            </div>
+          </div>
+        </ng-container>
+      </section>
+
+      <!-- WP-26: chart istorije vrednosti + comparison sa prosekom svih fondova. -->
+      <section class="z-card p-5 mb-6" data-testid="fund-value-chart">
+        <p class="text-xs font-semibold tracking-wider text-muted-foreground uppercase mb-3">
+          Kretanje vrednosti fonda
+        </p>
+
+        <app-state *ngIf="historyLoading" mode="loading" text="Ucitavanje istorije vrednosti..."></app-state>
+        <app-state *ngIf="historyError && !historyLoading"
+                   mode="error" text="Greska pri ucitavanju istorije vrednosti."></app-state>
+
+        <ng-container *ngIf="!historyLoading && !historyError">
+          <div *ngIf="fundValueSeries.length === 0"
+               class="z-callout-info"
+               data-testid="history-empty">
+            Jos uvek nema zabelezenih snapshot-ova vrednosti za ovaj fond.
+          </div>
+
+          <app-fund-history-chart
+            *ngIf="fundValueSeries.length > 0"
+            data-testid="history-chart"
+            [fundSeries]="fundValueSeries"
+            [averageSeries]="averageValueSeries"
+            [fundLabel]="fund.naziv"
+            averageLabel="Prosek svih fondova"
+            [height]="320">
+          </app-fund-history-chart>
+          <p *ngIf="fundValueSeries.length > 0 && averageValueSeries.length === 0"
+             class="text-[11px] text-muted-foreground mt-2">
+            Prosek svih fondova trenutno nije dostupan za poredjenje.
+          </p>
+        </ng-container>
+      </section>
+
       <!-- Client own position -->
       <section *ngIf="isClient && myPosition" class="z-card p-5 mb-6">
         <p class="text-xs font-semibold tracking-wider text-muted-foreground uppercase mb-3">Moja pozicija</p>

--- a/src/app/features/funds/components/fund-details/fund-details.component.spec.ts
+++ b/src/app/features/funds/components/fund-details/fund-details.component.spec.ts
@@ -1,0 +1,230 @@
+import { Component, Input } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute } from '@angular/router';
+import { of, throwError } from 'rxjs';
+
+import { FundDetailsComponent } from './fund-details.component';
+import { FundService } from '../../services/fund.service';
+import { AuthService } from '../../../../core/services/auth.service';
+import { AccountService } from '../../../client/services/account.service';
+import { StateComponent } from '../../../../shared/components/state/state.component';
+import {
+  FundStatistics,
+  FundValueSnapshotPoint,
+  InvestmentFund,
+} from '../../models/fund.model';
+
+/**
+ * Stub za `app-fund-history-chart` (WP-26). Deli isti selektor kao stvarni
+ * `FundHistoryChartComponent` pa zamenjuje ApexCharts wrapper u testu —
+ * spec ostaje deterministican u headless Chrome okruzenju i ne mora da
+ * inicijalizuje stvarnu chart biblioteku.
+ */
+@Component({ selector: 'app-fund-history-chart', standalone: true, template: '' })
+class FundHistoryChartStub {
+  @Input() fundSeries: unknown;
+  @Input() averageSeries: unknown;
+  @Input() fundLabel: unknown;
+  @Input() averageLabel: unknown;
+  @Input() height: unknown;
+}
+
+describe('FundDetailsComponent', () => {
+  let component: FundDetailsComponent;
+  let fixture: ComponentFixture<FundDetailsComponent>;
+  let fundServiceSpy: jasmine.SpyObj<FundService>;
+  let authServiceSpy: jasmine.SpyObj<AuthService>;
+  let accountServiceSpy: jasmine.SpyObj<AccountService>;
+
+  const fund: InvestmentFund = {
+    id: 7,
+    naziv: 'Test Fond',
+    opis: 'opis',
+    minimumContribution: 1000,
+    managerId: 1,
+    likvidnaSredstva: 5000,
+    accountNumber: '111',
+    datumKreiranja: '2026-01-01',
+    totalValue: 10000,
+    profit: 500,
+    annualizedReturn: 0.12,
+    rewardToVariability: 1.4,
+    maxDrawdown: -0.08,
+    volatility: 0.06,
+  };
+
+  const statsAvailable: FundStatistics = {
+    metricsAvailable: true,
+    annualizedReturn: 0.12,
+    rewardToVariability: 1.4,
+    maxDrawdown: -0.08,
+    volatility: 0.06,
+  };
+
+  const statsUnavailable: FundStatistics = {
+    metricsAvailable: false,
+    annualizedReturn: null,
+    rewardToVariability: null,
+    maxDrawdown: null,
+    volatility: null,
+  };
+
+  const history: FundValueSnapshotPoint[] = [
+    { snapshotDate: '2026-01-01', totalValue: 1000, profit: 0 },
+    { snapshotDate: '2026-02-01', totalValue: 1100, profit: 100 },
+  ];
+
+  const average: FundValueSnapshotPoint[] = [
+    { snapshotDate: '2026-01-01', totalValue: 900, profit: 0 },
+    { snapshotDate: '2026-02-01', totalValue: 950, profit: 50 },
+  ];
+
+  function setup(): void {
+    fixture = TestBed.createComponent(FundDetailsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  beforeEach(() => {
+    fundServiceSpy = jasmine.createSpyObj<FundService>('FundService', [
+      'details', 'fundSecurities', 'fundPositions', 'myPositions',
+      'getStatistics', 'getValueHistory', 'getAverageValueHistory',
+    ]);
+    authServiceSpy = jasmine.createSpyObj<AuthService>('AuthService', ['hasPermission', 'isClient']);
+    accountServiceSpy = jasmine.createSpyObj<AccountService>('AccountService', ['getMyAccounts']);
+
+    fundServiceSpy.details.and.returnValue(of(fund));
+    fundServiceSpy.fundSecurities.and.returnValue(of([]));
+    fundServiceSpy.fundPositions.and.returnValue(of([]));
+    fundServiceSpy.myPositions.and.returnValue(of([]));
+    fundServiceSpy.getStatistics.and.returnValue(of(statsAvailable));
+    fundServiceSpy.getValueHistory.and.returnValue(of(history));
+    fundServiceSpy.getAverageValueHistory.and.returnValue(of(average));
+    authServiceSpy.hasPermission.and.returnValue(false);
+    authServiceSpy.isClient.and.returnValue(false);
+    accountServiceSpy.getMyAccounts.and.returnValue(of([]));
+
+    TestBed.configureTestingModule({
+      declarations: [FundDetailsComponent],
+      imports: [ReactiveFormsModule, FormsModule, RouterTestingModule, StateComponent, FundHistoryChartStub],
+      providers: [
+        { provide: FundService, useValue: fundServiceSpy },
+        { provide: AuthService, useValue: authServiceSpy },
+        { provide: AccountService, useValue: accountServiceSpy },
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => '7' } } } },
+      ],
+    });
+  });
+
+  it('should create and load the fund', () => {
+    setup();
+    expect(component).toBeTruthy();
+    expect(component.fund?.id).toBe(7);
+  });
+
+  describe('statistics panel', () => {
+    it('should load statistics on init', () => {
+      setup();
+      expect(fundServiceSpy.getStatistics).toHaveBeenCalledWith(7);
+      expect(component.statistics).toEqual(statsAvailable);
+      expect(component.hasMetrics).toBeTrue();
+    });
+
+    it('should render the 4 metric stat cards when metrics are available', () => {
+      setup();
+      const grid: HTMLElement | null = fixture.nativeElement.querySelector('[data-testid="metrics-grid"]');
+      expect(grid).not.toBeNull();
+      expect(grid!.querySelector('[data-testid="stat-annualizedReturn"]')!.textContent).toContain('%');
+      expect(grid!.querySelector('[data-testid="stat-rewardToVariability"]')!.textContent!.trim()).toBe('1,40');
+      expect(grid!.querySelector('[data-testid="stat-maxDrawdown"]')!.textContent).toContain('%');
+      expect(grid!.querySelector('[data-testid="stat-volatility"]')!.textContent).toContain('%');
+    });
+
+    it('should show the "not enough data" callout when metricsAvailable is false', () => {
+      fundServiceSpy.getStatistics.and.returnValue(of(statsUnavailable));
+      setup();
+
+      expect(component.hasMetrics).toBeFalse();
+      const callout: HTMLElement | null =
+        fixture.nativeElement.querySelector('[data-testid="metrics-unavailable"]');
+      expect(callout).not.toBeNull();
+      expect(fixture.nativeElement.querySelector('[data-testid="metrics-grid"]')).toBeNull();
+    });
+
+    it('should flag a statistics error when the request fails', () => {
+      fundServiceSpy.getStatistics.and.returnValue(throwError(() => new Error('stats failed')));
+      setup();
+
+      expect(component.statisticsError).toBeTrue();
+      expect(component.statisticsLoading).toBeFalse();
+    });
+  });
+
+  describe('value-history chart', () => {
+    it('should load the fund and average series on init', () => {
+      setup();
+      expect(fundServiceSpy.getValueHistory).toHaveBeenCalledWith(7);
+      expect(fundServiceSpy.getAverageValueHistory).toHaveBeenCalled();
+      expect(component.fundValueSeries.length).toBe(2);
+      expect(component.averageValueSeries.length).toBe(2);
+      expect(component.fundValueSeries[0]).toEqual({ x: '2026-01-01', y: 1000 });
+    });
+
+    it('should render the chart when there is history', () => {
+      setup();
+      expect(fixture.nativeElement.querySelector('[data-testid="history-chart"]')).not.toBeNull();
+      expect(fixture.nativeElement.querySelector('[data-testid="history-empty"]')).toBeNull();
+    });
+
+    it('should show the empty callout when the fund has no history', () => {
+      fundServiceSpy.getValueHistory.and.returnValue(of([]));
+      setup();
+
+      expect(component.fundValueSeries.length).toBe(0);
+      expect(fixture.nativeElement.querySelector('[data-testid="history-empty"]')).not.toBeNull();
+      expect(fixture.nativeElement.querySelector('[data-testid="history-chart"]')).toBeNull();
+    });
+
+    it('should still render the fund series when only the average request fails', () => {
+      fundServiceSpy.getAverageValueHistory.and.returnValue(throwError(() => new Error('avg failed')));
+      setup();
+
+      // Average is best-effort (catchError) -> fund line still loads, no error.
+      expect(component.historyError).toBeFalse();
+      expect(component.fundValueSeries.length).toBe(2);
+      expect(component.averageValueSeries.length).toBe(0);
+      expect(fixture.nativeElement.querySelector('[data-testid="history-chart"]')).not.toBeNull();
+    });
+
+    it('should flag a history error when the fund value-history request fails', () => {
+      fundServiceSpy.getValueHistory.and.returnValue(throwError(() => new Error('history failed')));
+      setup();
+
+      expect(component.historyError).toBeTrue();
+      expect(component.historyLoading).toBeFalse();
+    });
+  });
+
+  describe('metric formatting helpers', () => {
+    beforeEach(() => setup());
+
+    it('metricPercent renders fraction as percentage', () => {
+      expect(component.metricPercent(0.085)).toContain('8,50');
+    });
+
+    it('metricPercent renders "—" for null/undefined', () => {
+      expect(component.metricPercent(null)).toBe('—');
+      expect(component.metricPercent(undefined)).toBe('—');
+    });
+
+    it('metricRatio renders 2-decimal ratio', () => {
+      expect(component.metricRatio(2)).toBe('2,00');
+    });
+
+    it('metricRatio renders "—" for null', () => {
+      expect(component.metricRatio(null)).toBe('—');
+    });
+  });
+});

--- a/src/app/features/funds/components/fund-details/fund-details.component.ts
+++ b/src/app/features/funds/components/fund-details/fund-details.component.ts
@@ -1,13 +1,21 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { forkJoin } from 'rxjs';
+import { forkJoin, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 
 import { FundService } from '../../services/fund.service';
-import { ClientFundPosition, FundHolding, InvestmentFund } from '../../models/fund.model';
+import {
+  ClientFundPosition,
+  FundHolding,
+  FundStatistics,
+  FundValueSnapshotPoint,
+  InvestmentFund,
+} from '../../models/fund.model';
 import { AuthService } from '../../../../core/services/auth.service';
 import { AccountService } from '../../../client/services/account.service';
 import { Account } from '../../../client/models/account.model';
+import { FundSeriesPoint } from '../../../../shared/charts/fund-history-chart/fund-history-chart.component';
 
 @Component({
   selector: 'app-fund-details',
@@ -22,6 +30,15 @@ export class FundDetailsComponent implements OnInit {
   securities: FundHolding[] = [];
   positions: ClientFundPosition[] = [];
   myPosition: ClientFundPosition | null = null;
+
+  // WP-26 (Celina 4 — statistika fondova): metrike + chart serije.
+  statistics: FundStatistics | null = null;
+  statisticsLoading = false;
+  statisticsError = false;
+  fundValueSeries: FundSeriesPoint[] = [];
+  averageValueSeries: FundSeriesPoint[] = [];
+  historyLoading = false;
+  historyError = false;
 
   isSupervisor = false;
   isClient = false;
@@ -88,6 +105,8 @@ export class FundDetailsComponent implements OnInit {
             .find(p => p.fundId === this.fundId) ?? null;
         }
         this.loadSecurities();
+        this.loadStatistics();
+        this.loadValueHistory();
       },
       error: err => {
         this.error = err?.error?.message || 'Greska pri ucitavanju fonda.';
@@ -100,6 +119,72 @@ export class FundDetailsComponent implements OnInit {
     this.fundService.fundSecurities(this.fundId).subscribe({
       next: s => { this.securities = s; this.loading = false; },
       error: () => { this.loading = false; },
+    });
+  }
+
+  /** WP-26: ucitava performance metrike fonda. */
+  private loadStatistics(): void {
+    this.statisticsLoading = true;
+    this.statisticsError = false;
+    this.fundService.getStatistics(this.fundId).subscribe({
+      next: stats => { this.statistics = stats; this.statisticsLoading = false; },
+      error: () => { this.statisticsError = true; this.statisticsLoading = false; },
+    });
+  }
+
+  /**
+   * WP-26: ucitava istoriju vrednosti fonda i sistemski prosek paralelno.
+   * Prosek je best-effort — `catchError` na average struji znaci da pad
+   * proseka NE rusi chart; serija samog fonda se i dalje prikazuje (chart
+   * onda nema comparison liniju). `historyError` se pali samo ako padne
+   * realna istorija fonda.
+   */
+  private loadValueHistory(): void {
+    this.historyLoading = true;
+    this.historyError = false;
+    forkJoin({
+      fund: this.fundService.getValueHistory(this.fundId),
+      average: this.fundService.getAverageValueHistory().pipe(
+        catchError(() => of([] as FundValueSnapshotPoint[])),
+      ),
+    }).subscribe({
+      next: ({ fund, average }) => {
+        this.fundValueSeries = fund.map(p => this.toSeriesPoint(p));
+        this.averageValueSeries = average.map(p => this.toSeriesPoint(p));
+        this.historyLoading = false;
+      },
+      error: () => { this.historyError = true; this.historyLoading = false; },
+    });
+  }
+
+  private toSeriesPoint(p: FundValueSnapshotPoint): FundSeriesPoint {
+    return { x: p.snapshotDate, y: p.totalValue };
+  }
+
+  /** WP-26: true kad metrike postoje i ima ih smisla prikazati. */
+  get hasMetrics(): boolean {
+    return !!this.statistics && this.statistics.metricsAvailable;
+  }
+
+  /** WP-26: frakcija (0.12) -> procenat string; null -> placeholder. */
+  metricPercent(value: number | null | undefined): string {
+    if (value === null || value === undefined) {
+      return '—';
+    }
+    return `${(value * 100).toLocaleString('sr-RS', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })}%`;
+  }
+
+  /** WP-26: reward-to-variability ratio (ne procenat); null -> placeholder. */
+  metricRatio(value: number | null | undefined): string {
+    if (value === null || value === undefined) {
+      return '—';
+    }
+    return value.toLocaleString('sr-RS', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
     });
   }
 

--- a/src/app/features/funds/components/fund-discovery/fund-discovery.component.html
+++ b/src/app/features/funds/components/fund-discovery/fund-discovery.component.html
@@ -23,19 +23,32 @@
     <div class="flex flex-wrap items-center gap-3 mb-5">
       <input [(ngModel)]="search" (ngModelChange)="apply()"
              class="z-input flex-1 min-w-[200px]" placeholder="Pretrazi po nazivu ili opisu..." />
-      <div class="flex items-center gap-2 text-sm">
+      <!-- WP-26: sort dugmad prosirena sa 4 metric kljuca (statistika fondova). -->
+      <div class="flex flex-wrap items-center gap-2 text-sm">
         <span class="text-muted-foreground">Sortiraj:</span>
-        <button class="z-btn-outline-sm" (click)="setSort('naziv')">
+        <button class="z-btn-outline-sm" data-testid="sort-naziv" (click)="setSort('naziv')">
           Naziv <span *ngIf="sortField === 'naziv'">{{ sortDir === 'asc' ? '↑' : '↓' }}</span>
         </button>
-        <button class="z-btn-outline-sm" (click)="setSort('totalValue')">
+        <button class="z-btn-outline-sm" data-testid="sort-totalValue" (click)="setSort('totalValue')">
           Vrednost <span *ngIf="sortField === 'totalValue'">{{ sortDir === 'asc' ? '↑' : '↓' }}</span>
         </button>
-        <button class="z-btn-outline-sm" (click)="setSort('profit')">
+        <button class="z-btn-outline-sm" data-testid="sort-profit" (click)="setSort('profit')">
           Profit <span *ngIf="sortField === 'profit'">{{ sortDir === 'asc' ? '↑' : '↓' }}</span>
         </button>
-        <button class="z-btn-outline-sm" (click)="setSort('minimumContribution')">
+        <button class="z-btn-outline-sm" data-testid="sort-minimumContribution" (click)="setSort('minimumContribution')">
           Min. ulog <span *ngIf="sortField === 'minimumContribution'">{{ sortDir === 'asc' ? '↑' : '↓' }}</span>
+        </button>
+        <button class="z-btn-outline-sm" data-testid="sort-annualizedReturn" (click)="setSort('annualizedReturn')">
+          Godisnji prinos <span *ngIf="sortField === 'annualizedReturn'">{{ sortDir === 'asc' ? '↑' : '↓' }}</span>
+        </button>
+        <button class="z-btn-outline-sm" data-testid="sort-rewardToVariability" (click)="setSort('rewardToVariability')">
+          Reward/Variability <span *ngIf="sortField === 'rewardToVariability'">{{ sortDir === 'asc' ? '↑' : '↓' }}</span>
+        </button>
+        <button class="z-btn-outline-sm" data-testid="sort-maxDrawdown" (click)="setSort('maxDrawdown')">
+          Maks. pad <span *ngIf="sortField === 'maxDrawdown'">{{ sortDir === 'asc' ? '↑' : '↓' }}</span>
+        </button>
+        <button class="z-btn-outline-sm" data-testid="sort-volatility" (click)="setSort('volatility')">
+          Volatilnost <span *ngIf="sortField === 'volatility'">{{ sortDir === 'asc' ? '↑' : '↓' }}</span>
         </button>
       </div>
     </div>
@@ -75,6 +88,54 @@
               <dd class="font-mono font-bold text-lg text-foreground mt-0.5">{{ f.totalValue | number:'1.0-2' }} RSD</dd>
             </div>
           </dl>
+
+          <!-- WP-26: performance metrike (Celina 4 — statistika fondova).
+               Frakcije sa backend-a; "—" kad fond nema dovoljno snapshot-ova. -->
+          <dl class="grid grid-cols-2 gap-y-3 gap-x-4 text-sm border-t border-border pt-4 mt-4"
+              data-testid="fund-metrics">
+            <div>
+              <dt class="text-[11px] font-semibold tracking-wider text-muted-foreground uppercase">Godisnji prinos</dt>
+              <dd class="font-mono font-semibold mt-0.5"
+                  data-testid="metric-annualizedReturn"
+                  [class.text-success]="f.annualizedReturn !== null && f.annualizedReturn > 0"
+                  [class.text-destructive]="f.annualizedReturn !== null && f.annualizedReturn < 0"
+                  [class.text-muted-foreground]="f.annualizedReturn === null">
+                {{ metricPercent(f.annualizedReturn) }}
+              </dd>
+            </div>
+            <div>
+              <dt class="text-[11px] font-semibold tracking-wider text-muted-foreground uppercase">Reward/Variability</dt>
+              <dd class="font-mono font-semibold mt-0.5"
+                  data-testid="metric-rewardToVariability"
+                  [class.text-foreground]="f.rewardToVariability !== null"
+                  [class.text-muted-foreground]="f.rewardToVariability === null">
+                {{ metricRatio(f.rewardToVariability) }}
+              </dd>
+            </div>
+            <div>
+              <dt class="text-[11px] font-semibold tracking-wider text-muted-foreground uppercase">Maks. pad</dt>
+              <dd class="font-mono font-semibold mt-0.5"
+                  data-testid="metric-maxDrawdown"
+                  [class.text-destructive]="f.maxDrawdown !== null && f.maxDrawdown !== 0"
+                  [class.text-muted-foreground]="f.maxDrawdown === null">
+                {{ metricPercent(f.maxDrawdown) }}
+              </dd>
+            </div>
+            <div>
+              <dt class="text-[11px] font-semibold tracking-wider text-muted-foreground uppercase">Volatilnost</dt>
+              <dd class="font-mono font-semibold mt-0.5"
+                  data-testid="metric-volatility"
+                  [class.text-foreground]="f.volatility !== null"
+                  [class.text-muted-foreground]="f.volatility === null">
+                {{ metricPercent(f.volatility) }}
+              </dd>
+            </div>
+          </dl>
+          <p *ngIf="f.annualizedReturn === null"
+             class="text-[11px] text-muted-foreground mt-2"
+             data-testid="metric-empty-hint">
+            Nedovoljno podataka za statistiku.
+          </p>
 
           <div class="flex items-center justify-end mt-4 pt-3 border-t border-border text-sm font-semibold text-primary group-hover:underline">
             Detalji i investicija <span aria-hidden="true" class="ml-1">→</span>

--- a/src/app/features/funds/components/fund-discovery/fund-discovery.component.spec.ts
+++ b/src/app/features/funds/components/fund-discovery/fund-discovery.component.spec.ts
@@ -1,0 +1,176 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of, throwError } from 'rxjs';
+
+import { FundDiscoveryComponent } from './fund-discovery.component';
+import { FundService } from '../../services/fund.service';
+import { AuthService } from '../../../../core/services/auth.service';
+import { StateComponent } from '../../../../shared/components/state/state.component';
+import { InvestmentFund } from '../../models/fund.model';
+
+describe('FundDiscoveryComponent', () => {
+  let component: FundDiscoveryComponent;
+  let fixture: ComponentFixture<FundDiscoveryComponent>;
+  let fundServiceSpy: jasmine.SpyObj<FundService>;
+  let authServiceSpy: jasmine.SpyObj<AuthService>;
+
+  const buildFund = (over: Partial<InvestmentFund>): InvestmentFund => ({
+    id: 1,
+    naziv: 'Fond',
+    opis: '',
+    minimumContribution: 1000,
+    managerId: 1,
+    likvidnaSredstva: 5000,
+    accountNumber: '111',
+    datumKreiranja: '2026-01-01',
+    totalValue: 10000,
+    profit: 0,
+    annualizedReturn: null,
+    rewardToVariability: null,
+    maxDrawdown: null,
+    volatility: null,
+    ...over,
+  });
+
+  const buildFunds = (): InvestmentFund[] => [
+    buildFund({ id: 1, naziv: 'Alfa', annualizedReturn: 0.05, rewardToVariability: 1.1, maxDrawdown: -0.04, volatility: 0.07 }),
+    buildFund({ id: 2, naziv: 'Beta', annualizedReturn: 0.18, rewardToVariability: 2.2, maxDrawdown: -0.02, volatility: 0.03 }),
+    buildFund({ id: 3, naziv: 'Gama', annualizedReturn: null, rewardToVariability: null, maxDrawdown: null, volatility: null }),
+  ];
+
+  function setup(funds: InvestmentFund[] = buildFunds()): void {
+    fundServiceSpy.discovery.and.returnValue(of(funds));
+    fixture = TestBed.createComponent(FundDiscoveryComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  beforeEach(() => {
+    fundServiceSpy = jasmine.createSpyObj<FundService>('FundService', ['discovery']);
+    authServiceSpy = jasmine.createSpyObj<AuthService>('AuthService', ['hasPermission']);
+    authServiceSpy.hasPermission.and.returnValue(false);
+
+    TestBed.configureTestingModule({
+      declarations: [FundDiscoveryComponent],
+      imports: [FormsModule, RouterTestingModule, StateComponent],
+      providers: [
+        { provide: FundService, useValue: fundServiceSpy },
+        { provide: AuthService, useValue: authServiceSpy },
+      ],
+    });
+  });
+
+  it('should create and load funds', () => {
+    setup();
+    expect(component).toBeTruthy();
+    expect(fundServiceSpy.discovery).toHaveBeenCalled();
+    expect(component.funds.length).toBe(3);
+  });
+
+  it('should render the 4 metric values on each card', () => {
+    setup();
+    const cards: HTMLElement[] = fixture.nativeElement.querySelectorAll('[data-testid="fund-metrics"]');
+    expect(cards.length).toBe(3);
+
+    // First sorted card is "Alfa" (sortField defaults to naziv asc).
+    const alfa = cards[0];
+    expect(alfa.querySelector('[data-testid="metric-annualizedReturn"]')!.textContent).toContain('%');
+    expect(alfa.querySelector('[data-testid="metric-rewardToVariability"]')!.textContent!.trim()).toBe('1,10');
+    expect(alfa.querySelector('[data-testid="metric-maxDrawdown"]')!.textContent).toContain('%');
+    expect(alfa.querySelector('[data-testid="metric-volatility"]')!.textContent).toContain('%');
+  });
+
+  it('should show a "—" placeholder for funds without metrics', () => {
+    setup();
+    // Card index 2 = "Gama" (null metrics).
+    const cards: HTMLElement[] = fixture.nativeElement.querySelectorAll('[data-testid="fund-metrics"]');
+    const gama = cards[2];
+    expect(gama.querySelector('[data-testid="metric-annualizedReturn"]')!.textContent!.trim()).toBe('—');
+    expect(gama.querySelector('[data-testid="metric-rewardToVariability"]')!.textContent!.trim()).toBe('—');
+  });
+
+  it('should render the "not enough data" hint only for null-metric funds', () => {
+    setup();
+    const hints: HTMLElement[] = fixture.nativeElement.querySelectorAll('[data-testid="metric-empty-hint"]');
+    expect(hints.length).toBe(1);
+  });
+
+  describe('sorting by metrics', () => {
+    it('should sort ascending by annualizedReturn with null funds last', () => {
+      setup();
+      component.setSort('annualizedReturn');
+
+      expect(component.sortField).toBe('annualizedReturn');
+      expect(component.sortDir).toBe('asc');
+      // 0.05 (Alfa), 0.18 (Beta), null (Gama) — null last.
+      expect(component.funds.map(f => f.id)).toEqual([1, 2, 3]);
+    });
+
+    it('should keep null-metric funds last even when descending', () => {
+      setup();
+      component.setSort('annualizedReturn'); // asc
+      component.setSort('annualizedReturn'); // toggles to desc
+
+      expect(component.sortDir).toBe('desc');
+      // 0.18 (Beta), 0.05 (Alfa), null (Gama) — null STILL last.
+      expect(component.funds.map(f => f.id)).toEqual([2, 1, 3]);
+    });
+
+    it('should sort by volatility ascending with null funds last', () => {
+      setup();
+      component.setSort('volatility');
+
+      // 0.03 (Beta), 0.07 (Alfa), null (Gama).
+      expect(component.funds.map(f => f.id)).toEqual([2, 1, 3]);
+    });
+
+    it('should sort by rewardToVariability with null funds last', () => {
+      setup();
+      component.setSort('rewardToVariability');
+
+      // 1.1 (Alfa), 2.2 (Beta), null (Gama).
+      expect(component.funds.map(f => f.id)).toEqual([1, 2, 3]);
+    });
+
+    it('should still sort plain fields normally (no null-last special case)', () => {
+      setup();
+      // sortField defaults to 'naziv' asc -> a single setSort('naziv') toggles to desc.
+      component.setSort('naziv');
+
+      expect(component.sortDir).toBe('desc');
+      expect(component.funds.map(f => f.naziv)).toEqual(['Gama', 'Beta', 'Alfa']);
+    });
+  });
+
+  describe('metric formatting helpers', () => {
+    beforeEach(() => setup());
+
+    it('metricPercent should render a fraction as a percentage', () => {
+      expect(component.metricPercent(0.1234)).toContain('12,34');
+      expect(component.metricPercent(0.1234)).toContain('%');
+    });
+
+    it('metricPercent should render "—" for null', () => {
+      expect(component.metricPercent(null)).toBe('—');
+    });
+
+    it('metricRatio should render a ratio with 2 decimals', () => {
+      expect(component.metricRatio(1.5)).toBe('1,50');
+    });
+
+    it('metricRatio should render "—" for null', () => {
+      expect(component.metricRatio(null)).toBe('—');
+    });
+  });
+
+  it('should show an error state when discovery fails', () => {
+    fundServiceSpy.discovery.and.returnValue(throwError(() => ({ error: { message: 'boom' } })));
+    fixture = TestBed.createComponent(FundDiscoveryComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    expect(component.error).toBe('boom');
+    expect(component.loading).toBeFalse();
+  });
+});

--- a/src/app/features/funds/components/fund-discovery/fund-discovery.component.ts
+++ b/src/app/features/funds/components/fund-discovery/fund-discovery.component.ts
@@ -4,8 +4,26 @@ import { FundService } from '../../services/fund.service';
 import { InvestmentFund } from '../../models/fund.model';
 import { AuthService } from '../../../../core/services/auth.service';
 
-type SortField = 'naziv' | 'totalValue' | 'profit' | 'minimumContribution';
+// WP-26: sort polja prosirena sa 4 metric kljuca (Celina 4 — statistika fondova).
+type SortField =
+  | 'naziv'
+  | 'totalValue'
+  | 'profit'
+  | 'minimumContribution'
+  | 'annualizedReturn'
+  | 'rewardToVariability'
+  | 'maxDrawdown'
+  | 'volatility';
 type SortDir = 'asc' | 'desc';
+
+// WP-26: metric kljucevi tretirani posebno pri sortiranju — null vrednosti
+// (fond bez dovoljno snapshot-ova) uvek idu poslednje, nezavisno od smera.
+const METRIC_FIELDS: ReadonlySet<SortField> = new Set<SortField>([
+  'annualizedReturn',
+  'rewardToVariability',
+  'maxDrawdown',
+  'volatility',
+]);
 
 @Component({
   selector: 'app-fund-discovery',
@@ -38,14 +56,30 @@ export class FundDiscoveryComponent implements OnInit {
 
   apply(): void {
     const q = this.search.trim().toLowerCase();
-    let result = q
+    const result = q
       ? this.allFunds.filter(f => f.naziv.toLowerCase().includes(q) || (f.opis || '').toLowerCase().includes(q))
       : [...this.allFunds];
 
+    const field = this.sortField;
+    const isMetric = METRIC_FIELDS.has(field);
     result.sort((a, b) => {
-      const av = a[this.sortField] as string | number;
-      const bv = b[this.sortField] as string | number;
-      const cmp = av < bv ? -1 : av > bv ? 1 : 0;
+      const av = a[field] as string | number | null;
+      const bv = b[field] as string | number | null;
+
+      // WP-26: fondovi bez metrike (null) uvek na dno, bez obzira na sortDir.
+      if (isMetric) {
+        const aNull = av === null || av === undefined;
+        const bNull = bv === null || bv === undefined;
+        if (aNull && bNull) return 0;
+        if (aNull) return 1;
+        if (bNull) return -1;
+      }
+
+      const cmp = (av as string | number) < (bv as string | number)
+        ? -1
+        : (av as string | number) > (bv as string | number)
+          ? 1
+          : 0;
       return this.sortDir === 'asc' ? cmp : -cmp;
     });
 
@@ -60,5 +94,27 @@ export class FundDiscoveryComponent implements OnInit {
       this.sortDir = 'asc';
     }
     this.apply();
+  }
+
+  /** WP-26: frakcija (0.12) -> procenat string ("12,00%"); null -> placeholder. */
+  metricPercent(value: number | null): string {
+    if (value === null || value === undefined) {
+      return '—';
+    }
+    return `${(value * 100).toLocaleString('sr-RS', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })}%`;
+  }
+
+  /** WP-26: reward-to-variability je ratio (ne procenat) — 2 decimale, null -> placeholder. */
+  metricRatio(value: number | null): string {
+    if (value === null || value === undefined) {
+      return '—';
+    }
+    return value.toLocaleString('sr-RS', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
   }
 }

--- a/src/app/features/funds/funds.module.ts
+++ b/src/app/features/funds/funds.module.ts
@@ -12,6 +12,8 @@ import { CreateFundComponent } from './components/create-fund/create-fund.compon
 // PR_19 C19.5 + C19.6: shared standalone components.
 import { StateComponent } from '../../shared/components/state/state.component';
 import { FormModalComponent } from '../../shared/components/form-modal/form-modal.component';
+// WP-26: standalone multi-series chart za statistiku fondova.
+import { FundHistoryChartComponent } from '../../shared/charts/fund-history-chart/fund-history-chart.component';
 import { roleGuard } from '../../core/guards/role.guard';
 
 const routes: Routes = [
@@ -51,6 +53,7 @@ const routes: Routes = [
     ReactiveFormsModule,
     RouterModule.forChild(routes),
     StateComponent,
-    FormModalComponent],
+    FormModalComponent,
+    FundHistoryChartComponent],
 })
 export class FundsModule {}

--- a/src/app/features/funds/models/fund.model.ts
+++ b/src/app/features/funds/models/fund.model.ts
@@ -12,6 +12,35 @@ export interface InvestmentFund {
   datumKreiranja: string;
   totalValue: number;
   profit: number;
+  // WP-26 (Celina 4 — statistika fondova): performance metrike sa backend-a.
+  // Sve su frakcije (0.12 = 12%) i null kad fond nema dovoljno snapshot-ova.
+  annualizedReturn: number | null;
+  rewardToVariability: number | null;
+  maxDrawdown: number | null;
+  volatility: number | null;
+}
+
+/**
+ * WP-26: rezultat `GET /funds/{id}/statistics`. `metricsAvailable=false` znaci da
+ * fond jos uvek nema dovoljno istorijskih snapshot-ova — tada su sve metrike null.
+ */
+export interface FundStatistics {
+  metricsAvailable: boolean;
+  annualizedReturn: number | null;
+  rewardToVariability: number | null;
+  maxDrawdown: number | null;
+  volatility: number | null;
+}
+
+/**
+ * WP-26: jedna tacka u istoriji vrednosti fonda (`FundValueSnapshot`).
+ * Koristi se i za seriju jednog fonda (`/funds/{id}/value-history`) i za
+ * sistemski prosek (`/funds/value-history/average`).
+ */
+export interface FundValueSnapshotPoint {
+  snapshotDate: string;
+  totalValue: number;
+  profit: number;
 }
 
 export interface ClientFundPosition {

--- a/src/app/features/funds/services/fund.service.spec.ts
+++ b/src/app/features/funds/services/fund.service.spec.ts
@@ -1,0 +1,159 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+import { FundService } from './fund.service';
+import { environment } from '../../../../environments/environment';
+import { FundStatistics, FundValueSnapshotPoint } from '../models/fund.model';
+
+describe('FundService', () => {
+  let service: FundService;
+  let httpMock: HttpTestingController;
+
+  const baseUrl = `${environment.apiUrl}/funds`;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [FundService],
+    });
+
+    service = TestBed.inject(FundService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('discovery', () => {
+    it('should fetch the fund list without sort params by default', () => {
+      service.discovery().subscribe();
+
+      const req = httpMock.expectOne(baseUrl);
+      expect(req.request.method).toBe('GET');
+      expect(req.request.params.keys().length).toBe(0);
+      req.flush([]);
+    });
+
+    it('should pass sort and direction params when provided', () => {
+      service.discovery('annualizedReturn', 'desc').subscribe();
+
+      const req = httpMock.expectOne(
+        (r) =>
+          r.url === baseUrl &&
+          r.params.get('sort') === 'annualizedReturn' &&
+          r.params.get('direction') === 'desc',
+      );
+      expect(req.request.method).toBe('GET');
+      req.flush([]);
+    });
+
+    it('should map the metric fields, defaulting missing ones to null', () => {
+      let result: any;
+      service.discovery().subscribe((funds) => (result = funds));
+
+      const req = httpMock.expectOne(baseUrl);
+      req.flush([
+        { id: 1, naziv: 'A', annualizedReturn: 0.12, volatility: 0.05 },
+        { id: 2, naziv: 'B' },
+      ]);
+
+      expect(result[0].annualizedReturn).toBe(0.12);
+      expect(result[0].volatility).toBe(0.05);
+      expect(result[0].rewardToVariability).toBeNull();
+      expect(result[0].maxDrawdown).toBeNull();
+      expect(result[1].annualizedReturn).toBeNull();
+      expect(result[1].rewardToVariability).toBeNull();
+      expect(result[1].maxDrawdown).toBeNull();
+      expect(result[1].volatility).toBeNull();
+    });
+  });
+
+  describe('getStatistics', () => {
+    it('should fetch the statistics for a fund', () => {
+      const payload: FundStatistics = {
+        metricsAvailable: true,
+        annualizedReturn: 0.12,
+        rewardToVariability: 1.4,
+        maxDrawdown: -0.08,
+        volatility: 0.06,
+      };
+      let result: FundStatistics | undefined;
+      service.getStatistics(7).subscribe((s) => (result = s));
+
+      const req = httpMock.expectOne(`${baseUrl}/7/statistics`);
+      expect(req.request.method).toBe('GET');
+      req.flush(payload);
+
+      expect(result).toEqual(payload);
+    });
+  });
+
+  describe('getValueHistory', () => {
+    it('should fetch the value-history series for a fund', () => {
+      const series: FundValueSnapshotPoint[] = [
+        { snapshotDate: '2026-01-01', totalValue: 1000, profit: 0 },
+        { snapshotDate: '2026-02-01', totalValue: 1100, profit: 100 },
+      ];
+      let result: FundValueSnapshotPoint[] | undefined;
+      service.getValueHistory(7).subscribe((s) => (result = s));
+
+      const req = httpMock.expectOne(`${baseUrl}/7/value-history`);
+      expect(req.request.method).toBe('GET');
+      req.flush(series);
+
+      expect(result).toEqual(series);
+    });
+
+    it('should return an empty array when the body is null', () => {
+      let result: FundValueSnapshotPoint[] | undefined;
+      service.getValueHistory(7).subscribe((s) => (result = s));
+
+      httpMock.expectOne(`${baseUrl}/7/value-history`).flush(null);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('fundPerformance', () => {
+    it('should be backed by the value-history endpoint', () => {
+      let result: FundValueSnapshotPoint[] | undefined;
+      service.fundPerformance(9).subscribe((s) => (result = s));
+
+      const req = httpMock.expectOne(`${baseUrl}/9/value-history`);
+      expect(req.request.method).toBe('GET');
+      req.flush([{ snapshotDate: '2026-03-01', totalValue: 500, profit: 5 }]);
+
+      expect(result?.length).toBe(1);
+    });
+  });
+
+  describe('getAverageValueHistory', () => {
+    it('should fetch the system-wide average series', () => {
+      const series: FundValueSnapshotPoint[] = [
+        { snapshotDate: '2026-01-01', totalValue: 900, profit: 0 },
+      ];
+      let result: FundValueSnapshotPoint[] | undefined;
+      service.getAverageValueHistory().subscribe((s) => (result = s));
+
+      const req = httpMock.expectOne(`${baseUrl}/value-history/average`);
+      expect(req.request.method).toBe('GET');
+      req.flush(series);
+
+      expect(result).toEqual(series);
+    });
+
+    it('should return an empty array when the body is null', () => {
+      let result: FundValueSnapshotPoint[] | undefined;
+      service.getAverageValueHistory().subscribe((s) => (result = s));
+
+      httpMock.expectOne(`${baseUrl}/value-history/average`).flush(null);
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/app/features/funds/services/fund.service.ts
+++ b/src/app/features/funds/services/fund.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -10,6 +10,8 @@ import {
   ClientFundPosition,
   ClientFundTransaction,
   FundHolding,
+  FundStatistics,
+  FundValueSnapshotPoint,
   InvestmentFund,
   InvestmentRequest,
   RedemptionRequest,
@@ -28,9 +30,50 @@ export class FundService {
 
   constructor(private http: HttpClient) {}
 
-  discovery(): Observable<InvestmentFund[]> {
-    return this.http.get<any[]>(this.baseUrl).pipe(
+  /**
+   * WP-26: discovery lista. `sort`/`direction` su opcioni — backend prihvata
+   * postojeca polja plus 4 metric naziva (annualizedReturn, rewardToVariability,
+   * maxDrawdown, volatility). Komponenta i dalje sortira klijent-side, ali
+   * parametri se prosledjuju kad se eksplicitno zatraze.
+   */
+  discovery(sort?: string, direction?: 'asc' | 'desc'): Observable<InvestmentFund[]> {
+    let params = new HttpParams();
+    if (sort) {
+      params = params.set('sort', sort);
+    }
+    if (direction) {
+      params = params.set('direction', direction);
+    }
+    return this.http.get<any[]>(this.baseUrl, { params }).pipe(
       map((funds) => (funds ?? []).map((fund) => this.mapFund(fund))),
+    );
+  }
+
+  /** WP-26: performance metrike fonda (`GET /funds/{id}/statistics`). */
+  getStatistics(fundId: number): Observable<FundStatistics> {
+    return this.http.get<FundStatistics>(`${this.baseUrl}/${fundId}/statistics`);
+  }
+
+  /** WP-26: realna istorija vrednosti fonda (`FundValueSnapshot` serija, rastuca po datumu). */
+  getValueHistory(fundId: number): Observable<FundValueSnapshotPoint[]> {
+    return this.http.get<FundValueSnapshotPoint[]>(`${this.baseUrl}/${fundId}/value-history`).pipe(
+      map((points) => points ?? []),
+    );
+  }
+
+  /**
+   * WP-26: alias za `getValueHistory` — implementation plan referencira
+   * `fundPerformance()` koji je nedostajao u servisu. Backed je realnim
+   * `/funds/{id}/value-history` endpoint-om.
+   */
+  fundPerformance(fundId: number): Observable<FundValueSnapshotPoint[]> {
+    return this.getValueHistory(fundId);
+  }
+
+  /** WP-26: sistemski prosek snapshot serije preko svih fondova (za comparison chart). */
+  getAverageValueHistory(): Observable<FundValueSnapshotPoint[]> {
+    return this.http.get<FundValueSnapshotPoint[]>(`${this.baseUrl}/value-history/average`).pipe(
+      map((points) => points ?? []),
     );
   }
 
@@ -113,7 +156,18 @@ export class FundService {
         fund.account?.account_id,
       ),
       accountNumber: fund.accountNumber ?? fund.account?.accountNumber ?? fund.account?.brojRacuna,
+      // WP-26: metrike su nullable na backend-u (null kad fond nema dovoljno
+      // snapshot-ova). Normalizujemo `undefined` -> `null` da template uvek
+      // ima determinisanu vrednost za "Nedovoljno podataka" placeholder.
+      annualizedReturn: this.normalizeMetric(fund.annualizedReturn),
+      rewardToVariability: this.normalizeMetric(fund.rewardToVariability),
+      maxDrawdown: this.normalizeMetric(fund.maxDrawdown),
+      volatility: this.normalizeMetric(fund.volatility),
     } as InvestmentFund;
+  }
+
+  private normalizeMetric(value: unknown): number | null {
+    return typeof value === 'number' && Number.isFinite(value) ? value : null;
   }
 
   private normalizeAccountId(value: unknown): number | undefined {

--- a/src/app/features/notifications/notifications.component.html
+++ b/src/app/features/notifications/notifications.component.html
@@ -1,0 +1,82 @@
+<div class="z-stagger space-y-4">
+  <header class="flex items-center justify-between flex-wrap gap-3">
+    <div>
+      <h1 class="text-2xl font-bold tracking-tight">Notifikacije</h1>
+      <p class="text-sm text-muted-foreground mt-1">
+        Pregled obavestenja vezanih za vas nalog.
+      </p>
+    </div>
+    <button
+      type="button"
+      class="z-btn-secondary"
+      [disabled]="markingAll || unreadOnPage === 0"
+      (click)="markAllRead()"
+    >
+      Oznaci sve kao procitano
+    </button>
+  </header>
+
+  <app-state *ngIf="isLoading" mode="loading" text="Ucitavanje notifikacija..."></app-state>
+  <app-state
+    *ngIf="!isLoading && error"
+    mode="error"
+    title="Greska"
+    [text]="error || ''"
+  ></app-state>
+  <app-state
+    *ngIf="!isLoading && !error && notifications.length === 0"
+    mode="empty"
+    icon="bell"
+    title="Nema notifikacija"
+    text="Trenutno nemate nijedno obavestenje."
+  ></app-state>
+
+  <div *ngIf="!isLoading && !error && notifications.length > 0" class="z-card overflow-hidden">
+    <ul class="divide-y divide-border">
+      <li
+        *ngFor="let n of notifications; trackBy: trackByNotification"
+        class="flex items-start gap-3 px-4 py-3"
+        [class.bg-accent]="!n.read"
+      >
+        <span
+          class="mt-1.5 h-2 w-2 flex-shrink-0 rounded-full"
+          [class.bg-primary]="!n.read"
+          [class.bg-transparent]="n.read"
+          [attr.aria-label]="n.read ? 'Procitano' : 'Neprocitano'"
+        ></span>
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center justify-between gap-3">
+            <p class="font-semibold text-sm truncate" [class.text-muted-foreground]="n.read">
+              {{ n.title }}
+            </p>
+            <span class="text-xs text-muted-foreground whitespace-nowrap">
+              {{ n.createdAt | date: 'dd.MM.yyyy. HH:mm' }}
+            </span>
+          </div>
+          <p class="text-sm text-muted-foreground mt-0.5">{{ n.body }}</p>
+        </div>
+        <button
+          *ngIf="!n.read"
+          type="button"
+          class="z-btn-icon flex-shrink-0"
+          title="Oznaci kao procitano"
+          aria-label="Oznaci kao procitano"
+          (click)="markRead(n)"
+        >
+          <lucide-icon name="shieldcheck" [size]="14"></lucide-icon>
+        </button>
+      </li>
+    </ul>
+    <div class="px-4 py-3 border-t border-border flex items-center justify-between flex-wrap gap-3">
+      <span class="text-sm text-muted-foreground">
+        {{ totalElements }} notifikacija ukupno
+      </span>
+      <app-pagination
+        [total]="totalElements"
+        [pageSize]="pageSize"
+        [page]="currentPage + 1"
+        (pageChange)="onPageChange($event - 1)"
+      ></app-pagination>
+    </div>
+  </div>
+</div>

--- a/src/app/features/notifications/notifications.component.spec.ts
+++ b/src/app/features/notifications/notifications.component.spec.ts
@@ -1,0 +1,144 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+
+import { NotificationsComponent } from './notifications.component';
+import { NotificationService } from '../../core/services/notification.service';
+import { ToastService } from '../../shared/services/toast.service';
+import { Notification, NotificationPage } from '../../core/models/notification.model';
+
+function notif(id: number, read = false): Notification {
+  return {
+    id,
+    type: 'PAYMENT',
+    title: `Naslov ${id}`,
+    body: `Telo ${id}`,
+    read,
+    referenceId: null,
+    createdAt: '2026-05-19T10:00:00Z',
+  };
+}
+
+function page(content: Notification[], totalElements = content.length): NotificationPage {
+  return {
+    content,
+    totalElements,
+    totalPages: Math.max(1, Math.ceil(totalElements / 10)),
+    number: 0,
+    size: 10,
+  };
+}
+
+describe('NotificationsComponent', () => {
+  let fixture: ComponentFixture<NotificationsComponent>;
+  let component: NotificationsComponent;
+  let notificationService: jasmine.SpyObj<NotificationService>;
+  let toast: jasmine.SpyObj<ToastService>;
+
+  beforeEach(async () => {
+    notificationService = jasmine.createSpyObj('NotificationService', [
+      'list',
+      'markRead',
+      'markAllRead',
+    ]);
+    toast = jasmine.createSpyObj('ToastService', ['success', 'error']);
+
+    await TestBed.configureTestingModule({
+      imports: [NotificationsComponent],
+      providers: [
+        { provide: NotificationService, useValue: notificationService },
+        { provide: ToastService, useValue: toast },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NotificationsComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('loads the first page on init', () => {
+    notificationService.list.and.returnValue(of(page([notif(1), notif(2, true)], 2)));
+    fixture.detectChanges();
+
+    expect(notificationService.list).toHaveBeenCalledWith(0, 10);
+    expect(component.notifications.length).toBe(2);
+    expect(component.totalElements).toBe(2);
+    expect(component.isLoading).toBeFalse();
+  });
+
+  it('sets an error message when the feed fails to load', () => {
+    notificationService.list.and.returnValue(
+      throwError(() => new Error('network')),
+    );
+    fixture.detectChanges();
+
+    expect(component.error).toBe('Greska pri ucitavanju notifikacija.');
+    expect(component.isLoading).toBeFalse();
+  });
+
+  it('counts unread notifications on the current page', () => {
+    notificationService.list.and.returnValue(
+      of(page([notif(1), notif(2, true), notif(3)], 3)),
+    );
+    fixture.detectChanges();
+    expect(component.unreadOnPage).toBe(2);
+  });
+
+  it('onPageChange reloads with the new 0-indexed page', () => {
+    notificationService.list.and.returnValue(of(page([], 50)));
+    fixture.detectChanges();
+
+    component.onPageChange(3);
+    expect(component.currentPage).toBe(3);
+    expect(notificationService.list).toHaveBeenCalledWith(3, 10);
+  });
+
+  it('markRead flips the row to read on success', () => {
+    notificationService.list.and.returnValue(of(page([notif(1)], 1)));
+    notificationService.markRead.and.returnValue(of(void 0));
+    fixture.detectChanges();
+
+    const n = component.notifications[0];
+    component.markRead(n);
+    expect(notificationService.markRead).toHaveBeenCalledWith(1);
+    expect(n.read).toBeTrue();
+  });
+
+  it('markRead is a no-op for an already-read notification', () => {
+    notificationService.list.and.returnValue(of(page([notif(1, true)], 1)));
+    fixture.detectChanges();
+
+    component.markRead(component.notifications[0]);
+    expect(notificationService.markRead).not.toHaveBeenCalled();
+  });
+
+  it('markRead surfaces an error toast on failure', () => {
+    notificationService.list.and.returnValue(of(page([notif(1)], 1)));
+    notificationService.markRead.and.returnValue(
+      throwError(() => new Error('boom')),
+    );
+    fixture.detectChanges();
+
+    component.markRead(component.notifications[0]);
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it('markAllRead reloads and toasts success', () => {
+    notificationService.list.and.returnValue(of(page([notif(1)], 1)));
+    notificationService.markAllRead.and.returnValue(of(void 0));
+    fixture.detectChanges();
+    notificationService.list.calls.reset();
+
+    component.markAllRead();
+    expect(notificationService.markAllRead).toHaveBeenCalled();
+    expect(toast.success).toHaveBeenCalled();
+    expect(notificationService.list).toHaveBeenCalled();
+    expect(component.markingAll).toBeFalse();
+  });
+
+  it('markAllRead is a no-op when nothing is unread', () => {
+    notificationService.list.and.returnValue(of(page([notif(1, true)], 1)));
+    fixture.detectChanges();
+
+    component.markAllRead();
+    expect(notificationService.markAllRead).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/features/notifications/notifications.component.ts
+++ b/src/app/features/notifications/notifications.component.ts
@@ -1,0 +1,114 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+
+import { NotificationService } from '../../core/services/notification.service';
+import { Notification } from '../../core/models/notification.model';
+import { StateComponent } from '../../shared/components/state/state.component';
+import { AppPaginationComponent } from '../../shared/components/pagination/pagination.component';
+import { LucideIconComponent } from '../../shared/icons/lucide-icon.component';
+import { ToastService } from '../../shared/services/toast.service';
+
+/**
+ * WP-21 (Celina 2): full in-app notifications page (`/notifications`).
+ *
+ * <p>Server-paginated list of the caller's notification feed (newest first)
+ * with a per-row "mark as read" action and a global "mark all read" button.
+ * Reachable by every authenticated user — no extra permission — both from
+ * the route and from the topbar bell panel "see all" link.
+ *
+ * <p>Standalone, lazy-loaded via `loadComponent` so it stays out of the
+ * initial bundle.
+ */
+@Component({
+  selector: 'app-notifications',
+  standalone: true,
+  imports: [
+    CommonModule,
+    StateComponent,
+    AppPaginationComponent,
+    LucideIconComponent,
+  ],
+  templateUrl: './notifications.component.html',
+})
+export class NotificationsComponent implements OnInit {
+  notifications: Notification[] = [];
+  totalElements = 0;
+  pageSize = 10;
+  /** 0-indexed page number (matches the Spring Data `Page` envelope). */
+  currentPage = 0;
+
+  isLoading = true;
+  error: string | null = null;
+  /** True while a mark-all-read request is in flight. */
+  markingAll = false;
+
+  constructor(
+    private readonly notificationService: NotificationService,
+    private readonly toast: ToastService,
+  ) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.isLoading = true;
+    this.error = null;
+    this.notificationService.list(this.currentPage, this.pageSize).subscribe({
+      next: (page) => {
+        this.notifications = page?.content ?? [];
+        this.totalElements = page?.totalElements ?? 0;
+        this.isLoading = false;
+      },
+      error: () => {
+        this.isLoading = false;
+        this.error = 'Greska pri ucitavanju notifikacija.';
+      },
+    });
+  }
+
+  onPageChange(page: number): void {
+    this.currentPage = page;
+    this.load();
+  }
+
+  /** Number of unread notifications on the current page. */
+  get unreadOnPage(): number {
+    return this.notifications.filter((n) => !n.read).length;
+  }
+
+  markRead(n: Notification): void {
+    if (n.read) {
+      return;
+    }
+    this.notificationService.markRead(n.id).subscribe({
+      next: () => {
+        /* Optimistic local flip — avoids a full page reload. */
+        n.read = true;
+      },
+      error: () => this.toast.error('Greska pri oznacavanju notifikacije.'),
+    });
+  }
+
+  markAllRead(): void {
+    if (this.markingAll || this.unreadOnPage === 0) {
+      return;
+    }
+    this.markingAll = true;
+    this.notificationService.markAllRead().subscribe({
+      next: () => {
+        this.markingAll = false;
+        this.toast.success('Sve notifikacije su oznacene kao procitane.');
+        this.load();
+      },
+      error: () => {
+        this.markingAll = false;
+        this.toast.error('Greska pri oznacavanju notifikacija.');
+      },
+    });
+  }
+
+  trackByNotification(_: number, n: Notification): number {
+    return n.id;
+  }
+}

--- a/src/app/features/orders/components/my-orders/my-orders.component.html
+++ b/src/app/features/orders/components/my-orders/my-orders.component.html
@@ -1,0 +1,102 @@
+<!-- WP-22 (Celina 3): "Moji orderi" — order history page. -->
+<div class="space-y-6">
+  <div class="flex items-center justify-between">
+    <h1 class="text-2xl font-bold text-foreground">Moji orderi</h1>
+  </div>
+
+  <!-- Filter bar -->
+  <div class="z-card p-5">
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-3">
+      <div>
+        <label class="z-label" for="mo-status">Status</label>
+        <select id="mo-status" class="z-select" [(ngModel)]="statusFilter">
+          <option *ngFor="let o of statusOptions" [ngValue]="o.value">{{ o.label }}</option>
+        </select>
+      </div>
+      <div>
+        <label class="z-label" for="mo-direction">Smer</label>
+        <select id="mo-direction" class="z-select" [(ngModel)]="directionFilter">
+          <option *ngFor="let o of directionOptions" [ngValue]="o.value">{{ o.label }}</option>
+        </select>
+      </div>
+      <div>
+        <label class="z-label" for="mo-type">Tip hartije</label>
+        <select id="mo-type" class="z-select" [(ngModel)]="securityTypeFilter">
+          <option *ngFor="let o of securityTypeOptions" [ngValue]="o.value">{{ o.label }}</option>
+        </select>
+      </div>
+      <div>
+        <label class="z-label" for="mo-from">Datum od</label>
+        <input id="mo-from" type="date" class="z-input" [(ngModel)]="fromDate" />
+      </div>
+      <div>
+        <label class="z-label" for="mo-to">Datum do</label>
+        <input id="mo-to" type="date" class="z-input" [(ngModel)]="toDate" />
+      </div>
+    </div>
+    <div class="flex justify-end gap-2 mt-4">
+      <button type="button" class="z-btn-outline z-btn-sm" (click)="clearFilters()">Resetuj</button>
+      <button type="button" class="z-btn-primary z-btn-sm" (click)="applyFilters()">Primeni</button>
+    </div>
+  </div>
+
+  <!-- States -->
+  <app-state *ngIf="isLoading" mode="loading" text="Ucitavanje ordera..."></app-state>
+  <app-state *ngIf="!isLoading && error" mode="error" [text]="error"></app-state>
+  <app-state
+    *ngIf="!isLoading && !error && orders.length === 0"
+    mode="empty"
+    title="Nema ordera"
+    text="Nema ordera za zadate filtere."
+  ></app-state>
+
+  <!-- Orders table -->
+  <div *ngIf="!isLoading && !error && orders.length > 0" class="z-card">
+    <table class="z-table">
+      <thead>
+        <tr>
+          <th>TIP</th>
+          <th>HARTIJA</th>
+          <th>SMER</th>
+          <th class="text-right">KOLICINA</th>
+          <th class="text-right">CENA</th>
+          <th class="text-right">PROVIZIJA</th>
+          <th>STATUS</th>
+          <th>KREIRAN</th>
+          <th>IZVRSEN</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let o of orders; trackBy: trackByOrder">
+          <td class="font-semibold">{{ o.orderType }}</td>
+          <td>
+            <span class="font-semibold">{{ o.ticker }}</span>
+            <span class="block text-xs text-muted-foreground">{{ o.securityName }}</span>
+            <span class="block text-[10px] text-muted-foreground/70">{{ o.listingType }}</span>
+          </td>
+          <td>{{ directionLabel(o.direction) }}</td>
+          <td class="text-right font-mono tabular-nums">{{ o.quantity }}</td>
+          <td class="text-right font-mono tabular-nums">{{ o.pricePerUnit | number: '1.2-2' }}</td>
+          <td class="text-right font-mono tabular-nums">{{ o.fee | number: '1.2-2' }}</td>
+          <td><span [class]="statusBadgeClass(o.status)">{{ statusLabel(o.status) }}</span></td>
+          <td class="text-muted-foreground whitespace-nowrap">
+            {{ o.createdAt | date: 'dd.MM.yyyy. HH:mm' }}
+          </td>
+          <td class="text-muted-foreground whitespace-nowrap">
+            {{ o.lastModification | date: 'dd.MM.yyyy. HH:mm' }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="flex justify-between items-center px-5 py-3 border-t border-border">
+      <span class="text-sm text-muted-foreground">Ukupno: {{ totalElements }}</span>
+      <app-pagination
+        [total]="totalElements"
+        [pageSize]="pageSize"
+        [page]="currentPage + 1"
+        (pageChange)="onPageChange($event - 1)"
+      ></app-pagination>
+    </div>
+  </div>
+</div>

--- a/src/app/features/orders/components/my-orders/my-orders.component.spec.ts
+++ b/src/app/features/orders/components/my-orders/my-orders.component.spec.ts
@@ -1,0 +1,142 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+
+import { MyOrdersComponent } from './my-orders.component';
+import { MyOrderService } from '../../services/my-order.service';
+import { MyOrder, MyOrderPage } from '../../models/my-order.model';
+
+function order(id: number, overrides: Partial<MyOrder> = {}): MyOrder {
+  return {
+    id,
+    orderType: 'MARKET',
+    listingType: 'STOCK',
+    ticker: `TKR${id}`,
+    securityName: `Security ${id}`,
+    quantity: 10,
+    pricePerUnit: 100,
+    status: 'DONE',
+    direction: 'BUY',
+    createdAt: '2026-05-01T10:00:00Z',
+    lastModification: '2026-05-01T10:05:00Z',
+    fee: 7,
+    ...overrides,
+  };
+}
+
+function page(content: MyOrder[], totalElements = content.length): MyOrderPage {
+  return {
+    content,
+    page: {
+      size: 10,
+      number: 0,
+      totalElements,
+      totalPages: Math.max(1, Math.ceil(totalElements / 10)),
+    },
+  };
+}
+
+describe('MyOrdersComponent', () => {
+  let fixture: ComponentFixture<MyOrdersComponent>;
+  let component: MyOrdersComponent;
+  let myOrderService: jasmine.SpyObj<MyOrderService>;
+
+  beforeEach(async () => {
+    myOrderService = jasmine.createSpyObj('MyOrderService', ['getMyOrders']);
+    myOrderService.getMyOrders.and.returnValue(of(page([])));
+
+    await TestBed.configureTestingModule({
+      imports: [MyOrdersComponent],
+      providers: [{ provide: MyOrderService, useValue: myOrderService }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MyOrdersComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('creates', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('loads the first page on init', () => {
+    myOrderService.getMyOrders.and.returnValue(of(page([order(1), order(2)], 2)));
+    fixture.detectChanges();
+
+    expect(myOrderService.getMyOrders).toHaveBeenCalledWith({}, 0, 10);
+    expect(component.orders.length).toBe(2);
+    expect(component.totalElements).toBe(2);
+    expect(component.isLoading).toBeFalse();
+  });
+
+  it('sets an error message when the history fails to load', () => {
+    myOrderService.getMyOrders.and.returnValue(throwError(() => new Error('network')));
+    fixture.detectChanges();
+
+    expect(component.error).toBe('Greska pri ucitavanju ordera.');
+    expect(component.isLoading).toBeFalse();
+  });
+
+  it('applyFilters resets to page 0 and forwards the filter', () => {
+    fixture.detectChanges();
+    component.currentPage = 4;
+    component.statusFilter = 'DONE';
+    component.directionFilter = 'SELL';
+    component.securityTypeFilter = 'STOCK';
+    component.fromDate = '2026-01-01';
+    component.toDate = '2026-05-19';
+
+    component.applyFilters();
+
+    expect(component.currentPage).toBe(0);
+    expect(myOrderService.getMyOrders).toHaveBeenCalledWith(
+      {
+        status: 'DONE',
+        direction: 'SELL',
+        securityType: 'STOCK',
+        from: '2026-01-01',
+        to: '2026-05-19',
+      },
+      0,
+      10,
+    );
+  });
+
+  it('clearFilters wipes every field and reloads with an empty filter', () => {
+    fixture.detectChanges();
+    component.statusFilter = 'DONE';
+    component.directionFilter = 'BUY';
+    component.securityTypeFilter = 'FOREX';
+    component.fromDate = '2026-01-01';
+    component.toDate = '2026-05-19';
+    myOrderService.getMyOrders.calls.reset();
+
+    component.clearFilters();
+
+    expect(component.statusFilter).toBe('');
+    expect(component.directionFilter).toBe('');
+    expect(component.securityTypeFilter).toBe('');
+    expect(component.fromDate).toBe('');
+    expect(component.toDate).toBe('');
+    expect(myOrderService.getMyOrders).toHaveBeenCalledWith({}, 0, 10);
+  });
+
+  it('onPageChange reloads with the new 0-indexed page', () => {
+    myOrderService.getMyOrders.and.returnValue(of(page([], 50)));
+    fixture.detectChanges();
+
+    component.onPageChange(3);
+    expect(component.currentPage).toBe(3);
+    expect(myOrderService.getMyOrders).toHaveBeenCalledWith({}, 3, 10);
+  });
+
+  it('statusBadgeClass maps statuses to the right palette', () => {
+    expect(component.statusBadgeClass('DONE')).toContain('z-badge-green');
+    expect(component.statusBadgeClass('PENDING')).toContain('z-badge-yellow');
+    expect(component.statusBadgeClass('CANCELLED')).toContain('z-badge-red');
+  });
+
+  it('directionLabel returns Serbian labels', () => {
+    expect(component.directionLabel('BUY')).toBe('Kupovina');
+    expect(component.directionLabel('SELL')).toBe('Prodaja');
+  });
+});

--- a/src/app/features/orders/components/my-orders/my-orders.component.ts
+++ b/src/app/features/orders/components/my-orders/my-orders.component.ts
@@ -1,0 +1,184 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+import { StateComponent } from '../../../../shared/components/state/state.component';
+import { AppPaginationComponent } from '../../../../shared/components/pagination/pagination.component';
+import { MyOrderService } from '../../services/my-order.service';
+import {
+  MyOrder,
+  MyOrderFilter,
+  MyOrderPage,
+} from '../../models/my-order.model';
+import { OrderDirection, OrderStatus } from '../../models/order.model';
+
+/**
+ * WP-22 (Celina 3): "Moji orderi" — the caller's own order history page.
+ *
+ * <p>Server-paginated `z-table` of every order the logged-in trader created,
+ * showing the order type, the security (ticker + name), the quantity and
+ * execution price, the status, the creation + last-modification dates and the
+ * paid brokerage commission (`fee`). A filter bar narrows the list by status,
+ * direction, security type and a creation-date range.
+ *
+ * <p>Reachable by every authenticated trader — clients with trading and
+ * actuary agents — via the lazy `orders/my` route. Standalone, lazy-loaded so
+ * it stays out of the initial bundle.
+ */
+
+interface SelectOption<T> {
+  value: T;
+  label: string;
+}
+
+/** Empty sentinel for the "no filter" select option. */
+const ALL = '';
+
+@Component({
+  selector: 'app-my-orders',
+  standalone: true,
+  imports: [CommonModule, FormsModule, StateComponent, AppPaginationComponent],
+  templateUrl: './my-orders.component.html',
+})
+export class MyOrdersComponent implements OnInit {
+  orders: MyOrder[] = [];
+  totalElements = 0;
+  pageSize = 10;
+  /** 0-indexed page number (matches the backend `PagedModel`). */
+  currentPage = 0;
+
+  isLoading = true;
+  error: string | null = null;
+
+  /* Filter-bar model. `''` means "no filter" for that field. */
+  statusFilter: OrderStatus | '' = ALL;
+  directionFilter: OrderDirection | '' = ALL;
+  securityTypeFilter = ALL;
+  fromDate = '';
+  toDate = '';
+
+  readonly statusOptions: SelectOption<OrderStatus | ''>[] = [
+    { value: ALL, label: 'Svi statusi' },
+    { value: 'PENDING_CONFIRMATION', label: 'Ceka potvrdu' },
+    { value: 'PENDING', label: 'Na cekanju' },
+    { value: 'APPROVED', label: 'Odobren' },
+    { value: 'DECLINED', label: 'Odbijen' },
+    { value: 'DONE', label: 'Izvrsen' },
+    { value: 'CANCELLED', label: 'Otkazan' },
+  ];
+
+  readonly directionOptions: SelectOption<OrderDirection | ''>[] = [
+    { value: ALL, label: 'Svi smerovi' },
+    { value: 'BUY', label: 'Kupovina' },
+    { value: 'SELL', label: 'Prodaja' },
+  ];
+
+  readonly securityTypeOptions: SelectOption<string>[] = [
+    { value: ALL, label: 'Sve hartije' },
+    { value: 'STOCK', label: 'Akcije' },
+    { value: 'FUTURE', label: 'Fjucersi' },
+    { value: 'FOREX', label: 'Forex' },
+    { value: 'OPTION', label: 'Opcije' },
+  ];
+
+  constructor(private readonly myOrderService: MyOrderService) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.isLoading = true;
+    this.error = null;
+    this.myOrderService
+      .getMyOrders(this.buildFilter(), this.currentPage, this.pageSize)
+      .subscribe({
+        next: (page: MyOrderPage) => {
+          this.orders = page?.content ?? [];
+          this.totalElements = page?.page?.totalElements ?? 0;
+          this.isLoading = false;
+        },
+        error: () => {
+          this.isLoading = false;
+          this.error = 'Greska pri ucitavanju ordera.';
+        },
+      });
+  }
+
+  /** Applies the current filter bar, resetting to the first page. */
+  applyFilters(): void {
+    this.currentPage = 0;
+    this.load();
+  }
+
+  /** Clears every filter field and reloads. */
+  clearFilters(): void {
+    this.statusFilter = ALL;
+    this.directionFilter = ALL;
+    this.securityTypeFilter = ALL;
+    this.fromDate = '';
+    this.toDate = '';
+    this.currentPage = 0;
+    this.load();
+  }
+
+  onPageChange(page: number): void {
+    this.currentPage = page;
+    this.load();
+  }
+
+  /**
+   * Builds the {@link MyOrderFilter} from the filter-bar model. Only the
+   * fields that actually have a value are included — an unset field is left
+   * off the object entirely rather than set to `undefined`.
+   */
+  private buildFilter(): MyOrderFilter {
+    const filter: MyOrderFilter = {};
+    if (this.statusFilter) {
+      filter.status = this.statusFilter;
+    }
+    if (this.directionFilter) {
+      filter.direction = this.directionFilter;
+    }
+    if (this.securityTypeFilter) {
+      filter.securityType = this.securityTypeFilter;
+    }
+    if (this.fromDate) {
+      filter.from = this.fromDate;
+    }
+    if (this.toDate) {
+      filter.to = this.toDate;
+    }
+    return filter;
+  }
+
+  statusBadgeClass(status: OrderStatus): string {
+    switch (status) {
+      case 'DONE':
+      case 'APPROVED':
+        return 'z-badge z-badge-green';
+      case 'PENDING':
+      case 'PENDING_CONFIRMATION':
+        return 'z-badge z-badge-yellow';
+      case 'DECLINED':
+      case 'CANCELLED':
+        return 'z-badge z-badge-red';
+      default:
+        return 'z-badge z-badge-gray';
+    }
+  }
+
+  statusLabel(status: OrderStatus): string {
+    return (
+      this.statusOptions.find((o) => o.value === status)?.label ?? status
+    );
+  }
+
+  directionLabel(direction: OrderDirection): string {
+    return direction === 'BUY' ? 'Kupovina' : 'Prodaja';
+  }
+
+  trackByOrder(_: number, order: MyOrder): number {
+    return order.id;
+  }
+}

--- a/src/app/features/orders/models/my-order.model.ts
+++ b/src/app/features/orders/models/my-order.model.ts
@@ -1,0 +1,63 @@
+/**
+ * WP-22 (Celina 3): "Moji orderi" — order history model.
+ *
+ * Mirrors the order DTO returned by `GET /orders/my-orders` (trading-service
+ * routed through the gateway at `/orders`). The endpoint is JWT-scoped to the
+ * authenticated caller; the {@link AuthInterceptor} attaches the token.
+ */
+import { OrderDirection, OrderStatus, OrderType } from './order.model';
+
+/**
+ * One row of the caller's order history.
+ *
+ * <p>Includes the security identity (`ticker` / `securityName`), the executed
+ * quantity & per-unit price, the lifecycle `status`, the creation + last
+ * modification timestamps and the paid `fee` (brokerage commission) — exactly
+ * the columns the Celina 3 spec asks the "Moji orderi" page to show.
+ */
+export interface MyOrder {
+  id: number;
+  orderType: OrderType;
+  /** Security category — `STOCK` / `FUTURE` / `FOREX` / `OPTION` (free-form). */
+  listingType: string;
+  ticker: string;
+  securityName: string;
+  quantity: number;
+  pricePerUnit: number;
+  status: OrderStatus;
+  direction: OrderDirection;
+  /** ISO-8601 creation timestamp. */
+  createdAt: string;
+  /** ISO-8601 last-modification timestamp (used as the execution date). */
+  lastModification: string;
+  /** Paid brokerage commission, in the security currency. */
+  fee: number;
+}
+
+/**
+ * `PagedModel`-shaped envelope returned by `GET /orders/my-orders`.
+ *
+ * <p>Note this differs from the plain Spring Data `Page` envelope: the paging
+ * metadata is nested under a `page` object rather than flattened onto the root.
+ */
+export interface MyOrderPage {
+  content: MyOrder[];
+  page: {
+    size: number;
+    number: number;
+    totalElements: number;
+    totalPages: number;
+  };
+}
+
+/** Query filter for `GET /orders/my-orders`. All fields optional. */
+export interface MyOrderFilter {
+  status?: OrderStatus;
+  direction?: OrderDirection;
+  /** Security category filter, e.g. `STOCK`. */
+  securityType?: string;
+  /** ISO date (`yyyy-MM-dd`) lower bound on creation date. */
+  from?: string;
+  /** ISO date (`yyyy-MM-dd`) upper bound on creation date. */
+  to?: string;
+}

--- a/src/app/features/orders/services/my-order.service.spec.ts
+++ b/src/app/features/orders/services/my-order.service.spec.ts
@@ -1,0 +1,96 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+
+import { environment } from '../../../../environments/environment';
+import { MyOrderService } from './my-order.service';
+import { MyOrderPage } from '../models/my-order.model';
+
+const baseUrl = `${environment.apiUrl}/orders/my-orders`;
+
+function emptyPage(): MyOrderPage {
+  return {
+    content: [],
+    page: { size: 10, number: 0, totalElements: 0, totalPages: 0 },
+  };
+}
+
+describe('MyOrderService', () => {
+  let service: MyOrderService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [MyOrderService],
+    });
+    service = TestBed.inject(MyOrderService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('GETs /orders/my-orders with default page/size and no filter params', () => {
+    let result: MyOrderPage | undefined;
+    service.getMyOrders().subscribe((p) => (result = p));
+
+    const req = httpMock.expectOne((r) => r.url === baseUrl && r.method === 'GET');
+    expect(req.request.params.get('page')).toBe('0');
+    expect(req.request.params.get('size')).toBe('10');
+    expect(req.request.params.has('status')).toBeFalse();
+    expect(req.request.params.has('direction')).toBeFalse();
+    expect(req.request.params.has('securityType')).toBeFalse();
+
+    const body = emptyPage();
+    req.flush(body);
+    expect(result).toEqual(body);
+  });
+
+  it('passes page and size through', () => {
+    service.getMyOrders({}, 3, 25).subscribe();
+    const req = httpMock.expectOne((r) => r.url === baseUrl);
+    expect(req.request.params.get('page')).toBe('3');
+    expect(req.request.params.get('size')).toBe('25');
+    req.flush(emptyPage());
+  });
+
+  it('serializes status / direction / securityType / from / to filters', () => {
+    service
+      .getMyOrders(
+        {
+          status: 'DONE',
+          direction: 'BUY',
+          securityType: 'STOCK',
+          from: '2026-01-01',
+          to: '2026-05-19',
+        },
+        0,
+        10,
+      )
+      .subscribe();
+
+    const req = httpMock.expectOne((r) => r.url === baseUrl);
+    expect(req.request.params.get('status')).toBe('DONE');
+    expect(req.request.params.get('direction')).toBe('BUY');
+    expect(req.request.params.get('securityType')).toBe('STOCK');
+    expect(req.request.params.get('from')).toBe('2026-01-01');
+    expect(req.request.params.get('to')).toBe('2026-05-19');
+    req.flush(emptyPage());
+  });
+
+  it('omits filter params whose value is empty / undefined', () => {
+    service
+      .getMyOrders({ status: undefined, direction: 'SELL', securityType: '' }, 0, 10)
+      .subscribe();
+
+    const req = httpMock.expectOne((r) => r.url === baseUrl);
+    expect(req.request.params.has('status')).toBeFalse();
+    expect(req.request.params.has('securityType')).toBeFalse();
+    expect(req.request.params.get('direction')).toBe('SELL');
+    req.flush(emptyPage());
+  });
+});

--- a/src/app/features/orders/services/my-order.service.ts
+++ b/src/app/features/orders/services/my-order.service.ts
@@ -1,0 +1,58 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { environment } from '../../../../environments/environment';
+import { MyOrderFilter, MyOrderPage } from '../models/my-order.model';
+
+/**
+ * WP-22 (Celina 3): "Moji orderi" — order history client.
+ *
+ * <p>Wraps the JWT-secured trading-service endpoint exposed through the gateway
+ * at `GET /orders/my-orders`. The {@link AuthInterceptor} attaches the
+ * `Authorization` header automatically.
+ *
+ * <p>This is deliberately a separate, narrow service from both `OrderService`
+ * implementations: `features/orders/services/order.service.ts` only does
+ * buy/sell/confirm/cancel, and `features/employee/services/order.service.ts`
+ * hits the supervisor-only `GET /order/orders`. "Moji orderi" needs the
+ * caller-scoped `/orders/my-orders` history endpoint instead.
+ */
+@Injectable({ providedIn: 'root' })
+export class MyOrderService {
+  private readonly baseUrl = `${environment.apiUrl}/orders/my-orders`;
+
+  constructor(private readonly http: HttpClient) {}
+
+  /**
+   * Fetches one page of the caller's order history.
+   *
+   * @param filter optional status / direction / security-type / date-range
+   *   filter; empty or `undefined` fields are not sent as query params.
+   * @param page 0-indexed page number (matches the backend `PagedModel`).
+   * @param size page size.
+   */
+  getMyOrders(filter: MyOrderFilter = {}, page = 0, size = 10): Observable<MyOrderPage> {
+    let params = new HttpParams()
+      .set('page', String(page))
+      .set('size', String(size));
+
+    if (filter.status) {
+      params = params.set('status', filter.status);
+    }
+    if (filter.direction) {
+      params = params.set('direction', filter.direction);
+    }
+    if (filter.securityType) {
+      params = params.set('securityType', filter.securityType);
+    }
+    if (filter.from) {
+      params = params.set('from', filter.from);
+    }
+    if (filter.to) {
+      params = params.set('to', filter.to);
+    }
+
+    return this.http.get<MyOrderPage>(this.baseUrl, { params });
+  }
+}

--- a/src/app/features/otc/components/otc-negotiation-history/otc-negotiation-history.component.html
+++ b/src/app/features/otc/components/otc-negotiation-history/otc-negotiation-history.component.html
@@ -1,0 +1,204 @@
+<div>
+  <div class="mb-6">
+    <h2 class="text-lg font-semibold text-foreground">Istorija pregovora</h2>
+    <p class="text-sm text-muted-foreground mt-1">
+      Svi zavrseni i tekuci OTC pregovori. Klik na red prikazuje kompletnu istoriju protivponuda.
+    </p>
+  </div>
+
+  <!-- Filter -->
+  <div class="z-card p-4 mb-6">
+    <div class="flex items-end gap-4 flex-wrap">
+      <div>
+        <label class="z-label" for="histStatus">Status</label>
+        <select id="histStatus"
+                class="z-select max-w-[200px]"
+                aria-label="Filter istorije po statusu"
+                data-testid="filter-status"
+                [(ngModel)]="filter.status">
+          <option *ngFor="let o of statusOptions" [ngValue]="o.value">{{ o.label }}</option>
+        </select>
+      </div>
+      <div>
+        <label class="z-label" for="histFrom">Od datuma</label>
+        <input id="histFrom" type="date"
+               class="z-input max-w-[180px]"
+               aria-label="Filter istorije od datuma"
+               data-testid="filter-from"
+               [(ngModel)]="filter.from" />
+      </div>
+      <div>
+        <label class="z-label" for="histTo">Do datuma</label>
+        <input id="histTo" type="date"
+               class="z-input max-w-[180px]"
+               aria-label="Filter istorije do datuma"
+               data-testid="filter-to"
+               [(ngModel)]="filter.to" />
+      </div>
+      <div>
+        <label class="z-label" for="histCounterparty">Druga strana (ID)</label>
+        <input id="histCounterparty" type="number" min="1"
+               class="z-input max-w-[160px]"
+               placeholder="ID kupca/prodavca"
+               aria-label="Filter istorije po drugoj strani"
+               data-testid="filter-counterparty"
+               [(ngModel)]="filter.counterparty" />
+      </div>
+      <div class="flex gap-2">
+        <button type="button" class="z-btn-primary" (click)="applyFilter()" data-testid="apply-filter">
+          Primeni filter
+        </button>
+        <button type="button" class="z-btn-outline" (click)="resetFilter()" data-testid="reset-filter">
+          Poništi
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <app-state *ngIf="loading" mode="loading" text="Ucitavanje istorije pregovora..."></app-state>
+  <app-state *ngIf="error && !loading" mode="error" [text]="error"></app-state>
+
+  <ng-container *ngIf="!loading && !error">
+    <app-state *ngIf="negotiations.length === 0"
+               mode="empty" title="Nema pregovora za izabrani filter"
+               text="Promeniti filter ili pokrenuti novi OTC pregovor."></app-state>
+
+    <div *ngIf="negotiations.length > 0" class="z-card overflow-hidden">
+      <div class="flex items-center justify-between px-5 py-4 border-b border-border">
+        <p class="text-xs font-semibold tracking-wider text-muted-foreground uppercase">Pregovori</p>
+        <span class="z-badge z-badge-blue">{{ negotiations.length }} pregovora</span>
+      </div>
+
+      <div class="overflow-x-auto">
+        <table class="z-table min-w-[920px]" data-testid="history-table">
+          <thead>
+            <tr>
+              <th class="w-8"></th>
+              <th>Akcija</th>
+              <th class="text-right">Količina</th>
+              <th class="text-right">Cena/akciji</th>
+              <th class="text-right">Premium</th>
+              <th>Settlement</th>
+              <th>Poslednja izmena</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <ng-container *ngFor="let n of negotiations">
+              <tr class="cursor-pointer hover:bg-muted/40"
+                  (click)="toggleRevisions(n)"
+                  [attr.data-testid]="'history-row-' + n.id">
+                <td class="text-muted-foreground text-center" aria-hidden="true">
+                  {{ isExpanded(n) ? '▾' : '▸' }}
+                </td>
+                <td class="font-semibold">{{ n.stockTicker }}</td>
+                <td class="text-right font-mono">{{ n.amount | number }}</td>
+                <td class="text-right font-mono">{{ n.pricePerStock | number:'1.2-2' }}</td>
+                <td class="text-right font-mono">{{ n.premium | number:'1.2-2' }}</td>
+                <td class="whitespace-nowrap">{{ formatDate(n.settlementDate) }}</td>
+                <td class="text-muted-foreground whitespace-nowrap">
+                  {{ n.lastModified ? (n.lastModified | date:'short') : '—' }}
+                </td>
+                <td>
+                  <span class="z-badge" [ngClass]="statusBadgeClass(n.status)">
+                    {{ statusLabel(n.status) }}
+                  </span>
+                </td>
+              </tr>
+
+              <!-- Revision trail panel -->
+              <tr *ngIf="isExpanded(n)" [attr.data-testid]="'history-detail-' + n.id">
+                <td colspan="8" class="bg-muted/30 p-0">
+                  <div class="p-5">
+                    <h3 class="text-sm font-semibold text-foreground mb-3">
+                      Istorija protivponuda — {{ n.stockTicker }}
+                    </h3>
+
+                    <app-state *ngIf="revisionsLoading" mode="loading"
+                               text="Ucitavanje istorije protivponuda..."></app-state>
+                    <app-state *ngIf="revisionsError && !revisionsLoading" mode="error"
+                               [text]="revisionsError"></app-state>
+
+                    <ng-container *ngIf="!revisionsLoading && !revisionsError">
+                      <app-state *ngIf="revisions.length === 0" mode="empty"
+                                 title="Nema zabeleženih revizija"
+                                 text="Ovaj pregovor nema istoriju promena."></app-state>
+
+                      <div *ngIf="revisions.length > 0" class="overflow-x-auto">
+                        <table class="z-table min-w-[860px]" data-testid="revision-table">
+                          <thead>
+                            <tr>
+                              <th>Akcija</th>
+                              <th>Akter</th>
+                              <th>Uloga</th>
+                              <th class="text-right">Količina (staro → novo)</th>
+                              <th class="text-right">Cena (staro → novo)</th>
+                              <th class="text-right">Premium (staro → novo)</th>
+                              <th>Settlement (staro → novo)</th>
+                              <th>Vreme</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr *ngFor="let r of revisions" [attr.data-testid]="'revision-row-' + r.id">
+                              <td class="font-semibold">{{ actionLabel(r.action) }}</td>
+                              <td>{{ r.actorName }}</td>
+                              <td>
+                                <span class="z-badge"
+                                      [ngClass]="r.actorRole === 'SELLER' ? 'z-badge-gold' : 'z-badge-blue'">
+                                  {{ roleLabel(r.actorRole) }}
+                                </span>
+                              </td>
+                              <td class="text-right font-mono whitespace-nowrap">
+                                <span class="text-muted-foreground">
+                                  {{ r.oldAmount !== null ? (r.oldAmount | number) : '—' }}
+                                </span>
+                                <span class="mx-1 text-muted-foreground">→</span>
+                                <span [class.z-diff-mid]="changed(r.oldAmount, r.newAmount)">
+                                  {{ r.newAmount !== null ? (r.newAmount | number) : '—' }}
+                                </span>
+                              </td>
+                              <td class="text-right font-mono whitespace-nowrap">
+                                <span class="text-muted-foreground">
+                                  {{ r.oldPricePerStock !== null ? (r.oldPricePerStock | number:'1.2-2') : '—' }}
+                                </span>
+                                <span class="mx-1 text-muted-foreground">→</span>
+                                <span [class.z-diff-mid]="changed(r.oldPricePerStock, r.newPricePerStock)">
+                                  {{ r.newPricePerStock !== null ? (r.newPricePerStock | number:'1.2-2') : '—' }}
+                                </span>
+                              </td>
+                              <td class="text-right font-mono whitespace-nowrap">
+                                <span class="text-muted-foreground">
+                                  {{ r.oldPremium !== null ? (r.oldPremium | number:'1.2-2') : '—' }}
+                                </span>
+                                <span class="mx-1 text-muted-foreground">→</span>
+                                <span [class.z-diff-mid]="changed(r.oldPremium, r.newPremium)">
+                                  {{ r.newPremium !== null ? (r.newPremium | number:'1.2-2') : '—' }}
+                                </span>
+                              </td>
+                              <td class="whitespace-nowrap">
+                                <span class="text-muted-foreground">
+                                  {{ formatDate(r.oldSettlementDate) }}
+                                </span>
+                                <span class="mx-1 text-muted-foreground">→</span>
+                                <span [class.z-diff-mid]="changed(r.oldSettlementDate, r.newSettlementDate)">
+                                  {{ formatDate(r.newSettlementDate) }}
+                                </span>
+                              </td>
+                              <td class="text-muted-foreground whitespace-nowrap">
+                                {{ r.createdAt | date:'short' }}
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </div>
+                    </ng-container>
+                  </div>
+                </td>
+              </tr>
+            </ng-container>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </ng-container>
+</div>

--- a/src/app/features/otc/components/otc-negotiation-history/otc-negotiation-history.component.spec.ts
+++ b/src/app/features/otc/components/otc-negotiation-history/otc-negotiation-history.component.spec.ts
@@ -1,0 +1,173 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { of, throwError } from 'rxjs';
+
+import { OtcNegotiationHistoryComponent } from './otc-negotiation-history.component';
+import { OtcService } from '../../services/otc.service';
+import { StateComponent } from '../../../../shared/components/state/state.component';
+import { OtcOffer, OtcOfferRevision } from '../../models/otc.model';
+
+/**
+ * WP-25 (Task D6) component spec za OTC negotiation history.
+ */
+describe('OtcNegotiationHistoryComponent (WP-25)', () => {
+  let component: OtcNegotiationHistoryComponent;
+  let fixture: ComponentFixture<OtcNegotiationHistoryComponent>;
+  let otcServiceSpy: jasmine.SpyObj<OtcService>;
+
+  const makeOffer = (overrides: Partial<OtcOffer>): OtcOffer => ({
+    id: 7, stockTicker: 'AAPL', buyerId: 1, sellerId: 2,
+    amount: 10, pricePerStock: 200, premium: 5,
+    settlementDate: '2026-12-31', status: 'ACCEPTED',
+    modifiedBy: 'C-1', lastModified: '2026-05-01T10:00:00Z',
+    ...overrides,
+  });
+
+  const makeRevision = (overrides: Partial<OtcOfferRevision>): OtcOfferRevision => ({
+    id: 1, offerId: 7, action: 'CREATE', actorUserId: 1, actorName: 'Marko Markovic',
+    actorRole: 'BUYER',
+    oldAmount: null, newAmount: 10,
+    oldPricePerStock: null, newPricePerStock: 200,
+    oldPremium: null, newPremium: 5,
+    oldSettlementDate: null, newSettlementDate: '2026-12-31',
+    createdAt: '2026-05-01T10:00:00Z',
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    otcServiceSpy = jasmine.createSpyObj<OtcService>('OtcService', [
+      'getNegotiationHistory', 'getOfferRevisions',
+    ]);
+    otcServiceSpy.getNegotiationHistory.and.returnValue(of([]));
+    otcServiceSpy.getOfferRevisions.and.returnValue(of([]));
+
+    await TestBed.configureTestingModule({
+      declarations: [OtcNegotiationHistoryComponent],
+      imports: [FormsModule, StateComponent],
+      providers: [{ provide: OtcService, useValue: otcServiceSpy }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(OtcNegotiationHistoryComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('kreira komponentu', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('ngOnInit ucitava istoriju pregovora', () => {
+    otcServiceSpy.getNegotiationHistory.and.returnValue(of([makeOffer({})]));
+    fixture.detectChanges();
+    expect(otcServiceSpy.getNegotiationHistory).toHaveBeenCalledTimes(1);
+    expect(component.negotiations.length).toBe(1);
+    expect(component.loading).toBe(false);
+  });
+
+  it('postavlja error poruku kad getNegotiationHistory padne', () => {
+    otcServiceSpy.getNegotiationHistory.and.returnValue(
+      throwError(() => ({ error: { message: 'pad' } })));
+    fixture.detectChanges();
+    expect(component.error).toBe('pad');
+    expect(component.negotiations.length).toBe(0);
+    expect(component.loading).toBe(false);
+  });
+
+  it('applyFilter ponovo poziva getNegotiationHistory sa tekucim filterom', () => {
+    fixture.detectChanges();
+    component.filter = { status: 'REJECTED', from: '2026-01-01', to: '', counterparty: 9 };
+    component.applyFilter();
+    expect(otcServiceSpy.getNegotiationHistory).toHaveBeenCalledTimes(2);
+    expect(otcServiceSpy.getNegotiationHistory.calls.mostRecent().args[0])
+      .toEqual({ status: 'REJECTED', from: '2026-01-01', to: '', counterparty: 9 });
+  });
+
+  it('resetFilter cisti sva polja i reloaduje', () => {
+    fixture.detectChanges();
+    component.filter = { status: 'ACCEPTED', from: '2026-01-01', to: '2026-02-01', counterparty: 3 };
+    component.resetFilter();
+    expect(component.filter).toEqual({ status: '', from: '', to: '', counterparty: null });
+    expect(otcServiceSpy.getNegotiationHistory).toHaveBeenCalledTimes(2);
+  });
+
+  it('toggleRevisions ucitava revision trail i otvara red', () => {
+    const trail = [makeRevision({}), makeRevision({ id: 2, action: 'COUNTER' })];
+    otcServiceSpy.getOfferRevisions.and.returnValue(of(trail));
+    fixture.detectChanges();
+
+    component.toggleRevisions(makeOffer({ id: 7 }));
+    expect(otcServiceSpy.getOfferRevisions).toHaveBeenCalledWith(7);
+    expect(component.expandedOfferId).toBe(7);
+    expect(component.revisions.length).toBe(2);
+    expect(component.revisionsLoading).toBe(false);
+  });
+
+  it('toggleRevisions na istom redu drugi put zatvara panel', () => {
+    otcServiceSpy.getOfferRevisions.and.returnValue(of([makeRevision({})]));
+    fixture.detectChanges();
+    const offer = makeOffer({ id: 7 });
+
+    component.toggleRevisions(offer);
+    expect(component.isExpanded(offer)).toBe(true);
+
+    component.toggleRevisions(offer);
+    expect(component.isExpanded(offer)).toBe(false);
+    expect(component.revisions.length).toBe(0);
+  });
+
+  it('toggleRevisions postavlja revisionsError kad poziv padne', () => {
+    otcServiceSpy.getOfferRevisions.and.returnValue(
+      throwError(() => ({ error: { message: 'trail pad' } })));
+    fixture.detectChanges();
+
+    component.toggleRevisions(makeOffer({ id: 7 }));
+    expect(component.revisionsError).toBe('trail pad');
+    expect(component.revisionsLoading).toBe(false);
+  });
+
+  it('applyFilter zatvara prethodno otvoreni revision trail', () => {
+    otcServiceSpy.getOfferRevisions.and.returnValue(of([makeRevision({})]));
+    fixture.detectChanges();
+    component.toggleRevisions(makeOffer({ id: 7 }));
+    expect(component.expandedOfferId).toBe(7);
+
+    component.applyFilter();
+    expect(component.expandedOfferId).toBeNull();
+  });
+
+  it('changed() detektuje promenu vrednosti', () => {
+    expect(component.changed(10, 8)).toBe(true);
+    expect(component.changed(10, 10)).toBe(false);
+    expect(component.changed(null, 10)).toBe(true);
+    expect(component.changed(null, null)).toBe(false);
+  });
+
+  it('statusBadgeClass mapira statuse na badge boje', () => {
+    expect(component.statusBadgeClass('ACCEPTED')).toBe('z-badge-green');
+    expect(component.statusBadgeClass('REJECTED')).toBe('z-badge-red');
+    expect(component.statusBadgeClass('WITHDRAWN')).toBe('z-badge-gray');
+    expect(component.statusBadgeClass('PENDING_BUYER')).toBe('z-badge-yellow');
+  });
+
+  it('actionLabel i roleLabel daju citljive nazive', () => {
+    expect(component.actionLabel('COUNTER')).toBe('Protivponuda');
+    expect(component.actionLabel('CREATE')).toBe('Kreirana ponuda');
+    expect(component.roleLabel('BUYER')).toBe('Kupac');
+    expect(component.roleLabel('SELLER')).toBe('Prodavac');
+  });
+
+  it('formatDate skracuje ISO datum sa T-delom i hendluje null', () => {
+    expect(component.formatDate('2026-12-31T00:00:00Z')).toBe('2026-12-31');
+    expect(component.formatDate('2026-12-31')).toBe('2026-12-31');
+    expect(component.formatDate(null)).toBe('—');
+  });
+
+  it('renderuje red tabele za svaki pregovor', () => {
+    otcServiceSpy.getNegotiationHistory.and.returnValue(of([
+      makeOffer({ id: 7 }), makeOffer({ id: 8, status: 'REJECTED' }),
+    ]));
+    fixture.detectChanges();
+    const rows = fixture.nativeElement.querySelectorAll('[data-testid^="history-row-"]');
+    expect(rows.length).toBe(2);
+  });
+});

--- a/src/app/features/otc/components/otc-negotiation-history/otc-negotiation-history.component.ts
+++ b/src/app/features/otc/components/otc-negotiation-history/otc-negotiation-history.component.ts
@@ -1,0 +1,175 @@
+import { Component, OnInit } from '@angular/core';
+
+import { OtcService } from '../../services/otc.service';
+import {
+  OtcActorRole,
+  OtcHistoryFilter,
+  OtcOffer,
+  OtcOfferRevision,
+  OtcOfferStatus,
+  OtcRevisionAction,
+} from '../../models/otc.model';
+
+/**
+ * WP-25 (Task D6): OTC negotiation history.
+ *
+ * <p>Do sada je OTC portal prikazivao samo aktivne pregovore. Ova komponenta
+ * dodaje pregled istorije SVIH pregovora — uklj. zavrsene
+ * (ACCEPTED/REJECTED/WITHDRAWN/EXPIRED) — sa kompletnim revision trail-om svakog
+ * pregovora (stare → nove vrednosti po protivponudi, akter + uloga, timestamp).
+ *
+ * <p>Lista se filtrira server-side preko `GET /otc/offers/history` (status /
+ * datumski opseg / druga strana). Klik na red ucitava i toggle-uje revision
+ * trail tog pregovora (`GET /otc/offers/{id}/history`) — lazy, jedan po jedan.
+ */
+@Component({
+  selector: 'app-otc-negotiation-history',
+  templateUrl: './otc-negotiation-history.component.html',
+})
+export class OtcNegotiationHistoryComponent implements OnInit {
+
+  negotiations: OtcOffer[] = [];
+  loading = false;
+  error: string | null = null;
+
+  /** Filter draft — vezan za UI; primenjuje se na `applyFilter()`. */
+  filter: OtcHistoryFilter = { status: '', from: '', to: '', counterparty: null };
+
+  /** Status opcije za dropdown ('' = svi statusi). */
+  readonly statusOptions: Array<{ value: OtcOfferStatus | ''; label: string }> = [
+    { value: '',               label: 'Svi statusi' },
+    { value: 'PENDING_BUYER',  label: 'Čeka kupca' },
+    { value: 'PENDING_SELLER', label: 'Čeka prodavca' },
+    { value: 'ACCEPTED',       label: 'Prihvaćeno' },
+    { value: 'REJECTED',       label: 'Odbijeno' },
+    { value: 'WITHDRAWN',      label: 'Povučeno' },
+    { value: 'EXPIRED',        label: 'Isteklo' },
+  ];
+
+  /** Id pregovora cija je istorija trenutno otvorena (`null` = nijedan). */
+  expandedOfferId: number | null = null;
+  /** Revizije ucitane za otvoreni pregovor. */
+  revisions: OtcOfferRevision[] = [];
+  revisionsLoading = false;
+  revisionsError: string | null = null;
+
+  constructor(private otcService: OtcService) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  /** Ucitava listu pregovora primenom tekuceg filtera. */
+  load(): void {
+    this.loading = true;
+    this.error = null;
+    this.otcService.getNegotiationHistory(this.filter).subscribe({
+      next: items => {
+        this.negotiations = items;
+        this.loading = false;
+      },
+      error: err => {
+        this.error = err?.error?.message || 'Greska pri ucitavanju istorije pregovora.';
+        this.negotiations = [];
+        this.loading = false;
+      },
+    });
+  }
+
+  /** Primenjuje filter — zatvara otvoreni trail i ponovo ucitava listu. */
+  applyFilter(): void {
+    this.collapse();
+    this.load();
+  }
+
+  /** Resetuje sva filter polja i ponovo ucitava listu. */
+  resetFilter(): void {
+    this.filter = { status: '', from: '', to: '', counterparty: null };
+    this.applyFilter();
+  }
+
+  /**
+   * Toggle revision trail-a za dati pregovor. Prvi klik ucitava revizije;
+   * ponovni klik na isti red zatvara panel.
+   */
+  toggleRevisions(offer: OtcOffer): void {
+    if (this.expandedOfferId === offer.id) {
+      this.collapse();
+      return;
+    }
+    this.expandedOfferId = offer.id;
+    this.revisions = [];
+    this.revisionsError = null;
+    this.revisionsLoading = true;
+    this.otcService.getOfferRevisions(offer.id).subscribe({
+      next: trail => {
+        this.revisions = trail;
+        this.revisionsLoading = false;
+      },
+      error: err => {
+        this.revisionsError = err?.error?.message || 'Greska pri ucitavanju istorije protivponuda.';
+        this.revisionsLoading = false;
+      },
+    });
+  }
+
+  /** Zatvara otvoreni revision trail. */
+  collapse(): void {
+    this.expandedOfferId = null;
+    this.revisions = [];
+    this.revisionsError = null;
+    this.revisionsLoading = false;
+  }
+
+  isExpanded(offer: OtcOffer): boolean {
+    return this.expandedOfferId === offer.id;
+  }
+
+  /** CSS klasa za status badge. */
+  statusBadgeClass(status: OtcOfferStatus): string {
+    switch (status) {
+      case 'ACCEPTED':       return 'z-badge-green';
+      case 'REJECTED':       return 'z-badge-red';
+      case 'EXPIRED':        return 'z-badge-red';
+      case 'WITHDRAWN':      return 'z-badge-gray';
+      case 'PENDING_BUYER':
+      case 'PENDING_SELLER': return 'z-badge-yellow';
+      default:               return 'z-badge-gray';
+    }
+  }
+
+  statusLabel(status: OtcOfferStatus): string {
+    return this.statusOptions.find(o => o.value === status)?.label ?? status;
+  }
+
+  /** Citljiv naziv revizijske akcije. */
+  actionLabel(action: OtcRevisionAction): string {
+    switch (action) {
+      case 'CREATE':   return 'Kreirana ponuda';
+      case 'COUNTER':  return 'Protivponuda';
+      case 'ACCEPT':   return 'Prihvaćeno';
+      case 'REJECT':   return 'Odbijeno';
+      case 'WITHDRAW': return 'Povučeno';
+      default:         return action;
+    }
+  }
+
+  roleLabel(role: OtcActorRole): string {
+    return role === 'BUYER' ? 'Kupac' : 'Prodavac';
+  }
+
+  /**
+   * True ako se vrednost promenila ovom revizijom — koristi se za bojenje
+   * `old → new` para. Prva revizija (`CREATE`) ima `old=null` pa je sve "novo".
+   */
+  changed(oldVal: number | string | null, newVal: number | string | null): boolean {
+    return oldVal !== newVal;
+  }
+
+  /** Skraćuje ISO datum na `yyyy-MM-dd` (settlement polje moze imati T-deo). */
+  formatDate(raw: string | null | undefined): string {
+    if (!raw) return '—';
+    const tIdx = raw.indexOf('T');
+    return tIdx > 0 ? raw.substring(0, tIdx) : raw;
+  }
+}

--- a/src/app/features/otc/components/otc-offers/otc-offers.component.spec.ts
+++ b/src/app/features/otc/components/otc-offers/otc-offers.component.spec.ts
@@ -1,4 +1,6 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { of } from 'rxjs';
 
 import { OtcOffersComponent } from './otc-offers.component';
@@ -28,7 +30,7 @@ describe('OtcOffersComponent — filter mode (PR_33 Phase B)', () => {
 
   beforeEach(() => {
     otcServiceStub = jasmine.createSpyObj<OtcService>('OtcService', [
-      'getActiveOffers', 'accept', 'reject', 'counterOffer',
+      'getActiveOffers', 'accept', 'reject', 'counterOffer', 'withdrawOffer',
       'acceptInterbankNegotiation', 'deleteInterbankNegotiation',
       'counterInterbankNegotiation',
     ]);
@@ -37,7 +39,13 @@ describe('OtcOffersComponent — filter mode (PR_33 Phase B)', () => {
     otcServiceStub.getActiveOffers.and.returnValue(of([]));
     priceServiceStub.poll.and.returnValue(of([]));
 
+    // OtcOffersComponent injektuje i AuthService (koji zavisi od HttpClient +
+    // Router). Bez HTTP/Router test providera Angular ne moze da konstruise
+    // realni AuthService → NullInjectorError za HttpClient. HttpClientTestingModule
+    // + RouterTestingModule zadovoljavaju tu zavisnost (AuthService se ne stub-uje
+    // jer njegove getUserIdFromToken/getJwtRoles metode citaju localStorage, ne mrezu).
     TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, RouterTestingModule],
       providers: [
         OtcOffersComponent,
         { provide: OtcService, useValue: otcServiceStub },
@@ -122,10 +130,12 @@ describe('OtcOffersComponent — filter mode (PR_33 Phase B)', () => {
     expect(otcServiceStub.acceptInterbankNegotiation).not.toHaveBeenCalled();
   });
 
-  it('reject(offer) za inter-bank zove deleteInterbankNegotiation', () => {
+  it('withdraw(offer) za inter-bank zove deleteInterbankNegotiation', () => {
+    // Inter-bank "brisanje pregovora" ide kroz withdraw() (canReject() je false za
+    // interbank ponude — reject() je intra-bank-only put).
     otcServiceStub.deleteInterbankNegotiation.and.returnValue(of(undefined));
     const offer = makeOffer({ interbank: true, localId: 'neg-1' });
-    component.reject(offer);
+    component.withdraw(offer);
     expect(otcServiceStub.deleteInterbankNegotiation).toHaveBeenCalledWith('neg-1');
   });
 

--- a/src/app/features/otc/components/otc-portal/otc-portal.component.html
+++ b/src/app/features/otc/components/otc-portal/otc-portal.component.html
@@ -45,13 +45,24 @@
             (click)="setTab('contracts')">
       Izvršeni ugovori
     </button>
+    <button type="button"
+            class="px-4 py-2.5 text-sm font-medium whitespace-nowrap transition-colors"
+            [class.border-b-2]="activeTab === 'history'"
+            [class.border-primary]="activeTab === 'history'"
+            [class.text-foreground]="activeTab === 'history'"
+            [class.text-muted-foreground]="activeTab !== 'history'"
+            (click)="setTab('history')"
+            data-testid="tab-history">
+      Istorija pregovora
+    </button>
   </div>
 
   <!-- Tab panels -->
   <ng-container [ngSwitch]="activeTab">
-    <app-otc-available-stocks *ngSwitchCase="'available-stocks'"></app-otc-available-stocks>
-    <app-otc-positions        *ngSwitchCase="'positions'"></app-otc-positions>
-    <app-otc-offers           *ngSwitchCase="'negotiations'"></app-otc-offers>
-    <app-otc-contracts        *ngSwitchCase="'contracts'"></app-otc-contracts>
+    <app-otc-available-stocks    *ngSwitchCase="'available-stocks'"></app-otc-available-stocks>
+    <app-otc-positions           *ngSwitchCase="'positions'"></app-otc-positions>
+    <app-otc-offers              *ngSwitchCase="'negotiations'"></app-otc-offers>
+    <app-otc-contracts           *ngSwitchCase="'contracts'"></app-otc-contracts>
+    <app-otc-negotiation-history *ngSwitchCase="'history'"></app-otc-negotiation-history>
   </ng-container>
 </div>

--- a/src/app/features/otc/components/otc-portal/otc-portal.component.ts
+++ b/src/app/features/otc/components/otc-portal/otc-portal.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 
-export type OtcTab = 'available-stocks' | 'positions' | 'negotiations' | 'contracts';
+export type OtcTab = 'available-stocks' | 'positions' | 'negotiations' | 'contracts' | 'history';
 
 @Component({
   selector: 'app-otc-portal',

--- a/src/app/features/otc/models/otc.model.ts
+++ b/src/app/features/otc/models/otc.model.ts
@@ -188,3 +188,59 @@ export interface CounterInterbankNegotiationRequest {
   premium: number;
   settlementDate: string;
 }
+
+// -------------------------------------------------------------------------
+// WP-25 (Task D6): OTC negotiation history.
+//
+// Backend ima dva endpoint-a (JWT-secured, gateway `/otc/...`):
+//   - GET /otc/offers/history?status=&from=&to=&counterparty=
+//       → caller-ovi pregovori kroz SVE statuse (uklj. terminalne
+//         ACCEPTED/REJECTED/WITHDRAWN/EXPIRED), svaki kao offer-summary.
+//   - GET /otc/offers/{id}/history
+//       → uredjeni revision trail jednog pregovora: lista revizija sa
+//         old/new vrednostima, akterom i timestamp-om.
+// -------------------------------------------------------------------------
+
+/** Akcija koja je proizvela reviziju pregovora. */
+export type OtcRevisionAction = 'CREATE' | 'COUNTER' | 'ACCEPT' | 'REJECT' | 'WITHDRAW';
+
+/** Uloga aktera koji je napravio reviziju (kupac ili prodavac). */
+export type OtcActorRole = 'BUYER' | 'SELLER';
+
+/**
+ * Jedan korak u istoriji pregovora — odgovara revision DTO-u backend-a
+ * (`GET /otc/offers/{id}/history`). `old*` polja su vrednosti pre revizije
+ * (`null` za prvu reviziju tj. `CREATE`), `new*` su vrednosti posle revizije.
+ */
+export interface OtcOfferRevision {
+  id: number;
+  offerId: number;
+  action: OtcRevisionAction;
+  actorUserId: number;
+  actorName: string;
+  actorRole: OtcActorRole;
+  oldAmount: number | null;
+  newAmount: number | null;
+  oldPricePerStock: number | null;
+  newPricePerStock: number | null;
+  oldPremium: number | null;
+  newPremium: number | null;
+  oldSettlementDate: string | null;
+  newSettlementDate: string | null;
+  createdAt: string;
+}
+
+/**
+ * Filter za `GET /otc/offers/history`. Sva polja su opciona; prazna polja se
+ * ne salju kao query parametri (backend tretira odsustvo kao "bez filtera").
+ *
+ * - `status`     = jedan `OtcOfferStatus` (npr. `ACCEPTED`).
+ * - `from` / `to`= ISO datum granice (`yyyy-MM-dd`) za vreme poslednje izmene.
+ * - `counterparty` = id druge strane (kupac ili prodavac).
+ */
+export interface OtcHistoryFilter {
+  status?: OtcOfferStatus | '';
+  from?: string;
+  to?: string;
+  counterparty?: number | null;
+}

--- a/src/app/features/otc/otc.module.ts
+++ b/src/app/features/otc/otc.module.ts
@@ -9,6 +9,7 @@ import { OtcPositionsComponent } from './components/otc-positions/otc-positions.
 import { OtcOffersComponent } from './components/otc-offers/otc-offers.component';
 import { OtcContractsComponent } from './components/otc-contracts/otc-contracts.component';
 import { OtcCreateOfferComponent } from './components/otc-create-offer/otc-create-offer.component';
+import { OtcNegotiationHistoryComponent } from './components/otc-negotiation-history/otc-negotiation-history.component';
 import { roleGuard } from '../../core/guards/role.guard';
 import { StateComponent } from '../../shared/components/state/state.component';
 
@@ -33,6 +34,7 @@ const routes: Routes = [
     OtcOffersComponent,
     OtcContractsComponent,
     OtcCreateOfferComponent,
+    OtcNegotiationHistoryComponent,
   ],
   imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterModule.forChild(routes), StateComponent],
 })

--- a/src/app/features/otc/services/otc.service.spec.ts
+++ b/src/app/features/otc/services/otc.service.spec.ts
@@ -8,6 +8,7 @@ import {
   CreateInterbankNegotiationRequest,
   InterbankNegotiationView,
   OtcOffer,
+  OtcOfferRevision,
 } from '../models/otc.model';
 
 /**
@@ -171,5 +172,105 @@ describe('OtcService — inter-bank wrapper (PR_33 Phase B)', () => {
     });
     httpMock.expectOne(`${localUrl}/offers/active`).flush(localOffers);
     httpMock.expectOne(interbankUrl).flush({ msg: 'down' }, { status: 500, statusText: 'Server Error' });
+  });
+});
+
+/**
+ * WP-25 (Task D6) unit testovi za OTC negotiation history API.
+ */
+describe('OtcService — negotiation history (WP-25)', () => {
+  let service: OtcService;
+  let httpMock: HttpTestingController;
+
+  const historyUrl = `${environment.apiUrl}/otc/offers/history`;
+
+  const makeOffer = (overrides: Partial<OtcOffer>): OtcOffer => ({
+    id: 7, stockTicker: 'AAPL', buyerId: 1, sellerId: 2,
+    amount: 10, pricePerStock: 200, premium: 5,
+    settlementDate: '2026-12-31', status: 'ACCEPTED',
+    modifiedBy: 'C-1', lastModified: '2026-05-01T10:00:00Z',
+    ...overrides,
+  });
+
+  const makeRevision = (overrides: Partial<OtcOfferRevision>): OtcOfferRevision => ({
+    id: 1, offerId: 7, action: 'CREATE', actorUserId: 1, actorName: 'Marko Markovic',
+    actorRole: 'BUYER',
+    oldAmount: null, newAmount: 10,
+    oldPricePerStock: null, newPricePerStock: 200,
+    oldPremium: null, newPremium: 5,
+    oldSettlementDate: null, newSettlementDate: '2026-12-31',
+    createdAt: '2026-05-01T10:00:00Z',
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [OtcService],
+    });
+    service = TestBed.inject(OtcService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('getNegotiationHistory() bez filtera GET-uje history URL bez query parametara', () => {
+    const fake = [makeOffer({ status: 'REJECTED' })];
+    service.getNegotiationHistory({}).subscribe(res => expect(res).toEqual(fake));
+
+    const req = httpMock.expectOne(historyUrl);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.keys().length).toBe(0);
+    req.flush(fake);
+  });
+
+  it('getNegotiationHistory() salje samo popunjena polja kao query parametre', () => {
+    service.getNegotiationHistory({
+      status: 'ACCEPTED',
+      from: '2026-01-01',
+      to: '2026-06-30',
+      counterparty: 42,
+    }).subscribe();
+
+    const req = httpMock.expectOne(r => r.url === historyUrl);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.get('status')).toBe('ACCEPTED');
+    expect(req.request.params.get('from')).toBe('2026-01-01');
+    expect(req.request.params.get('to')).toBe('2026-06-30');
+    expect(req.request.params.get('counterparty')).toBe('42');
+    req.flush([]);
+  });
+
+  it('getNegotiationHistory() izostavlja prazan status / undefined counterparty', () => {
+    service.getNegotiationHistory({
+      status: '',
+      from: '2026-01-01',
+      to: undefined,
+      counterparty: null,
+    }).subscribe();
+
+    const req = httpMock.expectOne(r => r.url === historyUrl);
+    expect(req.request.params.has('status')).toBe(false);
+    expect(req.request.params.has('to')).toBe(false);
+    expect(req.request.params.has('counterparty')).toBe(false);
+    expect(req.request.params.get('from')).toBe('2026-01-01');
+    req.flush([]);
+  });
+
+  it('getOfferRevisions() GET-uje /otc/offers/{id}/history', () => {
+    const trail = [makeRevision({ action: 'CREATE' }), makeRevision({
+      id: 2, action: 'COUNTER', actorRole: 'SELLER', actorName: 'Petar Petrovic',
+      oldAmount: 10, newAmount: 8, oldPricePerStock: 200, newPricePerStock: 220,
+      createdAt: '2026-05-02T11:00:00Z',
+    })];
+
+    service.getOfferRevisions(7).subscribe(res => {
+      expect(res.length).toBe(2);
+      expect(res[1].action).toBe('COUNTER');
+    });
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/otc/offers/7/history`);
+    expect(req.request.method).toBe('GET');
+    req.flush(trail);
   });
 });

--- a/src/app/features/otc/services/otc.service.ts
+++ b/src/app/features/otc/services/otc.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, forkJoin, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
@@ -13,7 +13,9 @@ import {
   InterbankNegotiationView,
   OptionContract,
   OptionContractStatus,
+  OtcHistoryFilter,
   OtcOffer,
+  OtcOfferRevision,
   OtcPosition,
   OtcPublicStockGroup,
   UpdateOtcPositionRequest,
@@ -91,6 +93,44 @@ export class OtcService {
       ? `${this.baseUrl}/contracts/my?status=${status}`
       : `${this.baseUrl}/contracts/my`;
     return this.http.get<OptionContract[]>(url);
+  }
+
+  // ------------------------------------------------------------------
+  // WP-25 (Task D6): OTC negotiation history.
+  // ------------------------------------------------------------------
+
+  /**
+   * Dohvata istoriju pregovora current user-a kroz SVE statuse (uklj. terminalne
+   * ACCEPTED/REJECTED/WITHDRAWN/EXPIRED) — backend ruta `GET /otc/offers/history`.
+   *
+   * Filter polja su opciona; samo popunjena se prosledjuju kao query parametri
+   * (prazan string / `null` / `undefined` se izostavljaju da backend tretira
+   * odsustvo kao "bez filtera").
+   */
+  getNegotiationHistory(filter: OtcHistoryFilter): Observable<OtcOffer[]> {
+    let params = new HttpParams();
+    if (filter.status) {
+      params = params.set('status', filter.status);
+    }
+    if (filter.from) {
+      params = params.set('from', filter.from);
+    }
+    if (filter.to) {
+      params = params.set('to', filter.to);
+    }
+    if (filter.counterparty != null) {
+      params = params.set('counterparty', String(filter.counterparty));
+    }
+    return this.http.get<OtcOffer[]>(`${this.baseUrl}/offers/history`, { params });
+  }
+
+  /**
+   * Dohvata uredjeni revision trail jednog pregovora — backend ruta
+   * `GET /otc/offers/{id}/history`. Svaka revizija nosi old/new vrednosti,
+   * aktera (id + ime + uloga) i timestamp.
+   */
+  getOfferRevisions(offerId: number): Observable<OtcOfferRevision[]> {
+    return this.http.get<OtcOfferRevision[]>(`${this.baseUrl}/offers/${offerId}/history`);
   }
 
   // ------------------------------------------------------------------

--- a/src/app/features/price-alerts/components/create-alert-modal/create-alert-modal.component.html
+++ b/src/app/features/price-alerts/components/create-alert-modal/create-alert-modal.component.html
@@ -1,0 +1,40 @@
+<!-- WP-22 (Celina 3): "Postavi obavestenje" — create price-alert modal. -->
+<app-form-modal
+  [title]="ticker ? 'Obavestenje: ' + ticker : 'Postavi obavestenje'"
+  [submitting]="submitting"
+  [errorMessage]="error"
+  confirmLabel="Postavi"
+  (close)="onCancel()"
+  (confirm)="submit()"
+>
+  <div class="space-y-4">
+    <div>
+      <label class="z-label" for="ca-condition">Uslov</label>
+      <select id="ca-condition" class="z-select" [(ngModel)]="condition">
+        <option *ngFor="let o of conditionOptions" [value]="o.value">{{ o.label }}</option>
+      </select>
+    </div>
+
+    <div>
+      <label class="z-label" for="ca-threshold">
+        {{ isPercent ? 'Procenat pada (%)' : 'Ciljna cena' }}
+      </label>
+      <input
+        id="ca-threshold"
+        type="number"
+        min="0"
+        step="0.01"
+        class="z-input"
+        [(ngModel)]="threshold"
+        [placeholder]="isPercent ? 'npr. 5' : 'npr. 150.00'"
+      />
+    </div>
+
+    <div>
+      <label class="z-label" for="ca-channel">Nacin obavestavanja</label>
+      <select id="ca-channel" class="z-select" [(ngModel)]="notificationType">
+        <option *ngFor="let o of channelOptions" [value]="o.value">{{ o.label }}</option>
+      </select>
+    </div>
+  </div>
+</app-form-modal>

--- a/src/app/features/price-alerts/components/create-alert-modal/create-alert-modal.component.spec.ts
+++ b/src/app/features/price-alerts/components/create-alert-modal/create-alert-modal.component.spec.ts
@@ -1,0 +1,105 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+
+import { CreateAlertModalComponent } from './create-alert-modal.component';
+import { AlertService } from '../../services/alert.service';
+import { ToastService } from '../../../../shared/services/toast.service';
+import { PriceAlert } from '../../models/price-alert.model';
+
+function alert(id: number): PriceAlert {
+  return {
+    id,
+    listingId: 100 + id,
+    ticker: `TKR${id}`,
+    securityName: `Security ${id}`,
+    condition: 'ABOVE',
+    threshold: 150,
+    notificationType: 'IN_APP',
+    active: true,
+    createdAt: '2026-05-01T10:00:00Z',
+  };
+}
+
+describe('CreateAlertModalComponent', () => {
+  let fixture: ComponentFixture<CreateAlertModalComponent>;
+  let component: CreateAlertModalComponent;
+  let service: jasmine.SpyObj<AlertService>;
+  let toast: jasmine.SpyObj<ToastService>;
+
+  beforeEach(async () => {
+    service = jasmine.createSpyObj('AlertService', ['createAlert']);
+    toast = jasmine.createSpyObj('ToastService', ['success', 'error']);
+
+    await TestBed.configureTestingModule({
+      imports: [CreateAlertModalComponent],
+      providers: [
+        { provide: AlertService, useValue: service },
+        { provide: ToastService, useValue: toast },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CreateAlertModalComponent);
+    component = fixture.componentInstance;
+    component.listingId = 777;
+    component.ticker = 'AAPL';
+  });
+
+  it('creates', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('isPercent is true only for the intraday-drop condition', () => {
+    component.condition = 'ABOVE';
+    expect(component.isPercent).toBeFalse();
+    component.condition = 'PCT_DROP_INTRADAY';
+    expect(component.isPercent).toBeTrue();
+  });
+
+  it('submit rejects a missing / non-positive threshold', () => {
+    fixture.detectChanges();
+    component.threshold = null;
+    component.submit();
+    expect(service.createAlert).not.toHaveBeenCalled();
+    expect(component.error).toBeTruthy();
+
+    component.threshold = 0;
+    component.submit();
+    expect(service.createAlert).not.toHaveBeenCalled();
+  });
+
+  it('submit posts the full request and emits created on success', () => {
+    service.createAlert.and.returnValue(of(alert(9)));
+    fixture.detectChanges();
+
+    const createdSpy = jasmine.createSpy('created');
+    const closeSpy = jasmine.createSpy('close');
+    component.created.subscribe(createdSpy);
+    component.close.subscribe(closeSpy);
+
+    component.condition = 'BELOW';
+    component.threshold = 120;
+    component.notificationType = 'ALL';
+    component.submit();
+
+    expect(service.createAlert).toHaveBeenCalledWith({
+      listingId: 777,
+      condition: 'BELOW',
+      threshold: 120,
+      notificationType: 'ALL',
+    });
+    expect(toast.success).toHaveBeenCalled();
+    expect(createdSpy).toHaveBeenCalled();
+    expect(closeSpy).toHaveBeenCalled();
+  });
+
+  it('submit surfaces an error and keeps the modal open on failure', () => {
+    service.createAlert.and.returnValue(throwError(() => new Error('boom')));
+    fixture.detectChanges();
+
+    component.threshold = 100;
+    component.submit();
+    expect(component.error).toBe('Greska pri postavljanju obavestenja.');
+    expect(component.submitting).toBeFalse();
+  });
+});

--- a/src/app/features/price-alerts/components/create-alert-modal/create-alert-modal.component.ts
+++ b/src/app/features/price-alerts/components/create-alert-modal/create-alert-modal.component.ts
@@ -1,0 +1,119 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+import { FormModalComponent } from '../../../../shared/components/form-modal/form-modal.component';
+import { ToastService } from '../../../../shared/services/toast.service';
+import { AlertService } from '../../services/alert.service';
+import {
+  AlertCondition,
+  AlertNotificationType,
+  PriceAlert,
+} from '../../models/price-alert.model';
+
+/**
+ * WP-22 (Celina 3): "Postavi obavestenje" — create price-alert modal.
+ *
+ * <p>A reusable `z-overlay`/`z-modal` form opened by the "Postavi obavestenje"
+ * button on the stock-detail / security-detail headers. The trader picks a
+ * trigger condition (above / below / intraday percent drop), a target value
+ * and a delivery channel; submitting calls {@link AlertService.createAlert}.
+ *
+ * <p>Standalone — drop `<app-create-alert-modal>` into any standalone
+ * component that knows the listing id and ticker it is arming an alert for.
+ */
+
+interface ConditionOption {
+  value: AlertCondition;
+  label: string;
+}
+
+interface ChannelOption {
+  value: AlertNotificationType;
+  label: string;
+}
+
+@Component({
+  selector: 'app-create-alert-modal',
+  standalone: true,
+  imports: [CommonModule, FormsModule, FormModalComponent],
+  templateUrl: './create-alert-modal.component.html',
+})
+export class CreateAlertModalComponent {
+  /** Listing id of the security the alert watches. */
+  @Input({ required: true }) listingId!: number;
+  /** Ticker shown in the modal title — purely cosmetic. */
+  @Input() ticker = '';
+
+  /** Emitted when the modal should close (cancel or after a successful save). */
+  @Output() close = new EventEmitter<void>();
+  /** Emitted with the created alert after a successful save. */
+  @Output() created = new EventEmitter<PriceAlert>();
+
+  condition: AlertCondition = 'ABOVE';
+  threshold: number | null = null;
+  notificationType: AlertNotificationType = 'IN_APP';
+
+  submitting = false;
+  error: string | null = null;
+
+  readonly conditionOptions: ConditionOption[] = [
+    { value: 'ABOVE', label: 'Cena iznad' },
+    { value: 'BELOW', label: 'Cena ispod' },
+    { value: 'PCT_DROP_INTRADAY', label: 'Intradnevni pad (%)' },
+  ];
+
+  readonly channelOptions: ChannelOption[] = [
+    { value: 'IN_APP', label: 'U aplikaciji' },
+    { value: 'EMAIL', label: 'Email' },
+    { value: 'PUSH', label: 'Push' },
+    { value: 'ALL', label: 'Svi kanali' },
+  ];
+
+  constructor(
+    private readonly alertService: AlertService,
+    private readonly toast: ToastService,
+  ) {}
+
+  /** True when the threshold input should be read as a percentage. */
+  get isPercent(): boolean {
+    return this.condition === 'PCT_DROP_INTRADAY';
+  }
+
+  onCancel(): void {
+    if (this.submitting) {
+      return;
+    }
+    this.close.emit();
+  }
+
+  submit(): void {
+    if (this.threshold === null || this.threshold <= 0) {
+      this.error = this.isPercent
+        ? 'Unesite procenat veci od 0.'
+        : 'Unesite ciljnu cenu vecu od 0.';
+      return;
+    }
+    this.submitting = true;
+    this.error = null;
+    this.alertService
+      .createAlert({
+        listingId: this.listingId,
+        condition: this.condition,
+        threshold: this.threshold,
+        notificationType: this.notificationType,
+      })
+      .subscribe({
+        next: (alert) => {
+          this.submitting = false;
+          this.toast.success('Obavestenje postavljeno.');
+          this.created.emit(alert);
+          this.close.emit();
+        },
+        error: () => {
+          this.submitting = false;
+          this.error = 'Greska pri postavljanju obavestenja.';
+        },
+      });
+  }
+}

--- a/src/app/features/price-alerts/components/price-alerts-page/price-alerts-page.component.html
+++ b/src/app/features/price-alerts/components/price-alerts-page/price-alerts-page.component.html
@@ -1,0 +1,61 @@
+<!-- WP-22 (Celina 3): price-alerts management page. -->
+<div class="space-y-6">
+  <div class="flex items-center justify-between">
+    <h1 class="text-2xl font-bold text-foreground">Cenovni alarmi</h1>
+  </div>
+
+  <app-state *ngIf="isLoading" mode="loading" text="Ucitavanje obavestenja..."></app-state>
+  <app-state *ngIf="!isLoading && error" mode="error" [text]="error"></app-state>
+  <app-state
+    *ngIf="!isLoading && !error && alerts.length === 0"
+    mode="empty"
+    icon="bell"
+    title="Nema obavestenja"
+    text="Postavite obavestenje sa stranice hartije od vrednosti."
+  ></app-state>
+
+  <div *ngIf="!isLoading && !error && alerts.length > 0" class="z-card">
+    <table class="z-table">
+      <thead>
+        <tr>
+          <th>HARTIJA</th>
+          <th>USLOV</th>
+          <th class="text-right">PRAG</th>
+          <th>KANAL</th>
+          <th>STANJE</th>
+          <th>AKCIJA</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let a of alerts; trackBy: trackByAlert">
+          <td>
+            <a [routerLink]="detailLink(a)" class="text-primary hover:underline font-semibold">
+              {{ a.ticker }}
+            </a>
+            <span class="block text-xs text-muted-foreground">{{ a.securityName }}</span>
+          </td>
+          <td>{{ conditionLabel(a.condition) }}</td>
+          <td class="text-right font-mono tabular-nums">
+            {{ a.threshold | number: '1.2-2' }}{{ isPercent(a.condition) ? '%' : '' }}
+          </td>
+          <td class="text-muted-foreground">{{ channelLabel(a.notificationType) }}</td>
+          <td>
+            <span
+              [class]="a.active ? 'z-badge z-badge-green' : 'z-badge z-badge-gray'"
+            >
+              {{ a.active ? 'Aktivan' : 'Pauziran' }}
+            </span>
+          </td>
+          <td class="space-x-2 whitespace-nowrap">
+            <button type="button" class="z-btn-outline z-btn-sm" (click)="toggle(a)">
+              {{ a.active ? 'Pauziraj' : 'Aktiviraj' }}
+            </button>
+            <button type="button" class="z-btn-outline z-btn-sm" (click)="remove(a)">
+              Obrisi
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/src/app/features/price-alerts/components/price-alerts-page/price-alerts-page.component.spec.ts
+++ b/src/app/features/price-alerts/components/price-alerts-page/price-alerts-page.component.spec.ts
@@ -1,0 +1,103 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of, throwError } from 'rxjs';
+
+import { PriceAlertsPageComponent } from './price-alerts-page.component';
+import { AlertService } from '../../services/alert.service';
+import { ToastService } from '../../../../shared/services/toast.service';
+import { PriceAlert } from '../../models/price-alert.model';
+
+function alert(id: number, overrides: Partial<PriceAlert> = {}): PriceAlert {
+  return {
+    id,
+    listingId: 100 + id,
+    ticker: `TKR${id}`,
+    securityName: `Security ${id}`,
+    condition: 'ABOVE',
+    threshold: 150,
+    notificationType: 'IN_APP',
+    active: true,
+    createdAt: '2026-05-01T10:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('PriceAlertsPageComponent', () => {
+  let fixture: ComponentFixture<PriceAlertsPageComponent>;
+  let component: PriceAlertsPageComponent;
+  let service: jasmine.SpyObj<AlertService>;
+  let toast: jasmine.SpyObj<ToastService>;
+
+  beforeEach(async () => {
+    service = jasmine.createSpyObj('AlertService', [
+      'getAlerts',
+      'toggleActive',
+      'deleteAlert',
+    ]);
+    toast = jasmine.createSpyObj('ToastService', ['success', 'error']);
+    service.getAlerts.and.returnValue(of([]));
+
+    await TestBed.configureTestingModule({
+      imports: [PriceAlertsPageComponent, RouterTestingModule],
+      providers: [
+        { provide: AlertService, useValue: service },
+        { provide: ToastService, useValue: toast },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PriceAlertsPageComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('creates', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('loads alerts on init', () => {
+    service.getAlerts.and.returnValue(of([alert(1), alert(2)]));
+    fixture.detectChanges();
+    expect(component.alerts.length).toBe(2);
+    expect(component.isLoading).toBeFalse();
+  });
+
+  it('shows an error when alerts fail to load', () => {
+    service.getAlerts.and.returnValue(throwError(() => new Error('down')));
+    fixture.detectChanges();
+    expect(component.error).toBe('Greska pri ucitavanju obavestenja.');
+  });
+
+  it('toggle flips the active flag locally on success', () => {
+    service.getAlerts.and.returnValue(of([alert(1, { active: true })]));
+    service.toggleActive.and.returnValue(of(alert(1, { active: false })));
+    fixture.detectChanges();
+
+    const a = component.alerts[0];
+    component.toggle(a);
+    expect(service.toggleActive).toHaveBeenCalledWith(1, false);
+    expect(a.active).toBeFalse();
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it('toggle surfaces an error toast on failure', () => {
+    service.getAlerts.and.returnValue(of([alert(1, { active: true })]));
+    service.toggleActive.and.returnValue(throwError(() => new Error('boom')));
+    fixture.detectChanges();
+
+    component.toggle(component.alerts[0]);
+    expect(toast.error).toHaveBeenCalled();
+    /* The optimistic flip must be left intact only on success. */
+    expect(component.alerts[0].active).toBeTrue();
+  });
+
+  it('conditionLabel and channelLabel return Serbian labels', () => {
+    expect(component.conditionLabel('ABOVE')).toBe('Cena iznad');
+    expect(component.conditionLabel('PCT_DROP_INTRADAY')).toBe('Intradnevni pad');
+    expect(component.channelLabel('ALL')).toBe('Svi kanali');
+  });
+
+  it('isPercent is true only for the intraday-drop condition', () => {
+    expect(component.isPercent('PCT_DROP_INTRADAY')).toBeTrue();
+    expect(component.isPercent('ABOVE')).toBeFalse();
+  });
+});

--- a/src/app/features/price-alerts/components/price-alerts-page/price-alerts-page.component.ts
+++ b/src/app/features/price-alerts/components/price-alerts-page/price-alerts-page.component.ts
@@ -1,0 +1,128 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+import { StateComponent } from '../../../../shared/components/state/state.component';
+import { ToastService } from '../../../../shared/services/toast.service';
+import { AlertService } from '../../services/alert.service';
+import {
+  AlertCondition,
+  AlertNotificationType,
+  PriceAlert,
+} from '../../models/price-alert.model';
+
+/**
+ * WP-22 (Celina 3): Price-alerts management page (`/price-alerts`).
+ *
+ * <p>Lists every price alert the caller has set, with a per-row toggle to
+ * arm / disarm an alert and a delete action. New alerts are created from the
+ * stock-detail / security-detail headers via {@link CreateAlertModalComponent}
+ * — this page is the management surface only.
+ *
+ * <p>Standalone, lazy-loaded via `loadComponent` so it stays out of the
+ * initial bundle.
+ */
+@Component({
+  selector: 'app-price-alerts-page',
+  standalone: true,
+  imports: [CommonModule, RouterModule, StateComponent],
+  templateUrl: './price-alerts-page.component.html',
+})
+export class PriceAlertsPageComponent implements OnInit {
+  alerts: PriceAlert[] = [];
+  isLoading = true;
+  error: string | null = null;
+
+  constructor(
+    private readonly alertService: AlertService,
+    private readonly toast: ToastService,
+  ) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.isLoading = true;
+    this.error = null;
+    this.alertService.getAlerts().subscribe({
+      next: (alerts) => {
+        this.alerts = alerts ?? [];
+        this.isLoading = false;
+      },
+      error: () => {
+        this.isLoading = false;
+        this.error = 'Greska pri ucitavanju obavestenja.';
+      },
+    });
+  }
+
+  toggle(alert: PriceAlert): void {
+    const next = !alert.active;
+    this.alertService.toggleActive(alert.id, next).subscribe({
+      next: () => {
+        /* Optimistic local flip — avoids a full reload. */
+        alert.active = next;
+        this.toast.success(
+          next ? 'Obavestenje aktivirano.' : 'Obavestenje pauzirano.',
+        );
+      },
+      error: () => this.toast.error('Greska pri izmeni obavestenja.'),
+    });
+  }
+
+  remove(alert: PriceAlert): void {
+    if (!confirm(`Obrisati obavestenje za ${alert.ticker}?`)) {
+      return;
+    }
+    this.alertService.deleteAlert(alert.id).subscribe({
+      next: () => {
+        this.toast.success('Obavestenje obrisano.');
+        this.load();
+      },
+      error: () => this.toast.error('Greska pri brisanju obavestenja.'),
+    });
+  }
+
+  conditionLabel(condition: AlertCondition): string {
+    switch (condition) {
+      case 'ABOVE':
+        return 'Cena iznad';
+      case 'BELOW':
+        return 'Cena ispod';
+      case 'PCT_DROP_INTRADAY':
+        return 'Intradnevni pad';
+      default:
+        return condition;
+    }
+  }
+
+  /** Whether the threshold of this alert should render as a percentage. */
+  isPercent(condition: AlertCondition): boolean {
+    return condition === 'PCT_DROP_INTRADAY';
+  }
+
+  channelLabel(type: AlertNotificationType): string {
+    switch (type) {
+      case 'EMAIL':
+        return 'Email';
+      case 'PUSH':
+        return 'Push';
+      case 'IN_APP':
+        return 'U aplikaciji';
+      case 'ALL':
+        return 'Svi kanali';
+      default:
+        return type;
+    }
+  }
+
+  /** Routerlink target for an alert's watched security-detail page. */
+  detailLink(alert: PriceAlert): string[] {
+    return ['/securities', 'stock', String(alert.listingId)];
+  }
+
+  trackByAlert(_: number, alert: PriceAlert): number {
+    return alert.id;
+  }
+}

--- a/src/app/features/price-alerts/models/price-alert.model.ts
+++ b/src/app/features/price-alerts/models/price-alert.model.ts
@@ -1,0 +1,46 @@
+/**
+ * WP-22 (Celina 3): Price Alert model.
+ *
+ * Mirrors the DTOs returned by the JWT-secured price-alert endpoints exposed
+ * through the gateway at `/price-alerts`. The {@link AuthInterceptor} attaches
+ * the token; every alert is scoped to the authenticated caller.
+ */
+
+/**
+ * Trigger condition for an alert.
+ *  - `ABOVE` — fire when the price rises above the threshold.
+ *  - `BELOW` — fire when the price falls below the threshold.
+ *  - `PCT_DROP_INTRADAY` — fire when the price drops by `threshold` percent
+ *    within a single trading day.
+ */
+export type AlertCondition = 'ABOVE' | 'BELOW' | 'PCT_DROP_INTRADAY';
+
+/** Delivery channel for a fired alert. */
+export type AlertNotificationType = 'EMAIL' | 'PUSH' | 'IN_APP' | 'ALL';
+
+/** One price alert owned by the caller. */
+export interface PriceAlert {
+  id: number;
+  /** Underlying listing id (the watched security primary key). */
+  listingId: number;
+  /** Security symbol — convenience field for the management list. */
+  ticker: string;
+  /** Security display name — convenience field for the management list. */
+  securityName: string;
+  condition: AlertCondition;
+  /** Target price, or percentage for `PCT_DROP_INTRADAY`. */
+  threshold: number;
+  notificationType: AlertNotificationType;
+  /** Whether the alert is currently armed. */
+  active: boolean;
+  /** ISO-8601 creation timestamp. */
+  createdAt: string;
+}
+
+/** Request body for `POST /price-alerts`. */
+export interface CreatePriceAlertRequest {
+  listingId: number;
+  condition: AlertCondition;
+  threshold: number;
+  notificationType: AlertNotificationType;
+}

--- a/src/app/features/price-alerts/services/alert.service.spec.ts
+++ b/src/app/features/price-alerts/services/alert.service.spec.ts
@@ -1,0 +1,93 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+
+import { environment } from '../../../../environments/environment';
+import { AlertService } from './alert.service';
+import { PriceAlert } from '../models/price-alert.model';
+
+const baseUrl = `${environment.apiUrl}/price-alerts`;
+
+function alert(id: number, overrides: Partial<PriceAlert> = {}): PriceAlert {
+  return {
+    id,
+    listingId: 100 + id,
+    ticker: `TKR${id}`,
+    securityName: `Security ${id}`,
+    condition: 'ABOVE',
+    threshold: 150,
+    notificationType: 'IN_APP',
+    active: true,
+    createdAt: '2026-05-01T10:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('AlertService', () => {
+  let service: AlertService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [AlertService],
+    });
+    service = TestBed.inject(AlertService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('getAlerts GETs /price-alerts', () => {
+    let result: PriceAlert[] | undefined;
+    service.getAlerts().subscribe((a) => (result = a));
+
+    const req = httpMock.expectOne(baseUrl);
+    expect(req.request.method).toBe('GET');
+    const body = [alert(1), alert(2)];
+    req.flush(body);
+    expect(result).toEqual(body);
+  });
+
+  it('createAlert POSTs the full request body', () => {
+    let result: PriceAlert | undefined;
+    service
+      .createAlert({
+        listingId: 555,
+        condition: 'BELOW',
+        threshold: 90,
+        notificationType: 'ALL',
+      })
+      .subscribe((a) => (result = a));
+
+    const req = httpMock.expectOne(baseUrl);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({
+      listingId: 555,
+      condition: 'BELOW',
+      threshold: 90,
+      notificationType: 'ALL',
+    });
+    req.flush(alert(9));
+    expect(result).toEqual(alert(9));
+  });
+
+  it('toggleActive PATCHes /price-alerts/{id} with the active flag', () => {
+    service.toggleActive(7, false).subscribe();
+    const req = httpMock.expectOne(`${baseUrl}/7`);
+    expect(req.request.method).toBe('PATCH');
+    expect(req.request.body).toEqual({ active: false });
+    req.flush(alert(7, { active: false }));
+  });
+
+  it('deleteAlert DELETEs /price-alerts/{id}', () => {
+    service.deleteAlert(7).subscribe();
+    const req = httpMock.expectOne(`${baseUrl}/7`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush(null);
+  });
+});

--- a/src/app/features/price-alerts/services/alert.service.ts
+++ b/src/app/features/price-alerts/services/alert.service.ts
@@ -1,0 +1,47 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { environment } from '../../../../environments/environment';
+import {
+  CreatePriceAlertRequest,
+  PriceAlert,
+} from '../models/price-alert.model';
+
+/**
+ * WP-22 (Celina 3): Price Alert client.
+ *
+ * <p>Wraps the JWT-secured price-alert endpoints exposed through the gateway
+ * at `/price-alerts`. The {@link AuthInterceptor} attaches the `Authorization`
+ * header automatically. Every alert is scoped to the authenticated caller.
+ *
+ * <p>An alert fires when the watched security's price crosses its target; the
+ * backend delivers the notification through the channel chosen at creation
+ * (`EMAIL` / `PUSH` / `IN_APP` / `ALL`).
+ */
+@Injectable({ providedIn: 'root' })
+export class AlertService {
+  private readonly baseUrl = `${environment.apiUrl}/price-alerts`;
+
+  constructor(private readonly http: HttpClient) {}
+
+  /** Lists every price alert owned by the caller. */
+  getAlerts(): Observable<PriceAlert[]> {
+    return this.http.get<PriceAlert[]>(this.baseUrl);
+  }
+
+  /** Creates a new price alert. */
+  createAlert(request: CreatePriceAlertRequest): Observable<PriceAlert> {
+    return this.http.post<PriceAlert>(this.baseUrl, request);
+  }
+
+  /** Arms or disarms an existing alert. */
+  toggleActive(id: number, active: boolean): Observable<PriceAlert> {
+    return this.http.patch<PriceAlert>(`${this.baseUrl}/${id}`, { active });
+  }
+
+  /** Deletes a price alert by id. */
+  deleteAlert(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/${id}`);
+  }
+}

--- a/src/app/features/recurring-orders/models/recurring-order.model.ts
+++ b/src/app/features/recurring-orders/models/recurring-order.model.ts
@@ -1,0 +1,58 @@
+/**
+ * WP-23 (Celina 3 — DCA): Recurring Orders model.
+ *
+ * Mirrors the DTOs returned by the JWT-secured recurring-order endpoints
+ * exposed through the gateway at `/recurring-orders`. The {@link AuthInterceptor}
+ * attaches the token; every standing order is scoped to the authenticated
+ * caller (a client-with-trading or an actuary agent).
+ *
+ * <p>A recurring order is a DCA (dollar-cost-averaging) standing order: the
+ * backend periodically places a Market Order on the caller's behalf. It can be
+ * paused and resumed, or cancelled outright, at any time.
+ */
+
+/** Order side of a recurring order. */
+export type RecurringDirection = 'BUY' | 'SELL';
+
+/**
+ * How the periodic Market Order sizes itself.
+ *  - `BY_QUANTITY` — `value` is a fixed share/contract count.
+ *  - `BY_AMOUNT` — `value` is a fixed money amount; the backend derives the
+ *    quantity from the current price at run time.
+ */
+export type RecurringMode = 'BY_QUANTITY' | 'BY_AMOUNT';
+
+/** How often the standing order places its Market Order. */
+export type RecurringCadence = 'DAILY' | 'WEEKLY' | 'MONTHLY';
+
+/** One recurring (DCA) order owned by the caller. */
+export interface RecurringOrder {
+  id: number;
+  /** Underlying listing id (the traded security primary key). */
+  listingId: number;
+  direction: RecurringDirection;
+  mode: RecurringMode;
+  /** Share count (`BY_QUANTITY`) or money amount (`BY_AMOUNT`). */
+  value: number;
+  /** Account id charged / credited by the periodic Market Order. */
+  accountId: number;
+  cadence: RecurringCadence;
+  /** ISO-8601 timestamp of the next scheduled run. */
+  nextRun: string;
+  /** Whether the schedule is currently active (`false` => paused). */
+  active: boolean;
+  /** ISO-8601 creation timestamp. */
+  createdAt: string;
+}
+
+/** Request body for `POST /recurring-orders`. */
+export interface CreateRecurringOrderRequest {
+  listingId: number;
+  direction: RecurringDirection;
+  mode: RecurringMode;
+  value: number;
+  accountId: number;
+  cadence: RecurringCadence;
+  /** ISO date (`yyyy-MM-dd`) of the first scheduled run. */
+  nextRun: string;
+}

--- a/src/app/features/recurring-orders/recurring-orders.component.html
+++ b/src/app/features/recurring-orders/recurring-orders.component.html
@@ -1,0 +1,160 @@
+<!-- WP-23 (Celina 3 — DCA): recurring (standing) orders page. -->
+<div class="space-y-6">
+  <div class="flex items-center justify-between">
+    <h1 class="text-2xl font-bold text-foreground">Trajni nalozi</h1>
+    <button type="button" class="z-btn-primary z-btn-sm" (click)="openModal()">
+      Novi trajni nalog
+    </button>
+  </div>
+
+  <app-state *ngIf="isLoading" mode="loading" text="Ucitavanje trajnih naloga..."></app-state>
+  <app-state *ngIf="!isLoading && error" mode="error" [text]="error"></app-state>
+  <app-state
+    *ngIf="!isLoading && !error && orders.length === 0"
+    mode="empty"
+    icon="repeat"
+    title="Nema trajnih naloga"
+    text="Kreirajte trajni nalog da periodicno automatski izvrsavate Market Order."
+  ></app-state>
+
+  <div *ngIf="!isLoading && !error && orders.length > 0" class="z-card">
+    <table class="z-table">
+      <thead>
+        <tr>
+          <th>HARTIJA</th>
+          <th>SMER</th>
+          <th>NACIN</th>
+          <th class="text-right">VREDNOST</th>
+          <th class="text-right">RACUN</th>
+          <th>UCESTALOST</th>
+          <th>SLEDECE IZVRSENJE</th>
+          <th>STANJE</th>
+          <th>AKCIJA</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let o of orders; trackBy: trackByOrder">
+          <td class="font-semibold font-mono tabular-nums">#{{ o.listingId }}</td>
+          <td>{{ directionLabel(o.direction) }}</td>
+          <td class="text-muted-foreground">{{ modeLabel(o.mode) }}</td>
+          <td class="text-right font-mono tabular-nums">
+            {{ o.value | number: '1.2-2' }}
+          </td>
+          <td class="text-right font-mono tabular-nums">#{{ o.accountId }}</td>
+          <td>{{ cadenceLabel(o.cadence) }}</td>
+          <td class="text-muted-foreground whitespace-nowrap">
+            {{ o.nextRun | date: 'dd.MM.yyyy. HH:mm' }}
+          </td>
+          <td>
+            <span [class]="o.active ? 'z-badge z-badge-green' : 'z-badge z-badge-gray'">
+              {{ o.active ? 'Aktivan' : 'Pauziran' }}
+            </span>
+          </td>
+          <td class="space-x-2 whitespace-nowrap">
+            <button
+              *ngIf="o.active"
+              type="button"
+              class="z-btn-outline z-btn-sm"
+              (click)="pause(o)"
+            >
+              Pauziraj
+            </button>
+            <button
+              *ngIf="!o.active"
+              type="button"
+              class="z-btn-outline z-btn-sm"
+              (click)="resume(o)"
+            >
+              Aktiviraj
+            </button>
+            <button type="button" class="z-btn-outline z-btn-sm" (click)="cancel(o)">
+              Otkazi
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<!-- Create modal -->
+<app-form-modal
+  *ngIf="modalOpen"
+  title="Novi trajni nalog"
+  [submitting]="submitting"
+  [errorMessage]="formError"
+  confirmLabel="Kreiraj"
+  (close)="closeModal()"
+  (confirm)="submit()"
+>
+  <div class="space-y-4">
+    <div>
+      <label class="z-label" for="ro-listing">ID hartije od vrednosti</label>
+      <input
+        id="ro-listing"
+        type="number"
+        min="1"
+        step="1"
+        class="z-input"
+        [(ngModel)]="listingId"
+        placeholder="npr. 101"
+      />
+    </div>
+
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <div>
+        <label class="z-label" for="ro-direction">Smer</label>
+        <select id="ro-direction" class="z-select" [(ngModel)]="direction">
+          <option *ngFor="let o of directionOptions" [value]="o.value">{{ o.label }}</option>
+        </select>
+      </div>
+      <div>
+        <label class="z-label" for="ro-mode">Nacin</label>
+        <select id="ro-mode" class="z-select" [(ngModel)]="mode">
+          <option *ngFor="let o of modeOptions" [value]="o.value">{{ o.label }}</option>
+        </select>
+      </div>
+    </div>
+
+    <div>
+      <label class="z-label" for="ro-value">
+        {{ isByAmount ? 'Iznos' : 'Kolicina' }}
+      </label>
+      <input
+        id="ro-value"
+        type="number"
+        min="0"
+        [step]="isByAmount ? '0.01' : '1'"
+        class="z-input"
+        [(ngModel)]="value"
+        [placeholder]="isByAmount ? 'npr. 500.00' : 'npr. 3'"
+      />
+    </div>
+
+    <div>
+      <label class="z-label" for="ro-account">ID racuna</label>
+      <input
+        id="ro-account"
+        type="number"
+        min="1"
+        step="1"
+        class="z-input"
+        [(ngModel)]="accountId"
+        placeholder="npr. 9001"
+      />
+    </div>
+
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <div>
+        <label class="z-label" for="ro-cadence">Ucestalost</label>
+        <select id="ro-cadence" class="z-select" [(ngModel)]="cadence">
+          <option *ngFor="let o of cadenceOptions" [value]="o.value">{{ o.label }}</option>
+        </select>
+      </div>
+      <div>
+        <label class="z-label" for="ro-next-run">Prvo izvrsenje</label>
+        <input id="ro-next-run" type="date" class="z-input" [(ngModel)]="nextRun" />
+      </div>
+    </div>
+  </div>
+</app-form-modal>

--- a/src/app/features/recurring-orders/recurring-orders.component.spec.ts
+++ b/src/app/features/recurring-orders/recurring-orders.component.spec.ts
@@ -1,0 +1,236 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+
+import { RecurringOrdersComponent } from './recurring-orders.component';
+import { RecurringOrderService } from './services/recurring-order.service';
+import { ToastService } from '../../shared/services/toast.service';
+import { RecurringOrder } from './models/recurring-order.model';
+
+function recurringOrder(
+  id: number,
+  overrides: Partial<RecurringOrder> = {},
+): RecurringOrder {
+  return {
+    id,
+    listingId: 100 + id,
+    direction: 'BUY',
+    mode: 'BY_AMOUNT',
+    value: 500,
+    accountId: 9000 + id,
+    cadence: 'MONTHLY',
+    nextRun: '2026-06-01T08:00:00Z',
+    active: true,
+    createdAt: '2026-05-01T10:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('RecurringOrdersComponent', () => {
+  let fixture: ComponentFixture<RecurringOrdersComponent>;
+  let component: RecurringOrdersComponent;
+  let service: jasmine.SpyObj<RecurringOrderService>;
+  let toast: jasmine.SpyObj<ToastService>;
+
+  beforeEach(async () => {
+    service = jasmine.createSpyObj('RecurringOrderService', [
+      'getRecurringOrders',
+      'createRecurringOrder',
+      'pause',
+      'resume',
+      'deleteRecurringOrder',
+    ]);
+    toast = jasmine.createSpyObj('ToastService', ['success', 'error']);
+    service.getRecurringOrders.and.returnValue(of([]));
+
+    await TestBed.configureTestingModule({
+      imports: [RecurringOrdersComponent],
+      providers: [
+        { provide: RecurringOrderService, useValue: service },
+        { provide: ToastService, useValue: toast },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RecurringOrdersComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('creates', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('loads recurring orders on init', () => {
+    service.getRecurringOrders.and.returnValue(
+      of([recurringOrder(1), recurringOrder(2)]),
+    );
+    fixture.detectChanges();
+    expect(component.orders.length).toBe(2);
+    expect(component.isLoading).toBeFalse();
+  });
+
+  it('shows an error when orders fail to load', () => {
+    service.getRecurringOrders.and.returnValue(
+      throwError(() => new Error('down')),
+    );
+    fixture.detectChanges();
+    expect(component.error).toBe('Greska pri ucitavanju trajnih naloga.');
+    expect(component.isLoading).toBeFalse();
+  });
+
+  it('openModal resets the form and opens the modal', () => {
+    fixture.detectChanges();
+    component.listingId = 99;
+    component.value = 1000;
+    component.openModal();
+    expect(component.modalOpen).toBeTrue();
+    expect(component.listingId).toBeNull();
+    expect(component.value).toBeNull();
+    expect(component.formError).toBeNull();
+  });
+
+  it('isByAmount tracks the sizing mode', () => {
+    component.mode = 'BY_AMOUNT';
+    expect(component.isByAmount).toBeTrue();
+    component.mode = 'BY_QUANTITY';
+    expect(component.isByAmount).toBeFalse();
+  });
+
+  it('submit rejects an incomplete form without calling the service', () => {
+    fixture.detectChanges();
+    component.openModal();
+    /* listingId still null */
+    component.submit();
+    expect(service.createRecurringOrder).not.toHaveBeenCalled();
+    expect(component.formError).toBeTruthy();
+
+    /* listingId set, value still null */
+    component.listingId = 101;
+    component.submit();
+    expect(service.createRecurringOrder).not.toHaveBeenCalled();
+
+    /* value set, accountId still null */
+    component.value = 500;
+    component.submit();
+    expect(service.createRecurringOrder).not.toHaveBeenCalled();
+
+    /* accountId set, nextRun still empty */
+    component.accountId = 9001;
+    component.submit();
+    expect(service.createRecurringOrder).not.toHaveBeenCalled();
+  });
+
+  it('submit posts the full request and reloads on success', () => {
+    service.createRecurringOrder.and.returnValue(of(recurringOrder(9)));
+    service.getRecurringOrders.and.returnValue(of([recurringOrder(9)]));
+    fixture.detectChanges();
+
+    component.openModal();
+    component.listingId = 101;
+    component.direction = 'SELL';
+    component.mode = 'BY_QUANTITY';
+    component.value = 4;
+    component.accountId = 9001;
+    component.cadence = 'WEEKLY';
+    component.nextRun = '2026-06-01';
+    component.submit();
+
+    expect(service.createRecurringOrder).toHaveBeenCalledWith({
+      listingId: 101,
+      direction: 'SELL',
+      mode: 'BY_QUANTITY',
+      value: 4,
+      accountId: 9001,
+      cadence: 'WEEKLY',
+      nextRun: '2026-06-01',
+    });
+    expect(component.modalOpen).toBeFalse();
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it('submit surfaces an error and keeps the modal open on failure', () => {
+    service.createRecurringOrder.and.returnValue(
+      throwError(() => new Error('boom')),
+    );
+    fixture.detectChanges();
+
+    component.openModal();
+    component.listingId = 101;
+    component.value = 500;
+    component.accountId = 9001;
+    component.nextRun = '2026-06-01';
+    component.submit();
+
+    expect(component.formError).toBe('Greska pri kreiranju trajnog naloga.');
+    expect(component.submitting).toBeFalse();
+    expect(component.modalOpen).toBeTrue();
+  });
+
+  it('pause flips an active order to paused on success', () => {
+    service.getRecurringOrders.and.returnValue(
+      of([recurringOrder(1, { active: true })]),
+    );
+    service.pause.and.returnValue(of(recurringOrder(1, { active: false })));
+    fixture.detectChanges();
+
+    const o = component.orders[0];
+    component.pause(o);
+    expect(service.pause).toHaveBeenCalledWith(1);
+    expect(o.active).toBeFalse();
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it('pause surfaces an error toast and leaves the order active on failure', () => {
+    service.getRecurringOrders.and.returnValue(
+      of([recurringOrder(1, { active: true })]),
+    );
+    service.pause.and.returnValue(throwError(() => new Error('boom')));
+    fixture.detectChanges();
+
+    component.pause(component.orders[0]);
+    expect(toast.error).toHaveBeenCalled();
+    expect(component.orders[0].active).toBeTrue();
+  });
+
+  it('resume flips a paused order to active on success', () => {
+    service.getRecurringOrders.and.returnValue(
+      of([recurringOrder(1, { active: false })]),
+    );
+    service.resume.and.returnValue(of(recurringOrder(1, { active: true })));
+    fixture.detectChanges();
+
+    const o = component.orders[0];
+    component.resume(o);
+    expect(service.resume).toHaveBeenCalledWith(1);
+    expect(o.active).toBeTrue();
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it('cancel deletes and reloads when confirmed', () => {
+    spyOn(window, 'confirm').and.returnValue(true);
+    service.getRecurringOrders.and.returnValue(of([recurringOrder(1)]));
+    service.deleteRecurringOrder.and.returnValue(of(void 0));
+    fixture.detectChanges();
+
+    component.cancel(component.orders[0]);
+    expect(service.deleteRecurringOrder).toHaveBeenCalledWith(1);
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it('cancel does nothing when the confirm dialog is dismissed', () => {
+    spyOn(window, 'confirm').and.returnValue(false);
+    service.getRecurringOrders.and.returnValue(of([recurringOrder(1)]));
+    fixture.detectChanges();
+
+    component.cancel(component.orders[0]);
+    expect(service.deleteRecurringOrder).not.toHaveBeenCalled();
+  });
+
+  it('label helpers return Serbian text', () => {
+    expect(component.directionLabel('BUY')).toBe('Kupovina');
+    expect(component.directionLabel('SELL')).toBe('Prodaja');
+    expect(component.modeLabel('BY_AMOUNT')).toBe('Po iznosu');
+    expect(component.modeLabel('BY_QUANTITY')).toBe('Po kolicini');
+    expect(component.cadenceLabel('DAILY')).toBe('Dnevno');
+    expect(component.cadenceLabel('MONTHLY')).toBe('Mesecno');
+  });
+});

--- a/src/app/features/recurring-orders/recurring-orders.component.ts
+++ b/src/app/features/recurring-orders/recurring-orders.component.ts
@@ -1,0 +1,240 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+import { StateComponent } from '../../shared/components/state/state.component';
+import { FormModalComponent } from '../../shared/components/form-modal/form-modal.component';
+import { ToastService } from '../../shared/services/toast.service';
+import { RecurringOrderService } from './services/recurring-order.service';
+import {
+  CreateRecurringOrderRequest,
+  RecurringCadence,
+  RecurringDirection,
+  RecurringMode,
+  RecurringOrder,
+} from './models/recurring-order.model';
+
+/**
+ * WP-23 (Celina 3 — DCA): Recurring (standing) Orders page (`/recurring-orders`).
+ *
+ * <p>Lists every recurring DCA order the caller has set, with a per-row
+ * pause / resume toggle and a cancel action. New orders are created from an
+ * `<app-form-modal>` create panel — the caller picks the listing, the side,
+ * the sizing mode (`BY_QUANTITY` / `BY_AMOUNT`), the value, the charged
+ * account, the cadence and the first-run date.
+ *
+ * <p>Reachable by every authenticated trader — clients-with-trading and
+ * actuary agents — via the lazy `recurring-orders` route. Standalone,
+ * lazy-loaded via `loadComponent` so it stays out of the initial bundle.
+ */
+
+interface SelectOption<T> {
+  value: T;
+  label: string;
+}
+
+@Component({
+  selector: 'app-recurring-orders',
+  standalone: true,
+  imports: [CommonModule, FormsModule, StateComponent, FormModalComponent],
+  templateUrl: './recurring-orders.component.html',
+})
+export class RecurringOrdersComponent implements OnInit {
+  orders: RecurringOrder[] = [];
+  isLoading = true;
+  error: string | null = null;
+
+  /* Create-modal state. */
+  modalOpen = false;
+  submitting = false;
+  formError: string | null = null;
+
+  /* Create-form model. */
+  listingId: number | null = null;
+  direction: RecurringDirection = 'BUY';
+  mode: RecurringMode = 'BY_AMOUNT';
+  value: number | null = null;
+  accountId: number | null = null;
+  cadence: RecurringCadence = 'MONTHLY';
+  nextRun = '';
+
+  readonly directionOptions: SelectOption<RecurringDirection>[] = [
+    { value: 'BUY', label: 'Kupovina' },
+    { value: 'SELL', label: 'Prodaja' },
+  ];
+
+  readonly modeOptions: SelectOption<RecurringMode>[] = [
+    { value: 'BY_AMOUNT', label: 'Po iznosu' },
+    { value: 'BY_QUANTITY', label: 'Po kolicini' },
+  ];
+
+  readonly cadenceOptions: SelectOption<RecurringCadence>[] = [
+    { value: 'DAILY', label: 'Dnevno' },
+    { value: 'WEEKLY', label: 'Nedeljno' },
+    { value: 'MONTHLY', label: 'Mesecno' },
+  ];
+
+  constructor(
+    private readonly recurringOrderService: RecurringOrderService,
+    private readonly toast: ToastService,
+  ) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.isLoading = true;
+    this.error = null;
+    this.recurringOrderService.getRecurringOrders().subscribe({
+      next: (orders) => {
+        this.orders = orders ?? [];
+        this.isLoading = false;
+      },
+      error: () => {
+        this.isLoading = false;
+        this.error = 'Greska pri ucitavanju trajnih naloga.';
+      },
+    });
+  }
+
+  /** True when `value` should render as a money amount rather than a count. */
+  get isByAmount(): boolean {
+    return this.mode === 'BY_AMOUNT';
+  }
+
+  openModal(): void {
+    this.resetForm();
+    this.modalOpen = true;
+  }
+
+  closeModal(): void {
+    if (this.submitting) {
+      return;
+    }
+    this.modalOpen = false;
+  }
+
+  /** Resets the create-form to its defaults. */
+  private resetForm(): void {
+    this.listingId = null;
+    this.direction = 'BUY';
+    this.mode = 'BY_AMOUNT';
+    this.value = null;
+    this.accountId = null;
+    this.cadence = 'MONTHLY';
+    this.nextRun = '';
+    this.formError = null;
+    this.submitting = false;
+  }
+
+  submit(): void {
+    const validationError = this.validate();
+    if (validationError) {
+      this.formError = validationError;
+      return;
+    }
+    this.submitting = true;
+    this.formError = null;
+
+    const request: CreateRecurringOrderRequest = {
+      listingId: this.listingId!,
+      direction: this.direction,
+      mode: this.mode,
+      value: this.value!,
+      accountId: this.accountId!,
+      cadence: this.cadence,
+      nextRun: this.nextRun,
+    };
+
+    this.recurringOrderService.createRecurringOrder(request).subscribe({
+      next: () => {
+        this.submitting = false;
+        this.modalOpen = false;
+        this.toast.success('Trajni nalog kreiran.');
+        this.load();
+      },
+      error: () => {
+        this.submitting = false;
+        this.formError = 'Greska pri kreiranju trajnog naloga.';
+      },
+    });
+  }
+
+  /** Returns a Serbian validation message, or `null` when the form is valid. */
+  private validate(): string | null {
+    if (this.listingId === null || this.listingId <= 0) {
+      return 'Unesite ID hartije od vrednosti.';
+    }
+    if (this.value === null || this.value <= 0) {
+      return this.isByAmount
+        ? 'Unesite iznos veci od 0.'
+        : 'Unesite kolicinu vecu od 0.';
+    }
+    if (this.accountId === null || this.accountId <= 0) {
+      return 'Unesite ID racuna.';
+    }
+    if (!this.nextRun) {
+      return 'Izaberite datum prvog izvrsenja.';
+    }
+    return null;
+  }
+
+  pause(order: RecurringOrder): void {
+    if (!order.active) {
+      return;
+    }
+    this.recurringOrderService.pause(order.id).subscribe({
+      next: () => {
+        /* Optimistic local flip — avoids a full reload. */
+        order.active = false;
+        this.toast.success('Trajni nalog pauziran.');
+      },
+      error: () => this.toast.error('Greska pri pauziranju naloga.'),
+    });
+  }
+
+  resume(order: RecurringOrder): void {
+    if (order.active) {
+      return;
+    }
+    this.recurringOrderService.resume(order.id).subscribe({
+      next: () => {
+        order.active = true;
+        this.toast.success('Trajni nalog aktiviran.');
+      },
+      error: () => this.toast.error('Greska pri aktiviranju naloga.'),
+    });
+  }
+
+  cancel(order: RecurringOrder): void {
+    if (!confirm('Otkazati ovaj trajni nalog? Ova akcija je nepovratna.')) {
+      return;
+    }
+    this.recurringOrderService.deleteRecurringOrder(order.id).subscribe({
+      next: () => {
+        this.toast.success('Trajni nalog otkazan.');
+        this.load();
+      },
+      error: () => this.toast.error('Greska pri otkazivanju naloga.'),
+    });
+  }
+
+  directionLabel(direction: RecurringDirection): string {
+    return direction === 'BUY' ? 'Kupovina' : 'Prodaja';
+  }
+
+  modeLabel(mode: RecurringMode): string {
+    return mode === 'BY_AMOUNT' ? 'Po iznosu' : 'Po kolicini';
+  }
+
+  cadenceLabel(cadence: RecurringCadence): string {
+    return (
+      this.cadenceOptions.find((o) => o.value === cadence)?.label ?? cadence
+    );
+  }
+
+  trackByOrder(_: number, order: RecurringOrder): number {
+    return order.id;
+  }
+}

--- a/src/app/features/recurring-orders/services/recurring-order.service.spec.ts
+++ b/src/app/features/recurring-orders/services/recurring-order.service.spec.ts
@@ -1,0 +1,111 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+
+import { environment } from '../../../../environments/environment';
+import { RecurringOrderService } from './recurring-order.service';
+import { RecurringOrder } from '../models/recurring-order.model';
+
+const baseUrl = `${environment.apiUrl}/recurring-orders`;
+
+function recurringOrder(
+  id: number,
+  overrides: Partial<RecurringOrder> = {},
+): RecurringOrder {
+  return {
+    id,
+    listingId: 100 + id,
+    direction: 'BUY',
+    mode: 'BY_AMOUNT',
+    value: 500,
+    accountId: 9000 + id,
+    cadence: 'MONTHLY',
+    nextRun: '2026-06-01T08:00:00Z',
+    active: true,
+    createdAt: '2026-05-01T10:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('RecurringOrderService', () => {
+  let service: RecurringOrderService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [RecurringOrderService],
+    });
+    service = TestBed.inject(RecurringOrderService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('getRecurringOrders GETs /recurring-orders', () => {
+    let result: RecurringOrder[] | undefined;
+    service.getRecurringOrders().subscribe((r) => (result = r));
+
+    const req = httpMock.expectOne(baseUrl);
+    expect(req.request.method).toBe('GET');
+    const body = [recurringOrder(1), recurringOrder(2)];
+    req.flush(body);
+    expect(result).toEqual(body);
+  });
+
+  it('createRecurringOrder POSTs the full request body', () => {
+    let result: RecurringOrder | undefined;
+    service
+      .createRecurringOrder({
+        listingId: 555,
+        direction: 'SELL',
+        mode: 'BY_QUANTITY',
+        value: 3,
+        accountId: 8001,
+        cadence: 'WEEKLY',
+        nextRun: '2026-06-01',
+      })
+      .subscribe((r) => (result = r));
+
+    const req = httpMock.expectOne(baseUrl);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({
+      listingId: 555,
+      direction: 'SELL',
+      mode: 'BY_QUANTITY',
+      value: 3,
+      accountId: 8001,
+      cadence: 'WEEKLY',
+      nextRun: '2026-06-01',
+    });
+    req.flush(recurringOrder(9));
+    expect(result).toEqual(recurringOrder(9));
+  });
+
+  it('pause PATCHes /recurring-orders/{id}/pause', () => {
+    service.pause(7).subscribe();
+    const req = httpMock.expectOne(`${baseUrl}/7/pause`);
+    expect(req.request.method).toBe('PATCH');
+    expect(req.request.body).toEqual({});
+    req.flush(recurringOrder(7, { active: false }));
+  });
+
+  it('resume PATCHes /recurring-orders/{id}/resume', () => {
+    service.resume(7).subscribe();
+    const req = httpMock.expectOne(`${baseUrl}/7/resume`);
+    expect(req.request.method).toBe('PATCH');
+    expect(req.request.body).toEqual({});
+    req.flush(recurringOrder(7, { active: true }));
+  });
+
+  it('deleteRecurringOrder DELETEs /recurring-orders/{id}', () => {
+    service.deleteRecurringOrder(7).subscribe();
+    const req = httpMock.expectOne(`${baseUrl}/7`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush(null);
+  });
+});

--- a/src/app/features/recurring-orders/services/recurring-order.service.ts
+++ b/src/app/features/recurring-orders/services/recurring-order.service.ts
@@ -1,0 +1,55 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { environment } from '../../../../environments/environment';
+import {
+  CreateRecurringOrderRequest,
+  RecurringOrder,
+} from '../models/recurring-order.model';
+
+/**
+ * WP-23 (Celina 3 — DCA): Recurring (standing) Orders client.
+ *
+ * <p>Wraps the JWT-secured recurring-order endpoints exposed through the
+ * gateway at `/recurring-orders`. The {@link AuthInterceptor} attaches the
+ * `Authorization` header automatically. Every standing order is scoped to the
+ * authenticated caller.
+ *
+ * <p>A recurring order is a DCA standing order: the backend periodically
+ * places a Market Order on the caller's behalf. It can be paused / resumed or
+ * cancelled at any time.
+ */
+@Injectable({ providedIn: 'root' })
+export class RecurringOrderService {
+  private readonly baseUrl = `${environment.apiUrl}/recurring-orders`;
+
+  constructor(private readonly http: HttpClient) {}
+
+  /** Lists every recurring order owned by the caller. */
+  getRecurringOrders(): Observable<RecurringOrder[]> {
+    return this.http.get<RecurringOrder[]>(this.baseUrl);
+  }
+
+  /** Creates a new recurring (DCA) order. */
+  createRecurringOrder(
+    request: CreateRecurringOrderRequest,
+  ): Observable<RecurringOrder> {
+    return this.http.post<RecurringOrder>(this.baseUrl, request);
+  }
+
+  /** Pauses an active recurring order — the schedule stops placing orders. */
+  pause(id: number): Observable<RecurringOrder> {
+    return this.http.patch<RecurringOrder>(`${this.baseUrl}/${id}/pause`, {});
+  }
+
+  /** Resumes a paused recurring order. */
+  resume(id: number): Observable<RecurringOrder> {
+    return this.http.patch<RecurringOrder>(`${this.baseUrl}/${id}/resume`, {});
+  }
+
+  /** Cancels (deletes) a recurring order by id. */
+  deleteRecurringOrder(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/${id}`);
+  }
+}

--- a/src/app/features/securities/components/securities-list/securities-list.component.html
+++ b/src/app/features/securities/components/securities-list/securities-list.component.html
@@ -356,13 +356,25 @@
               <td class="text-muted-foreground font-mono tabular-nums">{{ formatVolume(security.volume) }}</td>
               <td class="font-medium font-mono tabular-nums">{{ formatPrice(security.initialMarginCost) }}</td>
               <td>
-                <button
-                  type="button"
-                  class="z-btn-primary z-btn-sm"
-                  (click)="onBuy(security, $event)"
-                >
-                  Kupi
-                </button>
+                <div class="flex items-center gap-1.5">
+                  <button
+                    type="button"
+                    class="z-btn-primary z-btn-sm"
+                    (click)="onBuy(security, $event)"
+                  >
+                    Kupi
+                  </button>
+                  <!-- WP-22 (Celina 3): Dodaj na watchlist. -->
+                  <button
+                    type="button"
+                    class="z-btn-icon"
+                    title="Dodaj na watchlist"
+                    aria-label="Dodaj na watchlist"
+                    (click)="openWatchlistPicker(security, $event)"
+                  >
+                    <lucide-icon name="star" [size]="14"></lucide-icon>
+                  </button>
+                </div>
               </td>
             </tr>
           </tbody>
@@ -415,13 +427,25 @@
               <td class="font-medium font-mono tabular-nums">{{ formatPrice(security.initialMarginCost) }}</td>
               <td class="text-muted-foreground">{{ asFuture(security).settlementDate }}</td>
               <td>
-                <button
-                  type="button"
-                  class="z-btn-primary z-btn-sm"
-                  (click)="onBuy(security, $event)"
-                >
-                  Kupi
-                </button>
+                <div class="flex items-center gap-1.5">
+                  <button
+                    type="button"
+                    class="z-btn-primary z-btn-sm"
+                    (click)="onBuy(security, $event)"
+                  >
+                    Kupi
+                  </button>
+                  <!-- WP-22 (Celina 3): Dodaj na watchlist. -->
+                  <button
+                    type="button"
+                    class="z-btn-icon"
+                    title="Dodaj na watchlist"
+                    aria-label="Dodaj na watchlist"
+                    (click)="openWatchlistPicker(security, $event)"
+                  >
+                    <lucide-icon name="star" [size]="14"></lucide-icon>
+                  </button>
+                </div>
               </td>
             </tr>
           </tbody>
@@ -472,13 +496,25 @@
               <td class="text-muted-foreground font-mono tabular-nums">{{ asForex(security).spread.toFixed(4) }}</td>
               <td class="text-muted-foreground font-mono tabular-nums">{{ formatVolume(security.volume) }}</td>
               <td>
-                <button
-                  type="button"
-                  class="z-btn-primary z-btn-sm"
-                  (click)="onBuy(security, $event)"
-                >
-                  Kupi
-                </button>
+                <div class="flex items-center gap-1.5">
+                  <button
+                    type="button"
+                    class="z-btn-primary z-btn-sm"
+                    (click)="onBuy(security, $event)"
+                  >
+                    Kupi
+                  </button>
+                  <!-- WP-22 (Celina 3): Dodaj na watchlist. -->
+                  <button
+                    type="button"
+                    class="z-btn-icon"
+                    title="Dodaj na watchlist"
+                    aria-label="Dodaj na watchlist"
+                    (click)="openWatchlistPicker(security, $event)"
+                  >
+                    <lucide-icon name="star" [size]="14"></lucide-icon>
+                  </button>
+                </div>
               </td>
             </tr>
           </tbody>
@@ -504,3 +540,10 @@
     </div>
   </div>
 </div>
+
+<!-- WP-22 (Celina 3): watchlist picker modal (opened from the AKCIJA column). -->
+<app-watchlist-picker
+  *ngIf="watchlistPickerListingId !== null"
+  [listingId]="watchlistPickerListingId"
+  (close)="closeWatchlistPicker()"
+></app-watchlist-picker>

--- a/src/app/features/securities/components/securities-list/securities-list.component.ts
+++ b/src/app/features/securities/components/securities-list/securities-list.component.ts
@@ -14,6 +14,8 @@ import { AppPaginationComponent } from '../../../../shared/components/pagination
 import { StateComponent } from '../../../../shared/components/state/state.component';
 // PR_31 Phase 7 T22: lucide-icon za drawer close button.
 import { LucideIconComponent } from '../../../../shared/icons/lucide-icon.component';
+// WP-22 (Celina 3): watchlist picker modal otvoren iz "Dodaj na watchlist" dugmeta.
+import { WatchlistPickerComponent } from '../../../watchlist/components/watchlist-picker/watchlist-picker.component';
 import {
   Security,
   Stock,
@@ -30,7 +32,14 @@ type SecurityTab = 'stocks' | 'futures' | 'forex';
 @Component({
   selector: 'app-securities-list',
   standalone: true,
-  imports: [CommonModule, FormsModule, AppPaginationComponent, StateComponent, LucideIconComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    AppPaginationComponent,
+    StateComponent,
+    LucideIconComponent,
+    WatchlistPickerComponent,
+  ],
   templateUrl: './securities-list.component.html',
   styleUrls: ['./securities-list.component.scss'],
 })
@@ -57,6 +66,9 @@ export class SecuritiesListComponent implements OnInit, OnDestroy {
   sortConfig: SortConfig = { field: 'ticker', direction: 'asc' };
 
   searchQuery = '';
+
+  /** WP-22 (Celina 3): listing id whose watchlist picker is open; null = closed. */
+  watchlistPickerListingId: number | null = null;
 
   constructor(
     private readonly securitiesService: SecuritiesService,
@@ -283,6 +295,19 @@ export class SecuritiesListComponent implements OnInit, OnDestroy {
   onRowClick(security: Security): void {
     const type = this.activeTab === 'stocks' ? 'stock' : this.activeTab === 'futures' ? 'future' : 'forex';
     this.router.navigate(['/securities', type, security.id]);
+  }
+
+  /**
+   * WP-22 (Celina 3): opens the watchlist picker for a row.
+   * Stops row-click propagation so it does not also navigate to the detail page.
+   */
+  openWatchlistPicker(security: Security, event: Event): void {
+    event.stopPropagation();
+    this.watchlistPickerListingId = security.id;
+  }
+
+  closeWatchlistPicker(): void {
+    this.watchlistPickerListingId = null;
   }
 
   formatPrice(price: number): string {

--- a/src/app/features/securities/components/security-detail/security-detail.component.html
+++ b/src/app/features/securities/components/security-detail/security-detail.component.html
@@ -27,10 +27,31 @@
 
     <!-- Content -->
     <div *ngIf="!isLoading && !errorMessage && security">
-      <div class="flex items-baseline gap-3 mb-6 flex-wrap">
-        <h2 class="text-2xl font-bold text-foreground">{{ security.ticker }}</h2>
-        <span class="text-base text-muted-foreground">{{ security.name }}</span>
-        <span class="z-badge z-badge-blue">{{ security.exchange }}</span>
+      <div class="flex items-center justify-between gap-3 mb-6 flex-wrap">
+        <div class="flex items-baseline gap-3 flex-wrap">
+          <h2 class="text-2xl font-bold text-foreground">{{ security.ticker }}</h2>
+          <span class="text-base text-muted-foreground">{{ security.name }}</span>
+          <span class="z-badge z-badge-blue">{{ security.exchange }}</span>
+        </div>
+        <!-- WP-22 (Celina 3): watchlist + price-alert header actions. -->
+        <div class="flex items-center gap-2">
+          <button
+            type="button"
+            class="z-btn-outline z-btn-sm flex items-center gap-1.5"
+            (click)="openWatchlistPicker()"
+          >
+            <lucide-icon name="star" [size]="14"></lucide-icon>
+            Dodaj na watchlist
+          </button>
+          <button
+            type="button"
+            class="z-btn-outline z-btn-sm flex items-center gap-1.5"
+            (click)="openAlertModal()"
+          >
+            <lucide-icon name="bell" [size]="14"></lucide-icon>
+            Postavi obavestenje
+          </button>
+        </div>
       </div>
 
       <div class="z-card mb-6 overflow-hidden">
@@ -114,3 +135,17 @@
     </div>
   </div>
 </div>
+
+<!-- WP-22 (Celina 3): watchlist picker + create-alert modals. -->
+<app-watchlist-picker
+  *ngIf="watchlistPickerOpen && id !== null"
+  [listingId]="id"
+  (close)="closeWatchlistPicker()"
+></app-watchlist-picker>
+<app-create-alert-modal
+  *ngIf="alertModalOpen && id !== null"
+  [listingId]="id"
+  [ticker]="security?.ticker || ''"
+  (close)="closeAlertModal()"
+></app-create-alert-modal>
+

--- a/src/app/features/securities/components/security-detail/security-detail.component.ts
+++ b/src/app/features/securities/components/security-detail/security-detail.component.ts
@@ -14,6 +14,10 @@ import {
 import { StateComponent } from '../../../../shared/components/state/state.component';
 // PR_31 Phase 7 T24: ApexCharts zameni Canvas drawChart().
 import { PriceChartComponent, PriceSeriesPoint } from '../../../../shared/charts/price-chart/price-chart.component';
+// WP-22 (Celina 3): watchlist + price-alert action buttons in the header.
+import { LucideIconComponent } from '../../../../shared/icons/lucide-icon.component';
+import { WatchlistPickerComponent } from '../../../watchlist/components/watchlist-picker/watchlist-picker.component';
+import { CreateAlertModalComponent } from '../../../price-alerts/components/create-alert-modal/create-alert-modal.component';
 
 type Period = 'day' | 'week' | 'month' | 'year' | '5year' | 'all';
 
@@ -25,7 +29,14 @@ interface DetailRow {
 @Component({
   selector: 'app-security-detail',
   standalone: true,
-  imports: [CommonModule, StateComponent, PriceChartComponent],
+  imports: [
+    CommonModule,
+    StateComponent,
+    PriceChartComponent,
+    LucideIconComponent,
+    WatchlistPickerComponent,
+    CreateAlertModalComponent,
+  ],
   templateUrl: './security-detail.component.html',
   styleUrls: ['./security-detail.component.scss'],
 })
@@ -44,6 +55,10 @@ export class SecurityDetailComponent implements OnInit, OnDestroy {
   priceSeries: PriceSeriesPoint[] = [];
 
   selectedPeriod: Period = 'month';
+
+  /** WP-22 (Celina 3): header watchlist-picker / create-alert modal open flags. */
+  watchlistPickerOpen = false;
+  alertModalOpen = false;
 
   periods: { value: Period; label: string }[] = [
     { value: 'day', label: 'Dan' },
@@ -190,5 +205,23 @@ export class SecurityDetailComponent implements OnInit, OnDestroy {
 
   goBack(): void {
     this.router.navigate(['/securities']);
+  }
+
+  /* ---- WP-22 (Celina 3): watchlist + price-alert header actions ---- */
+
+  openWatchlistPicker(): void {
+    this.watchlistPickerOpen = true;
+  }
+
+  closeWatchlistPicker(): void {
+    this.watchlistPickerOpen = false;
+  }
+
+  openAlertModal(): void {
+    this.alertModalOpen = true;
+  }
+
+  closeAlertModal(): void {
+    this.alertModalOpen = false;
   }
 }

--- a/src/app/features/securities/components/stock-detail/stock-detail.component.html
+++ b/src/app/features/securities/components/stock-detail/stock-detail.component.html
@@ -27,10 +27,30 @@
 
     <!-- Content -->
     <div *ngIf="!isLoading && !errorMessage && stock">
-      <!-- Stock name -->
-      <h2 class="text-xl font-semibold text-foreground mb-6">
-        {{ stock.ticker }} - {{ stock.name }}
-      </h2>
+      <!-- Stock name + WP-22 (Celina 3) watchlist / price-alert header actions -->
+      <div class="flex items-center justify-between gap-3 mb-6 flex-wrap">
+        <h2 class="text-xl font-semibold text-foreground">
+          {{ stock.ticker }} - {{ stock.name }}
+        </h2>
+        <div class="flex items-center gap-2">
+          <button
+            type="button"
+            class="z-btn-outline z-btn-sm flex items-center gap-1.5"
+            (click)="openWatchlistPicker()"
+          >
+            <lucide-icon name="star" [size]="14"></lucide-icon>
+            Dodaj na watchlist
+          </button>
+          <button
+            type="button"
+            class="z-btn-outline z-btn-sm flex items-center gap-1.5"
+            (click)="openAlertModal()"
+          >
+            <lucide-icon name="bell" [size]="14"></lucide-icon>
+            Postavi obavestenje
+          </button>
+        </div>
+      </div>
 
       <!-- Main info card with chart -->
       <div class="z-card mb-6">
@@ -232,3 +252,17 @@
     </div>
   </div>
 </div>
+
+<!-- WP-22 (Celina 3): watchlist picker + create-alert modals. -->
+<app-watchlist-picker
+  *ngIf="watchlistPickerOpen && listingId !== null"
+  [listingId]="listingId"
+  (close)="closeWatchlistPicker()"
+></app-watchlist-picker>
+<app-create-alert-modal
+  *ngIf="alertModalOpen && listingId !== null"
+  [listingId]="listingId"
+  [ticker]="stock?.ticker || ''"
+  (close)="closeAlertModal()"
+></app-create-alert-modal>
+

--- a/src/app/features/securities/components/stock-detail/stock-detail.component.ts
+++ b/src/app/features/securities/components/stock-detail/stock-detail.component.ts
@@ -15,6 +15,10 @@ import {
 import { StateComponent } from '../../../../shared/components/state/state.component';
 // PR_31 Phase 7 T23: ApexCharts zameni Canvas drawChart().
 import { PriceChartComponent, PriceSeriesPoint } from '../../../../shared/charts/price-chart/price-chart.component';
+// WP-22 (Celina 3): watchlist + price-alert action buttons in the header.
+import { LucideIconComponent } from '../../../../shared/icons/lucide-icon.component';
+import { WatchlistPickerComponent } from '../../../watchlist/components/watchlist-picker/watchlist-picker.component';
+import { CreateAlertModalComponent } from '../../../price-alerts/components/create-alert-modal/create-alert-modal.component';
 
 type Period = 'day' | 'week' | 'month' | 'year' | '5year' | 'all';
 
@@ -26,7 +30,15 @@ interface DetailRow {
 @Component({
   selector: 'app-stock-detail',
   standalone: true,
-  imports: [CommonModule, FormsModule, StateComponent, PriceChartComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    StateComponent,
+    PriceChartComponent,
+    LucideIconComponent,
+    WatchlistPickerComponent,
+    CreateAlertModalComponent,
+  ],
   templateUrl: './stock-detail.component.html',
   styleUrls: ['./stock-detail.component.scss'],
 })
@@ -43,6 +55,10 @@ export class StockDetailComponent implements OnInit, OnDestroy {
 
   /** PR_31 Phase 7 T23: ApexCharts serija (zameni Canvas drawChart). */
   priceSeries: PriceSeriesPoint[] = [];
+
+  /** WP-22 (Celina 3): header watchlist-picker / create-alert modal open flags. */
+  watchlistPickerOpen = false;
+  alertModalOpen = false;
 
   selectedPeriod: Period = 'month';
   periods: { value: Period; label: string }[] = [
@@ -300,6 +316,37 @@ export class StockDetailComponent implements OnInit, OnDestroy {
 
   goBack(): void {
     this.router.navigate(['/securities']);
+  }
+
+  /* ---- WP-22 (Celina 3): watchlist + price-alert header actions ---- */
+
+  /**
+   * Listing id of the displayed stock. Prefers the loaded `stock.id`, falling
+   * back to the `:ticker` route param (which actually carries the listing id).
+   * `null` when neither is available yet.
+   */
+  get listingId(): number | null {
+    if (this.stock?.id != null) {
+      return this.stock.id;
+    }
+    const parsed = Number(this.ticker);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+  }
+
+  openWatchlistPicker(): void {
+    this.watchlistPickerOpen = true;
+  }
+
+  closeWatchlistPicker(): void {
+    this.watchlistPickerOpen = false;
+  }
+
+  openAlertModal(): void {
+    this.alertModalOpen = true;
+  }
+
+  closeAlertModal(): void {
+    this.alertModalOpen = false;
   }
 
   trackByStrike(index: number, strike: number): number {

--- a/src/app/features/watchlist/components/watchlist-page/watchlist-page.component.html
+++ b/src/app/features/watchlist/components/watchlist-page/watchlist-page.component.html
@@ -1,0 +1,136 @@
+<!-- WP-22 (Celina 3): Watchlist management page. -->
+<div class="space-y-6">
+  <div class="flex items-center justify-between">
+    <h1 class="text-2xl font-bold text-foreground">Moje watchliste</h1>
+    <button type="button" class="z-btn-primary z-btn-sm flex items-center gap-1.5" (click)="openCreateModal()">
+      <lucide-icon name="star" [size]="14"></lucide-icon>
+      Nova watchlista
+    </button>
+  </div>
+
+  <app-state *ngIf="isLoading" mode="loading" text="Ucitavanje watchlista..."></app-state>
+  <app-state *ngIf="!isLoading && error" mode="error" [text]="error"></app-state>
+  <app-state
+    *ngIf="!isLoading && !error && watchlists.length === 0"
+    mode="empty"
+    icon="star"
+    title="Nema watchlista"
+    text="Kreirajte prvu watchlistu da pratite hartije od vrednosti."
+  ></app-state>
+
+  <div *ngIf="!isLoading && !error && watchlists.length > 0" class="grid grid-cols-1 lg:grid-cols-4 gap-6">
+    <!-- Watchlist sidebar -->
+    <aside class="z-card p-3 lg:col-span-1 space-y-1">
+      <button
+        *ngFor="let wl of watchlists; trackBy: trackByWatchlist"
+        type="button"
+        class="w-full flex items-center justify-between gap-2 px-3 py-2 rounded-md text-sm text-left cursor-pointer hover:bg-accent/40"
+        [class.bg-accent]="selectedWatchlist?.id === wl.id"
+        [class.font-semibold]="selectedWatchlist?.id === wl.id"
+        (click)="selectWatchlist(wl)"
+      >
+        <span class="truncate">{{ wl.name }}</span>
+        <span
+          class="z-btn-icon flex-shrink-0 text-destructive"
+          role="button"
+          aria-label="Obrisi watchlistu"
+          (click)="$event.stopPropagation(); deleteWatchlist(wl)"
+        >
+          <lucide-icon name="x" [size]="14"></lucide-icon>
+        </span>
+      </button>
+    </aside>
+
+    <!-- Selected watchlist items -->
+    <section class="lg:col-span-3 space-y-4">
+      <div class="z-card p-4 flex items-center justify-between gap-4">
+        <h2 class="text-lg font-semibold text-foreground truncate">
+          {{ selectedWatchlist?.name }}
+        </h2>
+        <div>
+          <label class="sr-only" for="wl-type">Tip hartije</label>
+          <select
+            id="wl-type"
+            class="z-select"
+            [(ngModel)]="typeFilter"
+            (ngModelChange)="onTypeFilterChange()"
+          >
+            <option *ngFor="let o of typeOptions" [value]="o.value">{{ o.label }}</option>
+          </select>
+        </div>
+      </div>
+
+      <app-state *ngIf="itemsLoading" mode="loading" text="Ucitavanje hartija..."></app-state>
+      <app-state *ngIf="!itemsLoading && itemsError" mode="error" [text]="itemsError"></app-state>
+      <app-state
+        *ngIf="!itemsLoading && !itemsError && items.length === 0"
+        mode="empty"
+        icon="star"
+        title="Watchlista je prazna"
+        text="Dodajte hartije sa portala hartija od vrednosti."
+      ></app-state>
+
+      <div *ngIf="!itemsLoading && !itemsError && items.length > 0" class="z-card">
+        <table class="z-table">
+          <thead>
+            <tr>
+              <th>TICKER</th>
+              <th>NAZIV</th>
+              <th>TIP</th>
+              <th class="text-right">CENA</th>
+              <th class="text-right">PROMENA (%)</th>
+              <th class="text-right">VOLUMEN</th>
+              <th>AKCIJA</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let it of items; trackBy: trackByItem">
+              <td class="font-semibold">
+                <a [routerLink]="detailLink(it)" class="text-primary hover:underline">{{ it.ticker }}</a>
+              </td>
+              <td>{{ it.name }}</td>
+              <td class="text-muted-foreground">{{ it.listingType }}</td>
+              <td class="text-right font-mono tabular-nums">{{ it.price | number: '1.2-2' }}</td>
+              <td class="text-right font-mono tabular-nums" [ngClass]="changeClass(it.change)">
+                {{ it.change > 0 ? '+' : '' }}{{ it.change | number: '1.2-2' }}%
+              </td>
+              <td class="text-right font-mono tabular-nums text-muted-foreground">
+                {{ it.volume | number }}
+              </td>
+              <td>
+                <button
+                  type="button"
+                  class="z-btn-outline z-btn-sm"
+                  (click)="removeItem(it)"
+                >
+                  Ukloni
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </div>
+</div>
+
+<!-- Create-watchlist modal -->
+<app-form-modal
+  *ngIf="createModalOpen"
+  title="Nova watchlista"
+  [submitting]="creating"
+  [errorMessage]="createError"
+  confirmLabel="Kreiraj"
+  (close)="closeCreateModal()"
+  (confirm)="createWatchlist()"
+>
+  <label class="z-label" for="wl-name">Naziv watchliste</label>
+  <input
+    id="wl-name"
+    type="text"
+    class="z-input"
+    [(ngModel)]="newName"
+    placeholder="npr. Tehnoloske akcije"
+    maxlength="60"
+  />
+</app-form-modal>

--- a/src/app/features/watchlist/components/watchlist-page/watchlist-page.component.spec.ts
+++ b/src/app/features/watchlist/components/watchlist-page/watchlist-page.component.spec.ts
@@ -1,0 +1,165 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of, throwError } from 'rxjs';
+
+import { WatchlistPageComponent } from './watchlist-page.component';
+import { WatchlistService } from '../../services/watchlist.service';
+import { ToastService } from '../../../../shared/services/toast.service';
+import { Watchlist, WatchlistItem } from '../../models/watchlist.model';
+
+function wl(id: number, name = `WL ${id}`): Watchlist {
+  return { id, name };
+}
+
+function item(id: number, overrides: Partial<WatchlistItem> = {}): WatchlistItem {
+  return {
+    id,
+    listingId: 100 + id,
+    ticker: `TKR${id}`,
+    name: `Security ${id}`,
+    price: 50,
+    change: 1.5,
+    volume: 1000,
+    listingType: 'STOCK',
+    ...overrides,
+  };
+}
+
+describe('WatchlistPageComponent', () => {
+  let fixture: ComponentFixture<WatchlistPageComponent>;
+  let component: WatchlistPageComponent;
+  let service: jasmine.SpyObj<WatchlistService>;
+  let toast: jasmine.SpyObj<ToastService>;
+
+  beforeEach(async () => {
+    service = jasmine.createSpyObj('WatchlistService', [
+      'getWatchlists',
+      'createWatchlist',
+      'deleteWatchlist',
+      'getItems',
+      'addItem',
+      'removeItem',
+    ]);
+    toast = jasmine.createSpyObj('ToastService', ['success', 'error']);
+
+    service.getWatchlists.and.returnValue(of([]));
+    service.getItems.and.returnValue(of([]));
+
+    await TestBed.configureTestingModule({
+      imports: [WatchlistPageComponent, RouterTestingModule],
+      providers: [
+        { provide: WatchlistService, useValue: service },
+        { provide: ToastService, useValue: toast },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WatchlistPageComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('creates', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('loads watchlists on init and auto-selects the first one', () => {
+    service.getWatchlists.and.returnValue(of([wl(1), wl(2)]));
+    service.getItems.and.returnValue(of([item(1)]));
+    fixture.detectChanges();
+
+    expect(component.watchlists.length).toBe(2);
+    expect(component.selectedWatchlist?.id).toBe(1);
+    expect(service.getItems).toHaveBeenCalledWith(1, undefined);
+    expect(component.items.length).toBe(1);
+  });
+
+  it('shows an error when watchlists fail to load', () => {
+    service.getWatchlists.and.returnValue(throwError(() => new Error('down')));
+    fixture.detectChanges();
+    expect(component.error).toBe('Greska pri ucitavanju watchlista.');
+  });
+
+  it('selectWatchlist loads that watchlist items', () => {
+    service.getWatchlists.and.returnValue(of([wl(1), wl(2)]));
+    service.getItems.and.returnValue(of([]));
+    fixture.detectChanges();
+
+    component.selectWatchlist(wl(2));
+    expect(component.selectedWatchlist?.id).toBe(2);
+    expect(service.getItems).toHaveBeenCalledWith(2, undefined);
+  });
+
+  it('onTypeFilterChange reloads items with the chosen listingType', () => {
+    service.getWatchlists.and.returnValue(of([wl(1)]));
+    service.getItems.and.returnValue(of([]));
+    fixture.detectChanges();
+
+    component.typeFilter = 'FOREX';
+    component.onTypeFilterChange();
+    expect(service.getItems).toHaveBeenCalledWith(1, 'FOREX');
+  });
+
+  it('createWatchlist rejects an empty name without calling the service', () => {
+    fixture.detectChanges();
+    component.newName = '   ';
+    component.createWatchlist();
+    expect(service.createWatchlist).not.toHaveBeenCalled();
+    expect(component.createError).toBe('Naziv je obavezan.');
+  });
+
+  it('createWatchlist posts a trimmed name and reloads on success', () => {
+    service.getWatchlists.and.returnValue(of([]));
+    service.createWatchlist.and.returnValue(of(wl(9, 'Tech')));
+    fixture.detectChanges();
+    service.getWatchlists.calls.reset();
+
+    component.newName = '  Tech  ';
+    component.createWatchlist();
+
+    expect(service.createWatchlist).toHaveBeenCalledWith('Tech');
+    expect(component.createModalOpen).toBeFalse();
+    expect(toast.success).toHaveBeenCalled();
+    expect(service.getWatchlists).toHaveBeenCalled();
+  });
+
+  it('createWatchlist surfaces an error and keeps the modal open', () => {
+    service.createWatchlist.and.returnValue(throwError(() => new Error('boom')));
+    fixture.detectChanges();
+
+    component.newName = 'X';
+    component.createWatchlist();
+    expect(component.createError).toBe('Greska pri kreiranju watchlista.');
+    expect(component.creating).toBeFalse();
+  });
+
+  it('removeItem removes from the selected watchlist and reloads items', () => {
+    service.getWatchlists.and.returnValue(of([wl(1)]));
+    service.getItems.and.returnValue(of([item(5)]));
+    service.removeItem.and.returnValue(of(void 0));
+    fixture.detectChanges();
+    service.getItems.calls.reset();
+
+    component.removeItem(item(5));
+    expect(service.removeItem).toHaveBeenCalledWith(1, 5);
+    expect(service.getItems).toHaveBeenCalled();
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it('detailLink maps listingType to the right securities route segment', () => {
+    expect(component.detailLink(item(1, { listingType: 'STOCK', listingId: 7 }))).toEqual([
+      '/securities',
+      'stock',
+      '7',
+    ]);
+    expect(component.detailLink(item(1, { listingType: 'FUTURE', listingId: 8 }))).toEqual([
+      '/securities',
+      'future',
+      '8',
+    ]);
+    expect(component.detailLink(item(1, { listingType: 'FOREX', listingId: 9 }))).toEqual([
+      '/securities',
+      'forex',
+      '9',
+    ]);
+  });
+});

--- a/src/app/features/watchlist/components/watchlist-page/watchlist-page.component.ts
+++ b/src/app/features/watchlist/components/watchlist-page/watchlist-page.component.ts
@@ -1,0 +1,236 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+
+import { StateComponent } from '../../../../shared/components/state/state.component';
+import { FormModalComponent } from '../../../../shared/components/form-modal/form-modal.component';
+import { LucideIconComponent } from '../../../../shared/icons/lucide-icon.component';
+import { ToastService } from '../../../../shared/services/toast.service';
+import { WatchlistService } from '../../services/watchlist.service';
+import { Watchlist, WatchlistItem } from '../../models/watchlist.model';
+
+/**
+ * WP-22 (Celina 3): Watchlist management page (`/watchlists`).
+ *
+ * <p>Lets a trader (clients with trading + actuary agents) manage their
+ * personalized watchlists: list every watchlist, create / delete named ones,
+ * view a selected watchlist's followed securities enriched with live market
+ * data (price / daily change / volume), remove an item, and filter the items
+ * by security type.
+ *
+ * <p>Standalone, lazy-loaded via `loadComponent` so it stays out of the
+ * initial bundle.
+ */
+
+interface SelectOption {
+  value: string;
+  label: string;
+}
+
+@Component({
+  selector: 'app-watchlist-page',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    RouterModule,
+    StateComponent,
+    FormModalComponent,
+    LucideIconComponent,
+  ],
+  templateUrl: './watchlist-page.component.html',
+})
+export class WatchlistPageComponent implements OnInit {
+  watchlists: Watchlist[] = [];
+  selectedWatchlist: Watchlist | null = null;
+
+  items: WatchlistItem[] = [];
+
+  /** Loading flag for the watchlist sidebar. */
+  isLoading = true;
+  /** Loading flag for the selected watchlist's items. */
+  itemsLoading = false;
+  error: string | null = null;
+  itemsError: string | null = null;
+
+  /* Create-watchlist modal. */
+  createModalOpen = false;
+  newName = '';
+  creating = false;
+  createError: string | null = null;
+
+  /** Item security-type filter; `''` means "all types". */
+  typeFilter = '';
+
+  readonly typeOptions: SelectOption[] = [
+    { value: '', label: 'Sve hartije' },
+    { value: 'STOCK', label: 'Akcije' },
+    { value: 'FUTURE', label: 'Fjucersi' },
+    { value: 'FOREX', label: 'Forex' },
+  ];
+
+  constructor(
+    private readonly watchlistService: WatchlistService,
+    private readonly toast: ToastService,
+  ) {}
+
+  ngOnInit(): void {
+    this.loadWatchlists();
+  }
+
+  loadWatchlists(): void {
+    this.isLoading = true;
+    this.error = null;
+    this.watchlistService.getWatchlists().subscribe({
+      next: (lists) => {
+        this.watchlists = lists ?? [];
+        this.isLoading = false;
+        /* Auto-select the first watchlist (or keep the current one if it
+           still exists after a reload). */
+        const stillThere = this.selectedWatchlist
+          ? this.watchlists.find((w) => w.id === this.selectedWatchlist!.id)
+          : undefined;
+        const next = stillThere ?? this.watchlists[0] ?? null;
+        if (next) {
+          this.selectWatchlist(next);
+        } else {
+          this.selectedWatchlist = null;
+          this.items = [];
+        }
+      },
+      error: () => {
+        this.isLoading = false;
+        this.error = 'Greska pri ucitavanju watchlista.';
+      },
+    });
+  }
+
+  selectWatchlist(wl: Watchlist): void {
+    this.selectedWatchlist = wl;
+    this.loadItems();
+  }
+
+  loadItems(): void {
+    if (!this.selectedWatchlist) {
+      this.items = [];
+      return;
+    }
+    this.itemsLoading = true;
+    this.itemsError = null;
+    this.watchlistService
+      .getItems(this.selectedWatchlist.id, this.typeFilter || undefined)
+      .subscribe({
+        next: (items) => {
+          this.items = items ?? [];
+          this.itemsLoading = false;
+        },
+        error: () => {
+          this.itemsLoading = false;
+          this.itemsError = 'Greska pri ucitavanju hartija.';
+        },
+      });
+  }
+
+  onTypeFilterChange(): void {
+    this.loadItems();
+  }
+
+  /* ---- create watchlist ---- */
+
+  openCreateModal(): void {
+    this.newName = '';
+    this.createError = null;
+    this.createModalOpen = true;
+  }
+
+  closeCreateModal(): void {
+    if (this.creating) {
+      return;
+    }
+    this.createModalOpen = false;
+  }
+
+  createWatchlist(): void {
+    const name = this.newName.trim();
+    if (!name) {
+      this.createError = 'Naziv je obavezan.';
+      return;
+    }
+    this.creating = true;
+    this.createError = null;
+    this.watchlistService.createWatchlist(name).subscribe({
+      next: (created) => {
+        this.creating = false;
+        this.createModalOpen = false;
+        this.toast.success('Watchlist kreiran.');
+        this.selectedWatchlist = created;
+        this.loadWatchlists();
+      },
+      error: () => {
+        this.creating = false;
+        this.createError = 'Greska pri kreiranju watchlista.';
+      },
+    });
+  }
+
+  /* ---- delete watchlist ---- */
+
+  deleteWatchlist(wl: Watchlist): void {
+    if (!confirm(`Obrisati watchlist "${wl.name}"?`)) {
+      return;
+    }
+    this.watchlistService.deleteWatchlist(wl.id).subscribe({
+      next: () => {
+        this.toast.success('Watchlist obrisan.');
+        if (this.selectedWatchlist?.id === wl.id) {
+          this.selectedWatchlist = null;
+        }
+        this.loadWatchlists();
+      },
+      error: () => this.toast.error('Greska pri brisanju watchlista.'),
+    });
+  }
+
+  /* ---- remove item ---- */
+
+  removeItem(it: WatchlistItem): void {
+    if (!this.selectedWatchlist) {
+      return;
+    }
+    this.watchlistService
+      .removeItem(this.selectedWatchlist.id, it.id)
+      .subscribe({
+        next: () => {
+          this.toast.success('Hartija uklonjena sa watchlista.');
+          this.loadItems();
+        },
+        error: () => this.toast.error('Greska pri uklanjanju hartije.'),
+      });
+  }
+
+  /** Routerlink target for a watchlist item's security-detail page. */
+  detailLink(it: WatchlistItem): string[] {
+    const segment =
+      it.listingType === 'FUTURE'
+        ? 'future'
+        : it.listingType === 'FOREX'
+          ? 'forex'
+          : 'stock';
+    return ['/securities', segment, String(it.listingId)];
+  }
+
+  changeClass(change: number): string {
+    if (change > 0) return 'text-green-600';
+    if (change < 0) return 'text-red-600';
+    return 'text-muted-foreground';
+  }
+
+  trackByWatchlist(_: number, wl: Watchlist): number {
+    return wl.id;
+  }
+
+  trackByItem(_: number, it: WatchlistItem): number {
+    return it.id;
+  }
+}

--- a/src/app/features/watchlist/components/watchlist-picker/watchlist-picker.component.spec.ts
+++ b/src/app/features/watchlist/components/watchlist-picker/watchlist-picker.component.spec.ts
@@ -1,0 +1,99 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+
+import { WatchlistPickerComponent } from './watchlist-picker.component';
+import { WatchlistService } from '../../services/watchlist.service';
+import { ToastService } from '../../../../shared/services/toast.service';
+import { Watchlist, WatchlistItem } from '../../models/watchlist.model';
+
+function wl(id: number, name = `WL ${id}`): Watchlist {
+  return { id, name };
+}
+
+function flushedItem(): WatchlistItem {
+  return {
+    id: 1,
+    listingId: 999,
+    ticker: 'X',
+    name: 'X',
+    price: 1,
+    change: 0,
+    volume: 0,
+    listingType: 'STOCK',
+  };
+}
+
+describe('WatchlistPickerComponent', () => {
+  let fixture: ComponentFixture<WatchlistPickerComponent>;
+  let component: WatchlistPickerComponent;
+  let service: jasmine.SpyObj<WatchlistService>;
+  let toast: jasmine.SpyObj<ToastService>;
+
+  beforeEach(async () => {
+    service = jasmine.createSpyObj('WatchlistService', ['getWatchlists', 'addItem']);
+    toast = jasmine.createSpyObj('ToastService', ['success', 'error', 'warning']);
+    service.getWatchlists.and.returnValue(of([]));
+
+    await TestBed.configureTestingModule({
+      imports: [WatchlistPickerComponent],
+      providers: [
+        { provide: WatchlistService, useValue: service },
+        { provide: ToastService, useValue: toast },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WatchlistPickerComponent);
+    component = fixture.componentInstance;
+    component.listingId = 999;
+  });
+
+  it('creates and loads watchlists on init', () => {
+    service.getWatchlists.and.returnValue(of([wl(1), wl(2)]));
+    fixture.detectChanges();
+    expect(component.watchlists.length).toBe(2);
+    expect(component.loading).toBeFalse();
+  });
+
+  it('shows an error when watchlists fail to load', () => {
+    service.getWatchlists.and.returnValue(throwError(() => new Error('down')));
+    fixture.detectChanges();
+    expect(component.loadError).toBe('Greska pri ucitavanju watchlista.');
+  });
+
+  it('pick adds the listing to the chosen watchlist and closes', () => {
+    service.getWatchlists.and.returnValue(of([wl(3)]));
+    service.addItem.and.returnValue(of(flushedItem()));
+    fixture.detectChanges();
+
+    const closeSpy = jasmine.createSpy('close');
+    const addedSpy = jasmine.createSpy('added');
+    component.close.subscribe(closeSpy);
+    component.added.subscribe(addedSpy);
+
+    component.pick(wl(3));
+
+    expect(service.addItem).toHaveBeenCalledWith(3, 999);
+    expect(toast.success).toHaveBeenCalled();
+    expect(addedSpy).toHaveBeenCalled();
+    expect(closeSpy).toHaveBeenCalled();
+  });
+
+  it('pick surfaces a warning toast on a 409 duplicate', () => {
+    service.getWatchlists.and.returnValue(of([wl(3)]));
+    service.addItem.and.returnValue(throwError(() => ({ status: 409 })));
+    fixture.detectChanges();
+
+    component.pick(wl(3));
+    expect(toast.warning).toHaveBeenCalled();
+    expect(component.adding).toBeFalse();
+  });
+
+  it('pick surfaces an error toast on a 404 missing listing', () => {
+    service.getWatchlists.and.returnValue(of([wl(3)]));
+    service.addItem.and.returnValue(throwError(() => ({ status: 404 })));
+    fixture.detectChanges();
+
+    component.pick(wl(3));
+    expect(toast.error).toHaveBeenCalled();
+  });
+});

--- a/src/app/features/watchlist/components/watchlist-picker/watchlist-picker.component.ts
+++ b/src/app/features/watchlist/components/watchlist-picker/watchlist-picker.component.ts
@@ -1,0 +1,122 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+
+import { FormModalComponent } from '../../../../shared/components/form-modal/form-modal.component';
+import { StateComponent } from '../../../../shared/components/state/state.component';
+import { ToastService } from '../../../../shared/services/toast.service';
+import { WatchlistService } from '../../services/watchlist.service';
+import { Watchlist } from '../../models/watchlist.model';
+
+/**
+ * WP-22 (Celina 3): Watchlist picker modal.
+ *
+ * <p>A small reusable overlay opened by the "Dodaj na watchlist" button on the
+ * securities portal (list rows + detail headers). It lists the caller's
+ * watchlists; clicking one adds the given `listingId` to it via
+ * {@link WatchlistService.addItem}. The backend `404` (missing listing) and
+ * `409` (already on the watchlist) responses are surfaced as toasts.
+ *
+ * <p>Standalone — drop `<app-watchlist-picker>` into any standalone component
+ * that already knows the listing id it wants to add.
+ */
+@Component({
+  selector: 'app-watchlist-picker',
+  standalone: true,
+  imports: [CommonModule, FormModalComponent, StateComponent],
+  template: `
+    <app-form-modal
+      title="Dodaj na watchlist"
+      [submitting]="adding"
+      [hasCustomFooter]="true"
+      (close)="close.emit()"
+    >
+      <app-state *ngIf="loading" mode="loading" text="Ucitavanje watchlista..."></app-state>
+      <app-state *ngIf="!loading && loadError" mode="error" [text]="loadError"></app-state>
+      <app-state
+        *ngIf="!loading && !loadError && watchlists.length === 0"
+        mode="empty"
+        icon="star"
+        title="Nema watchlista"
+        text="Kreirajte watchlistu na stranici Watchlist."
+      ></app-state>
+
+      <ul
+        *ngIf="!loading && !loadError && watchlists.length > 0"
+        class="space-y-1"
+        data-testid="watchlist-picker-list"
+      >
+        <li *ngFor="let wl of watchlists">
+          <button
+            type="button"
+            class="w-full text-left px-3 py-2 rounded-md text-sm cursor-pointer hover:bg-accent/40 disabled:opacity-50"
+            [disabled]="adding"
+            (click)="pick(wl)"
+          >
+            {{ wl.name }}
+          </button>
+        </li>
+      </ul>
+
+      <button slot="footer" type="button" class="z-btn-outline" (click)="close.emit()">
+        Zatvori
+      </button>
+    </app-form-modal>
+  `,
+})
+export class WatchlistPickerComponent implements OnInit {
+  /** Listing id of the security to add. */
+  @Input({ required: true }) listingId!: number;
+
+  /** Emitted when the modal should close (cancel or after a successful add). */
+  @Output() close = new EventEmitter<void>();
+  /** Emitted after a security is successfully added to a watchlist. */
+  @Output() added = new EventEmitter<Watchlist>();
+
+  watchlists: Watchlist[] = [];
+  loading = true;
+  loadError: string | null = null;
+  adding = false;
+
+  constructor(
+    private readonly watchlistService: WatchlistService,
+    private readonly toast: ToastService,
+  ) {}
+
+  ngOnInit(): void {
+    this.watchlistService.getWatchlists().subscribe({
+      next: (lists) => {
+        this.watchlists = lists ?? [];
+        this.loading = false;
+      },
+      error: () => {
+        this.loading = false;
+        this.loadError = 'Greska pri ucitavanju watchlista.';
+      },
+    });
+  }
+
+  pick(wl: Watchlist): void {
+    if (this.adding) {
+      return;
+    }
+    this.adding = true;
+    this.watchlistService.addItem(wl.id, this.listingId).subscribe({
+      next: () => {
+        this.adding = false;
+        this.toast.success(`Hartija dodata na "${wl.name}".`);
+        this.added.emit(wl);
+        this.close.emit();
+      },
+      error: (err: { status?: number }) => {
+        this.adding = false;
+        if (err?.status === 409) {
+          this.toast.warning('Hartija je vec na toj watchlisti.');
+        } else if (err?.status === 404) {
+          this.toast.error('Hartija nije pronadjena.');
+        } else {
+          this.toast.error('Greska pri dodavanju na watchlist.');
+        }
+      },
+    });
+  }
+}

--- a/src/app/features/watchlist/components/watchlist-widget/watchlist-widget.component.html
+++ b/src/app/features/watchlist/components/watchlist-widget/watchlist-widget.component.html
@@ -1,0 +1,53 @@
+<!-- WP-22 (Celina 3): topbar watchlist quick-access dropdown body. -->
+<div class="flex items-center justify-between px-3 py-2 border-b border-border">
+  <span class="text-sm font-semibold text-foreground">
+    {{ watchlist?.name || 'Watchlist' }}
+  </span>
+  <a
+    routerLink="/watchlists"
+    (click)="navigate.emit()"
+    class="text-xs text-primary hover:underline"
+  >
+    Sve watchliste
+  </a>
+</div>
+
+<div *ngIf="loading" class="px-3 py-6 text-center text-sm text-muted-foreground">
+  Ucitavanje...
+</div>
+<div *ngIf="!loading && error" class="px-3 py-6 text-center text-sm text-destructive">
+  Greska pri ucitavanju watchliste.
+</div>
+<div
+  *ngIf="!loading && !error && items.length === 0"
+  class="px-3 py-6 text-center text-sm text-muted-foreground"
+>
+  Watchlista je prazna.
+</div>
+
+<ul
+  *ngIf="!loading && !error && items.length > 0"
+  class="max-h-80 overflow-y-auto divide-y divide-border"
+>
+  <li *ngFor="let it of items; trackBy: trackByItem">
+    <a
+      [routerLink]="detailLink(it)"
+      (click)="navigate.emit()"
+      class="flex items-center justify-between gap-2 px-3 py-2 cursor-pointer hover:bg-accent/40"
+    >
+      <span class="min-w-0">
+        <span class="block text-sm font-semibold truncate">{{ it.ticker }}</span>
+        <span class="block text-xs text-muted-foreground truncate">{{ it.name }}</span>
+      </span>
+      <span class="text-right flex-shrink-0">
+        <span class="block text-sm font-mono tabular-nums">{{ it.price | number: '1.2-2' }}</span>
+        <span class="block text-xs font-mono tabular-nums" [ngClass]="changeClass(it.change)">
+          {{ it.change > 0 ? '+' : '' }}{{ it.change | number: '1.2-2' }}%
+        </span>
+        <span class="block text-[10px] text-muted-foreground/70">
+          Vol {{ it.volume | number }}
+        </span>
+      </span>
+    </a>
+  </li>
+</ul>

--- a/src/app/features/watchlist/components/watchlist-widget/watchlist-widget.component.spec.ts
+++ b/src/app/features/watchlist/components/watchlist-widget/watchlist-widget.component.spec.ts
@@ -1,0 +1,111 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of, throwError } from 'rxjs';
+
+import { WatchlistWidgetComponent } from './watchlist-widget.component';
+import { WatchlistService } from '../../services/watchlist.service';
+import { Watchlist, WatchlistItem } from '../../models/watchlist.model';
+
+function wl(id: number, name = `WL ${id}`): Watchlist {
+  return { id, name };
+}
+
+function item(id: number, overrides: Partial<WatchlistItem> = {}): WatchlistItem {
+  return {
+    id,
+    listingId: 100 + id,
+    ticker: `TKR${id}`,
+    name: `Security ${id}`,
+    price: 50,
+    change: 1.5,
+    volume: 1000,
+    listingType: 'STOCK',
+    ...overrides,
+  };
+}
+
+describe('WatchlistWidgetComponent', () => {
+  let fixture: ComponentFixture<WatchlistWidgetComponent>;
+  let component: WatchlistWidgetComponent;
+  let service: jasmine.SpyObj<WatchlistService>;
+
+  beforeEach(async () => {
+    service = jasmine.createSpyObj('WatchlistService', ['getWatchlists', 'getItems']);
+    service.getWatchlists.and.returnValue(of([]));
+    service.getItems.and.returnValue(of([]));
+
+    await TestBed.configureTestingModule({
+      imports: [WatchlistWidgetComponent, RouterTestingModule],
+      providers: [{ provide: WatchlistService, useValue: service }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WatchlistWidgetComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('does not fetch while closed', () => {
+    component.open = false;
+    fixture.detectChanges();
+    expect(service.getWatchlists).not.toHaveBeenCalled();
+  });
+
+  it('fetches the first watchlist and its items when opened', () => {
+    service.getWatchlists.and.returnValue(of([wl(1), wl(2)]));
+    service.getItems.and.returnValue(of([item(1), item(2)]));
+
+    component.open = true;
+    component.ngOnChanges();
+
+    expect(service.getWatchlists).toHaveBeenCalled();
+    expect(service.getItems).toHaveBeenCalledWith(1);
+    expect(component.items.length).toBe(2);
+    expect(component.watchlist?.id).toBe(1);
+    expect(component.loading).toBeFalse();
+  });
+
+  it('does not refetch on a second open', () => {
+    service.getWatchlists.and.returnValue(of([wl(1)]));
+    service.getItems.and.returnValue(of([]));
+
+    component.open = true;
+    component.ngOnChanges();
+    service.getWatchlists.calls.reset();
+
+    component.ngOnChanges();
+    expect(service.getWatchlists).not.toHaveBeenCalled();
+  });
+
+  it('handles having no watchlists gracefully', () => {
+    service.getWatchlists.and.returnValue(of([]));
+    component.open = true;
+    component.ngOnChanges();
+
+    expect(component.watchlist).toBeNull();
+    expect(component.items).toEqual([]);
+    expect(component.loading).toBeFalse();
+    expect(service.getItems).not.toHaveBeenCalled();
+  });
+
+  it('sets the error flag when the watchlist fetch fails', () => {
+    service.getWatchlists.and.returnValue(throwError(() => new Error('down')));
+    component.open = true;
+    component.ngOnChanges();
+    expect(component.error).toBeTrue();
+  });
+
+  it('sets the error flag when the item fetch fails', () => {
+    service.getWatchlists.and.returnValue(of([wl(1)]));
+    service.getItems.and.returnValue(throwError(() => new Error('down')));
+    component.open = true;
+    component.ngOnChanges();
+    expect(component.error).toBeTrue();
+  });
+
+  it('detailLink maps listingType to the right route segment', () => {
+    expect(component.detailLink(item(1, { listingType: 'FOREX', listingId: 5 }))).toEqual([
+      '/securities',
+      'forex',
+      '5',
+    ]);
+  });
+});

--- a/src/app/features/watchlist/components/watchlist-widget/watchlist-widget.component.ts
+++ b/src/app/features/watchlist/components/watchlist-widget/watchlist-widget.component.ts
@@ -1,0 +1,99 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+import { WatchlistService } from '../../services/watchlist.service';
+import { Watchlist, WatchlistItem } from '../../models/watchlist.model';
+
+/**
+ * WP-22 (Celina 3): Topbar watchlist quick-access widget panel.
+ *
+ * <p>The dropdown body for the topbar's "star" button. When `open` flips true
+ * it fetches the caller's first watchlist and that watchlist's enriched items
+ * (ticker, current price, daily change, volume). Each row links to the
+ * security-detail page.
+ *
+ * <p>Standalone — the topbar renders `<app-watchlist-widget>` inside its own
+ * `relative` dropdown shell, reusing the existing theme/avatar/notification
+ * open/close pattern.
+ */
+@Component({
+  selector: 'app-watchlist-widget',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './watchlist-widget.component.html',
+})
+export class WatchlistWidgetComponent implements OnChanges {
+  /** Driven by the topbar; the panel lazily fetches when it becomes true. */
+  @Input() open = false;
+
+  /** Emitted when a row link is clicked so the topbar can close the dropdown. */
+  @Output() navigate = new EventEmitter<void>();
+
+  items: WatchlistItem[] = [];
+  watchlist: Watchlist | null = null;
+  loading = false;
+  error = false;
+  /** True once a fetch has run, so we do not refetch on every open. */
+  private loadedOnce = false;
+
+  constructor(private readonly watchlistService: WatchlistService) {}
+
+  ngOnChanges(): void {
+    if (this.open && !this.loadedOnce) {
+      this.load();
+    }
+  }
+
+  /** Fetches the first watchlist and its enriched items. */
+  load(): void {
+    this.loading = true;
+    this.error = false;
+    this.loadedOnce = true;
+    this.watchlistService.getWatchlists().subscribe({
+      next: (lists) => {
+        this.watchlist = lists?.[0] ?? null;
+        if (!this.watchlist) {
+          this.items = [];
+          this.loading = false;
+          return;
+        }
+        this.watchlistService.getItems(this.watchlist.id).subscribe({
+          next: (items) => {
+            this.items = items ?? [];
+            this.loading = false;
+          },
+          error: () => {
+            this.loading = false;
+            this.error = true;
+          },
+        });
+      },
+      error: () => {
+        this.loading = false;
+        this.error = true;
+      },
+    });
+  }
+
+  /** Routerlink target for a watchlist item's security-detail page. */
+  detailLink(it: WatchlistItem): string[] {
+    const segment =
+      it.listingType === 'FUTURE'
+        ? 'future'
+        : it.listingType === 'FOREX'
+          ? 'forex'
+          : 'stock';
+    return ['/securities', segment, String(it.listingId)];
+  }
+
+  changeClass(change: number): string {
+    if (change > 0) return 'text-green-600';
+    if (change < 0) return 'text-red-600';
+    return 'text-muted-foreground';
+  }
+
+  trackByItem(_: number, it: WatchlistItem): number {
+    return it.id;
+  }
+}

--- a/src/app/features/watchlist/models/watchlist.model.ts
+++ b/src/app/features/watchlist/models/watchlist.model.ts
@@ -1,0 +1,43 @@
+/**
+ * WP-22 (Celina 3): Watchlist — followed-securities model.
+ *
+ * Mirrors the DTOs returned by the JWT-secured watchlist endpoints exposed
+ * through the gateway at `/watchlists`. The {@link AuthInterceptor} attaches
+ * the token; every watchlist is scoped to the authenticated caller.
+ */
+
+/** A named watchlist owned by the caller. */
+export interface Watchlist {
+  id: number;
+  name: string;
+}
+
+/**
+ * One security inside a watchlist, enriched with live market data so the
+ * management page and the topbar quick-access widget can render price /
+ * daily-change / volume without a second round-trip.
+ */
+export interface WatchlistItem {
+  /** Watchlist-item row id (used for removal). */
+  id: number;
+  /** Underlying listing id (the security primary key). */
+  listingId: number;
+  ticker: string;
+  name: string;
+  price: number;
+  /** Daily change as a percentage (signed). */
+  change: number;
+  volume: number;
+  /** Security category — `STOCK` / `FUTURE` / `FOREX` (free-form). */
+  listingType: string;
+}
+
+/** Request body for `POST /watchlists`. */
+export interface CreateWatchlistRequest {
+  name: string;
+}
+
+/** Request body for `POST /watchlists/{id}/items`. */
+export interface AddWatchlistItemRequest {
+  listingId: number;
+}

--- a/src/app/features/watchlist/services/watchlist.service.spec.ts
+++ b/src/app/features/watchlist/services/watchlist.service.spec.ts
@@ -1,0 +1,113 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+
+import { environment } from '../../../../environments/environment';
+import { WatchlistService } from './watchlist.service';
+import { Watchlist, WatchlistItem } from '../models/watchlist.model';
+
+const baseUrl = `${environment.apiUrl}/watchlists`;
+
+function wl(id: number, name = `WL ${id}`): Watchlist {
+  return { id, name };
+}
+
+function item(id: number, overrides: Partial<WatchlistItem> = {}): WatchlistItem {
+  return {
+    id,
+    listingId: 100 + id,
+    ticker: `TKR${id}`,
+    name: `Security ${id}`,
+    price: 50,
+    change: 1.5,
+    volume: 1000,
+    listingType: 'STOCK',
+    ...overrides,
+  };
+}
+
+describe('WatchlistService', () => {
+  let service: WatchlistService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [WatchlistService],
+    });
+    service = TestBed.inject(WatchlistService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('getWatchlists GETs /watchlists', () => {
+    let result: Watchlist[] | undefined;
+    service.getWatchlists().subscribe((w) => (result = w));
+
+    const req = httpMock.expectOne(baseUrl);
+    expect(req.request.method).toBe('GET');
+    const body = [wl(1), wl(2)];
+    req.flush(body);
+    expect(result).toEqual(body);
+  });
+
+  it('createWatchlist POSTs the name', () => {
+    let result: Watchlist | undefined;
+    service.createWatchlist('Tech').subscribe((w) => (result = w));
+
+    const req = httpMock.expectOne(baseUrl);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ name: 'Tech' });
+    req.flush(wl(9, 'Tech'));
+    expect(result).toEqual(wl(9, 'Tech'));
+  });
+
+  it('deleteWatchlist DELETEs /watchlists/{id}', () => {
+    service.deleteWatchlist(7).subscribe();
+    const req = httpMock.expectOne(`${baseUrl}/7`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush(null);
+  });
+
+  it('getItems GETs /watchlists/{id}/items with no filter by default', () => {
+    let result: WatchlistItem[] | undefined;
+    service.getItems(3).subscribe((i) => (result = i));
+
+    const req = httpMock.expectOne(
+      (r) => r.url === `${baseUrl}/3/items` && r.method === 'GET',
+    );
+    expect(req.request.params.has('listingType')).toBeFalse();
+    const body = [item(1), item(2)];
+    req.flush(body);
+    expect(result).toEqual(body);
+  });
+
+  it('getItems forwards the listingType filter when given', () => {
+    service.getItems(3, 'FOREX').subscribe();
+    const req = httpMock.expectOne(
+      (r) => r.url === `${baseUrl}/3/items`,
+    );
+    expect(req.request.params.get('listingType')).toBe('FOREX');
+    req.flush([]);
+  });
+
+  it('addItem POSTs the listingId to /watchlists/{id}/items', () => {
+    service.addItem(3, 555).subscribe();
+    const req = httpMock.expectOne(`${baseUrl}/3/items`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ listingId: 555 });
+    req.flush(item(1));
+  });
+
+  it('removeItem DELETEs /watchlists/{id}/items/{itemId}', () => {
+    service.removeItem(3, 88).subscribe();
+    const req = httpMock.expectOne(`${baseUrl}/3/items/88`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush(null);
+  });
+});

--- a/src/app/features/watchlist/services/watchlist.service.ts
+++ b/src/app/features/watchlist/services/watchlist.service.ts
@@ -1,0 +1,82 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { environment } from '../../../../environments/environment';
+import {
+  AddWatchlistItemRequest,
+  CreateWatchlistRequest,
+  Watchlist,
+  WatchlistItem,
+} from '../models/watchlist.model';
+
+/**
+ * WP-22 (Celina 3): Watchlist client.
+ *
+ * <p>Wraps the JWT-secured watchlist endpoints exposed through the gateway at
+ * `/watchlists`. The {@link AuthInterceptor} attaches the `Authorization`
+ * header automatically. Every watchlist is scoped to the authenticated caller
+ * (clients with trading + actuary agents).
+ *
+ * <p>Item reads come back enriched with live market data (`price`, `change`,
+ * `volume`) so the management page and the topbar quick-access widget render
+ * without a second round-trip.
+ */
+@Injectable({ providedIn: 'root' })
+export class WatchlistService {
+  private readonly baseUrl = `${environment.apiUrl}/watchlists`;
+
+  constructor(private readonly http: HttpClient) {}
+
+  /** Lists every watchlist owned by the caller. */
+  getWatchlists(): Observable<Watchlist[]> {
+    return this.http.get<Watchlist[]>(this.baseUrl);
+  }
+
+  /** Creates a new named watchlist. */
+  createWatchlist(name: string): Observable<Watchlist> {
+    const body: CreateWatchlistRequest = { name };
+    return this.http.post<Watchlist>(this.baseUrl, body);
+  }
+
+  /** Deletes a watchlist by id. */
+  deleteWatchlist(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/${id}`);
+  }
+
+  /**
+   * Fetches the enriched items of one watchlist.
+   * @param listingType optional security-category filter, e.g. `STOCK`.
+   */
+  getItems(watchlistId: number, listingType?: string): Observable<WatchlistItem[]> {
+    let params = new HttpParams();
+    if (listingType) {
+      params = params.set('listingType', listingType);
+    }
+    return this.http.get<WatchlistItem[]>(
+      `${this.baseUrl}/${watchlistId}/items`,
+      { params },
+    );
+  }
+
+  /**
+   * Adds a security (by listing id) to a watchlist.
+   *
+   * <p>The backend answers `404` if the listing does not exist and `409` if
+   * the security is already on that watchlist — callers should surface those.
+   */
+  addItem(watchlistId: number, listingId: number): Observable<WatchlistItem> {
+    const body: AddWatchlistItemRequest = { listingId };
+    return this.http.post<WatchlistItem>(
+      `${this.baseUrl}/${watchlistId}/items`,
+      body,
+    );
+  }
+
+  /** Removes a watchlist item by its row id. */
+  removeItem(watchlistId: number, itemId: number): Observable<void> {
+    return this.http.delete<void>(
+      `${this.baseUrl}/${watchlistId}/items/${itemId}`,
+    );
+  }
+}

--- a/src/app/shared/charts/fund-history-chart/fund-history-chart.component.html
+++ b/src/app/shared/charts/fund-history-chart/fund-history-chart.component.html
@@ -1,0 +1,16 @@
+<apx-chart
+  *ngIf="options.chart"
+  [series]="apexSeries"
+  [chart]="options.chart!"
+  [theme]="options.theme!"
+  [colors]="options.colors!"
+  [grid]="options.grid!"
+  [stroke]="options.stroke!"
+  [fill]="options.fill!"
+  [tooltip]="options.tooltip!"
+  [markers]="options.markers!"
+  [xaxis]="options.xaxis!"
+  [yaxis]="options.yaxis!"
+  [dataLabels]="options.dataLabels!"
+  [legend]="options.legend!">
+</apx-chart>

--- a/src/app/shared/charts/fund-history-chart/fund-history-chart.component.spec.ts
+++ b/src/app/shared/charts/fund-history-chart/fund-history-chart.component.spec.ts
@@ -1,0 +1,83 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SimpleChange } from '@angular/core';
+
+import { FundHistoryChartComponent, FundSeriesPoint } from './fund-history-chart.component';
+import { ThemeService } from '../../../core/services/theme.service';
+
+describe('FundHistoryChartComponent', () => {
+  let component: FundHistoryChartComponent;
+  let fixture: ComponentFixture<FundHistoryChartComponent>;
+
+  const fundSeries: FundSeriesPoint[] = [
+    { x: '2026-01-01', y: 100 },
+    { x: '2026-02-01', y: 120 },
+  ];
+  const avgSeries: FundSeriesPoint[] = [
+    { x: '2026-01-01', y: 90 },
+    { x: '2026-02-01', y: 95 },
+  ];
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [FundHistoryChartComponent],
+      providers: [ThemeService],
+    });
+    fixture = TestBed.createComponent(FundHistoryChartComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should build a single series when no average series is given', () => {
+    component.fundSeries = fundSeries;
+    component.averageSeries = null;
+    component.ngOnInit();
+
+    expect(component.apexSeries.length).toBe(1);
+    expect(component.apexSeries[0].name).toBe('Fond');
+    expect(component.apexSeries[0].data).toEqual(fundSeries as any);
+  });
+
+  it('should add the average series when one is provided', () => {
+    component.fundSeries = fundSeries;
+    component.averageSeries = avgSeries;
+    component.fundLabel = 'Moj fond';
+    component.averageLabel = 'Prosek';
+    component.ngOnInit();
+
+    expect(component.apexSeries.length).toBe(2);
+    expect(component.apexSeries[0].name).toBe('Moj fond');
+    expect(component.apexSeries[1].name).toBe('Prosek');
+  });
+
+  it('should not add an empty average series', () => {
+    component.fundSeries = fundSeries;
+    component.averageSeries = [];
+    component.ngOnInit();
+
+    expect(component.apexSeries.length).toBe(1);
+  });
+
+  it('should build line-type options with a visible legend', () => {
+    component.fundSeries = fundSeries;
+    component.ngOnInit();
+
+    expect(component.options.chart?.type).toBe('line');
+    expect(component.options.legend?.show).toBeTrue();
+  });
+
+  it('should rebuild series on input changes', () => {
+    component.fundSeries = fundSeries;
+    component.ngOnInit();
+    expect(component.apexSeries.length).toBe(1);
+
+    component.averageSeries = avgSeries;
+    component.ngOnChanges({
+      averageSeries: new SimpleChange(null, avgSeries, false),
+    });
+
+    expect(component.apexSeries.length).toBe(2);
+  });
+});

--- a/src/app/shared/charts/fund-history-chart/fund-history-chart.component.ts
+++ b/src/app/shared/charts/fund-history-chart/fund-history-chart.component.ts
@@ -1,0 +1,86 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { ApexAxisChartSeries, ApexOptions, NgApexchartsModule } from 'ng-apexcharts';
+import { Subscription } from 'rxjs';
+
+import { ThemeService } from '../../../core/services/theme.service';
+import { buildPriceChartTheme, EffectiveTheme } from '../apex-theme';
+
+export interface FundSeriesPoint { x: number | string | Date; y: number; }
+
+/**
+ * WP-26 (Celina 4 — statistika fondova): linijski chart koji prikazuje
+ * istoriju vrednosti fonda i (opciono) sistemski prosek na istom grafiku.
+ *
+ * <p>`PriceChartComponent` podrzava samo jednu seriju. Umesto da ga
+ * proboravimo invazivno, ovo je sibling komponenta koja reuse-uje isti
+ * `buildPriceChartTheme()` builder (light/dark aware), ali render-uje 1-2
+ * serije kao `type: 'line'` (bez gradient fill-a, da se dve linije ne
+ * preklapaju vizuelno).
+ */
+@Component({
+  selector: 'app-fund-history-chart',
+  standalone: true,
+  imports: [CommonModule, NgApexchartsModule],
+  templateUrl: './fund-history-chart.component.html',
+})
+export class FundHistoryChartComponent implements OnInit, OnChanges, OnDestroy {
+  /** Primarna serija — istorija vrednosti samog fonda. */
+  @Input() fundSeries: FundSeriesPoint[] = [];
+  /** Opciona serija — sistemski prosek svih fondova (comparison). */
+  @Input() averageSeries: FundSeriesPoint[] | null = null;
+  @Input() fundLabel = 'Fond';
+  @Input() averageLabel = 'Prosek svih fondova';
+  @Input() height = 320;
+
+  options: Partial<ApexOptions> = {};
+  apexSeries: ApexAxisChartSeries = [];
+  private sub?: Subscription;
+  private currentEffective: EffectiveTheme = 'light';
+
+  constructor(private theme: ThemeService) {}
+
+  ngOnInit(): void {
+    this.refreshSeries();
+    this.sub = this.theme.effective$.subscribe((eff) => {
+      this.currentEffective = eff;
+      this.options = this.buildOptions(eff);
+    });
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['fundSeries'] || changes['averageSeries'] || changes['fundLabel'] || changes['averageLabel']) {
+      this.refreshSeries();
+    }
+    if (changes['height']) {
+      this.options = this.buildOptions(this.currentEffective);
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.sub?.unsubscribe();
+  }
+
+  private refreshSeries(): void {
+    const series: ApexAxisChartSeries = [
+      { name: this.fundLabel, data: this.fundSeries as any },
+    ];
+    if (this.averageSeries && this.averageSeries.length > 0) {
+      series.push({ name: this.averageLabel, data: this.averageSeries as any });
+    }
+    this.apexSeries = series;
+  }
+
+  private buildOptions(eff: EffectiveTheme): Partial<ApexOptions> {
+    const base = buildPriceChartTheme(eff);
+    return {
+      ...base,
+      chart: { ...(base.chart || {}), type: 'line', height: this.height },
+      // Line mode: bez gradient fill-a — dve linije bi se vizuelno preklapale.
+      fill: { type: 'solid', opacity: 1 },
+      stroke: { curve: 'smooth', width: 2.5 },
+      // Comparison chart treba legendu da razlikuje fond od proseka.
+      legend: { show: true, position: 'top', horizontalAlign: 'right' },
+    };
+  }
+}

--- a/src/app/shared/components/state/state.component.ts
+++ b/src/app/shared/components/state/state.component.ts
@@ -29,7 +29,7 @@ const LUCIDE_NAMES = new Set([
   'home', 'wallet', 'send', 'creditcard', 'piggybank', 'trendingup', 'briefcase',
   'handshake', 'building', 'users', 'shieldcheck', 'receipt', 'gauge',
   'search', 'menu', 'x', 'sun', 'moon', 'monitor', 'bell', 'chevrondown',
-  'inbox', 'alerttriangle',
+  'inbox', 'alerttriangle', 'star', 'repeat',
 ]);
 
 @Component({

--- a/src/app/shared/icons/lucide-icon.component.ts
+++ b/src/app/shared/icons/lucide-icon.component.ts
@@ -33,6 +33,10 @@ const ICONS: Record<string, string> = {
   moon:        '<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>',
   monitor:     '<rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/>',
   bell:        '<path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/>',
+  /* WP-22 (Celina 3): watchlist "follow" affordance. */
+  star:        '<polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>',
+  /* WP-23 (Celina 3): "Trajni nalozi" — recurring (DCA) standing orders. */
+  repeat:      '<polyline points="17 1 21 5 17 9"/><path d="M3 11V9a4 4 0 0 1 4-4h14"/><polyline points="7 23 3 19 7 15"/><path d="M21 13v2a4 4 0 0 1-4 4H3"/>',
   chevrondown: '<polyline points="6 9 12 15 18 9"/>',
   /* Empty / error state default ikone za StateComponent (zamenjuju emoji
    * sentineli). Caller-i jos uvek mogu da prosledjuju emoji string preko

--- a/src/app/shared/utils/validators.spec.ts
+++ b/src/app/shared/utils/validators.spec.ts
@@ -1,0 +1,127 @@
+import { AbstractControl } from '@angular/forms';
+import {
+  emailFormatValidator,
+  exactDigitsValidator,
+  notFutureDateValidator,
+  phoneNumberValidator,
+} from './validators';
+
+/** Pravi minimalni AbstractControl stub sa zadatom vrednoscu. */
+function ctrl(value: unknown): AbstractControl {
+  return { value } as AbstractControl;
+}
+
+describe('validators', () => {
+  describe('exactDigitsValidator', () => {
+    it('prihvata tacan broj cifara', () => {
+      expect(exactDigitsValidator(4)(ctrl('1234'))).toBeNull();
+    });
+
+    it('odbija pogresan broj cifara', () => {
+      expect(exactDigitsValidator(4)(ctrl('123'))).toEqual({
+        exactDigits: { requiredLength: 4, actualLength: 3 },
+      });
+    });
+
+    it('odbija ne-cifarski sadrzaj', () => {
+      expect(exactDigitsValidator(4)(ctrl('12a4'))).toEqual({ notDigitsOnly: true });
+    });
+
+    it('prazna vrednost je validna', () => {
+      expect(exactDigitsValidator(4)(ctrl(''))).toBeNull();
+      expect(exactDigitsValidator(4)(ctrl(null))).toBeNull();
+    });
+  });
+
+  describe('emailFormatValidator', () => {
+    it('prihvata validan email', () => {
+      expect(emailFormatValidator(ctrl('banka@primer.rs'))).toBeNull();
+      expect(emailFormatValidator(ctrl('ime.prezime@banka1.rs'))).toBeNull();
+      expect(emailFormatValidator(ctrl('a+tag@sub.domen.co.uk'))).toBeNull();
+    });
+
+    it('odbija email bez @', () => {
+      expect(emailFormatValidator(ctrl('bankaprimer.rs'))).toEqual({ emailFormat: true });
+    });
+
+    it('odbija email bez domena', () => {
+      expect(emailFormatValidator(ctrl('banka@'))).toEqual({ emailFormat: true });
+    });
+
+    it('odbija email bez TLD-a', () => {
+      expect(emailFormatValidator(ctrl('banka@primer'))).toEqual({ emailFormat: true });
+    });
+
+    it('odbija email sa razmakom', () => {
+      expect(emailFormatValidator(ctrl('ba nka@primer.rs'))).toEqual({ emailFormat: true });
+    });
+
+    it('prazna vrednost je validna (required to hvata)', () => {
+      expect(emailFormatValidator(ctrl(''))).toBeNull();
+      expect(emailFormatValidator(ctrl(null))).toBeNull();
+      expect(emailFormatValidator(ctrl(undefined))).toBeNull();
+    });
+  });
+
+  describe('phoneNumberValidator', () => {
+    it('prihvata cifre bez prefiksa', () => {
+      expect(phoneNumberValidator(ctrl('0611234567'))).toBeNull();
+    });
+
+    it('prihvata cifre sa vodecim +', () => {
+      expect(phoneNumberValidator(ctrl('+381611234567'))).toBeNull();
+    });
+
+    it('odbija slova', () => {
+      expect(phoneNumberValidator(ctrl('06abc1234'))).toEqual({ phoneFormat: true });
+    });
+
+    it('odbija + koji nije na pocetku', () => {
+      expect(phoneNumberValidator(ctrl('0611+234567'))).toEqual({ phoneFormat: true });
+    });
+
+    it('odbija previse kratak broj', () => {
+      expect(phoneNumberValidator(ctrl('1234567'))).toEqual({ phoneFormat: true });
+    });
+
+    it('odbija previse dug broj', () => {
+      expect(phoneNumberValidator(ctrl('+1234567890123456'))).toEqual({ phoneFormat: true });
+    });
+
+    it('odbija razmake', () => {
+      expect(phoneNumberValidator(ctrl('+381 61 1234567'))).toEqual({ phoneFormat: true });
+    });
+
+    it('prazna vrednost je validna (required to hvata)', () => {
+      expect(phoneNumberValidator(ctrl(''))).toBeNull();
+      expect(phoneNumberValidator(ctrl(null))).toBeNull();
+    });
+  });
+
+  describe('notFutureDateValidator', () => {
+    it('prihvata datum u proslosti', () => {
+      expect(notFutureDateValidator(ctrl('1990-01-01'))).toBeNull();
+    });
+
+    it('prihvata danasnji datum', () => {
+      const today = new Date().toISOString().slice(0, 10);
+      expect(notFutureDateValidator(ctrl(today))).toBeNull();
+    });
+
+    it('odbija datum u buducnosti', () => {
+      const future = new Date();
+      future.setFullYear(future.getFullYear() + 1);
+      const futureIso = future.toISOString().slice(0, 10);
+      expect(notFutureDateValidator(ctrl(futureIso))).toEqual({ futureDate: true });
+    });
+
+    it('odbija neispravan datum-string', () => {
+      expect(notFutureDateValidator(ctrl('nije-datum'))).toEqual({ futureDate: true });
+    });
+
+    it('prazna vrednost je validna (required to hvata)', () => {
+      expect(notFutureDateValidator(ctrl(''))).toBeNull();
+      expect(notFutureDateValidator(ctrl(null))).toBeNull();
+    });
+  });
+});

--- a/src/app/shared/utils/validators.ts
+++ b/src/app/shared/utils/validators.ts
@@ -25,3 +25,62 @@ export function exactDigitsValidator(length: number): ValidatorFn {
     return null;
   };
 }
+
+/**
+ * Validira format email adrese (Celina 1 — "Email mora biti validnog formata").
+ * Jedinstvenost se proverava na backendu; ovaj validator pokriva samo format.
+ * Prazna vrednost je validna — prisustvo prepustamo `Validators.required`.
+ * @returns `{ emailFormat: true }` ako format nije ispravan, inace `null`.
+ */
+export function emailFormatValidator(control: AbstractControl): ValidationErrors | null {
+  if (control.value === null || control.value === undefined || control.value === '') {
+    return null;
+  }
+
+  const value = String(control.value).trim();
+  // Lokalni deo + @ + domen sa bar jednim tackom-odvojenim TLD-om; bez razmaka.
+  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  return emailPattern.test(value) ? null : { emailFormat: true };
+}
+
+/**
+ * Validira broj telefona (Celina 1 — "samo cifre i znak '+' na pocetku").
+ * Regex `^\+?[0-9]{8,15}$` odgovara backend `@Pattern` ogranicenju.
+ * Prazna vrednost je validna — prisustvo prepustamo `Validators.required`.
+ * @returns `{ phoneFormat: true }` ako format nije ispravan, inace `null`.
+ */
+export function phoneNumberValidator(control: AbstractControl): ValidationErrors | null {
+  if (control.value === null || control.value === undefined || control.value === '') {
+    return null;
+  }
+
+  const value = String(control.value).trim();
+  const phonePattern = /^\+?[0-9]{8,15}$/;
+
+  return phonePattern.test(value) ? null : { phoneFormat: true };
+}
+
+/**
+ * Validira da datum nije u buducnosti (Celina 1 — "Datum rodjenja ne sme biti
+ * u buducnosti"). Radi sa ISO date-string vrednoscu kontrole (npr. "1990-01-01").
+ * Neispravan datum-string se tretira kao nevalidan.
+ * Prazna vrednost je validna — prisustvo prepustamo `Validators.required`.
+ * @returns `{ futureDate: true }` ako je datum u buducnosti ili neispravan, inace `null`.
+ */
+export function notFutureDateValidator(control: AbstractControl): ValidationErrors | null {
+  if (control.value === null || control.value === undefined || control.value === '') {
+    return null;
+  }
+
+  const parsed = new Date(String(control.value));
+  if (Number.isNaN(parsed.getTime())) {
+    return { futureDate: true };
+  }
+
+  // Poredimo na nivou dana — danasnji datum je dozvoljen.
+  const today = new Date();
+  today.setHours(23, 59, 59, 999);
+
+  return parsed.getTime() > today.getTime() ? { futureDate: true } : null;
+}


### PR DESCRIPTION
# Implementacija TODO_final specifikacije (Celine 1–4)

## Sazetak

Implementacija svih obaveznih stavki iz `TODO_final` specifikacije po Celinama 1–4 — sigurnosne mere, verifikacioni mehanizam, notifikacioni kanali, prosirenja trgovine i investicionih fondova, kao i sistemski audit log. Promene su unete u backend monorepo (Spring Boot 4, Java 21, Gradle 8.14, PostgreSQL, RabbitMQ) i Angular 16 frontend.

## Celina 1 — Upravljanje korisnicima

- **Validacija unosa pri kreiranju/izmeni naloga**: striktan format email-a, broj telefona ogranicen na cifre uz opcioni vodeci `+`, datum rodjenja ne sme biti u buducnosti. Custom Bean Validation constraint za epoch-millisecond datum klijenta. `existsByEmail` pre-check pri kreiranju klijenta vraca 409 umesto generickog 500.
- **Brute-force zastita**: posle 5 uzastopnih neuspesnih pokusaja prijave nalog se zakljucava na 10 minuta. Polja `failedLoginAttempts` (int) i `accountLockedUntil` (TIMESTAMP) dodata u oba korisnicka entiteta. Zakljucavanje salje email koji nudi reset lozinke; reset lozinke otkljucava nalog i resetuje brojac. Implementacija usaglasena na obe strane (employee + client).
- **Frontend validacioni helperi** (`emailFormatValidator`, `phoneNumberValidator`, `notFutureDateValidator`) primenjeni na sve relevantne reactive forme; nedostajuca polja (email/pol/datumRodjenja) dodata u employee-edit modal. Login forma prikazuje preciznu poruku o zakljucanom nalogu.

## Celina 2 — Osnovno poslovanje

- **TOTP verifikacioni kod**: zamenjen pseudorandom 6-cifreni kod standardnim RFC 6238 TOTP-om (30s period, ±1 step prozor za tolerancije clock skew-a). Per-sesija Base32 secret enkriptovan AES-GCM-256 sa zasebnim kljucem (ne reuse-uje JWT secret). Public REST ugovor verifikacionog servisa nepromenjen — postojeci pozivaoci (transfer, transaction, account, card) rade bez izmena. Novi `GET /verification/time` izlozen za sinhronizaciju klijenta.
- **Notifikacije**: dodate sve trazene tacke — placanje/transfer, izmena limita, kreiranje/odobravanje kredita, blokiranje/odblokiranje/deaktivacija kartice. Generalizovan FCM push (ranije samo OTP). Ispravljena cetiri prethodna defekta na produkcionim email putanjama gde su placeholder-i (`{{...}}`) ostajali ne-rendirani jer su producer-i slali podatke kao direktna polja umesto u `templateVariables` map: `CREDIT_APPROVED`/`CREDIT_DECLINED`/`CREDIT_INSTALLMENT_FAILED`, transfer i transaction email-ovi sada se rendiraju ispravno. Otkriven i otklonjen propust gde je `clientId` upisivan kao `creditId` u dve grane `LoanServiceImplementation.confirmation`.
- **In-app notifikacioni feed**: novi entitet `InAppNotification` (vlasnik, tip, naslov, telo, read flag, referenceId), izlozen kroz JWT-secured REST endpoint-e (`GET /notifications`, `GET /notifications/unread-count`, `PATCH /notifications/{id}/read`, `PATCH /notifications/read-all`). U notification-service-u aktivirana security-lib JWT konfiguracija; `/notifications/fcm/**` ostaje javno. In-app red i email isporuka su razdvojeni kanali — odsustvo email adrese ne sprecava upis in-app reda. FCM push se okida kao best-effort za svaki konzumirani event kad postoji registrovan token. Frontend dobija zvonce + dropdown panel u topbar-u sa unread badge-om i punu `/notifications` stranicu.

## Celina 3 — Trgovina na berzi

- **Order notifikacije**: dodati event-i za create, full execution (DONE), partial fill i auto-cancel. Postojeci approve/decline event-i ostaju.
- **Price Alert**: novi entitet (uslov ABOVE/BELOW/PCT_DROP_INTRADAY, prag, tip notifikacije, isActive, last-trigger flag), evaluator pozvan iz postojeceg listing refresh ciklusa, debounce kroz `lastTriggeredAt` koji se cuva u bazi. CRUD endpoint-i pod `/price-alerts`. market-service je dobio AMQP da bi mogao da publish-uje `price.alert_triggered`; notification-service mapa i `price.#` binding dopunjeni.
- **Istorija ordera**: dodato `created_at` polje na `orders`; novi filterabilan + paginated `GET /orders/my-orders` (po status/direction/security-type/datum opsegu), dostupan klijentima i agentima nad sopstvenim ordere-ima. Provizija (`fee`) ukljucena u odgovor. Frontend „Moji orderi" stranica sa filter-trakom i tabelom.
- **Watchlist**: vise imenovanih watchlist-i po korisniku, sa per-stavkom listing market data. Endpoint-i `/watchlists` (CRUD + add/remove stavki, filtriranje po tipu hartije). Frontend „Add to watchlist" dugme na securities listi/detalju, topbar widget za brzi pristup, stranica za upravljanje listama.
- **Audit log**: centralizovan kroz RabbitMQ. `audit.#` queue/binding u trading-service-u; entitet `AuditLog` sa filterabilnim `GET /audit` endpoint-om (`@PreAuthorize("hasAnyRole('ADMIN','SUPERVISOR')")`). Order approve/decline, agent limit/usedLimit/needApproval izmene, manual i scheduled tax run, izmene permisija zaposlenom — svi se publish-uju u `afterCommit` sa stvarnim akterom (ili SYSTEM sentinel za scheduler-skupinu). Frontend audit log viewer u Administracija grupi.
- **DCA (RecurringOrder)**: novi entitet i scheduler — DAILY/WEEKLY/MONTHLY kadenca, BY_QUANTITY / BY_AMOUNT mod. Cron izvrsava svaki due nalog u zasebnoj transakciji preko postojecih `createBuyOrder`/`createSellOrder` + `confirmOrder` putanja (aktuarska limit-rezervacija se automatski racuna). Nedostatak sredstava: nalog se preskace, korisnik dobija notifikaciju, `nextRun` se i dalje pomera za jednu kadencu. CRUD + pause/resume/cancel pod `/recurring-orders`. Frontend stranica sa listom i create modalom.
- **Isplata dividendi**: novi entitet `DividendPayout`, kvartalni dnevni cron sa self-gate-om za poslednji radni dan marta/juna/septembra/decembra. Formula `Dividenda = Quantity × Price × (DividendYield / 4)`. Klijenti placaju 15% porez (u RSD, na drzavni racun, bez provizije konverzije), aktuarske pozicije u ime banke ostaju ne-oporezovane (ulaze u Profit Banke). Isplata u valuti listinga na racun korisnika u toj valuti kad postoji; fallback na RSD racun sa konverzijom (novi `/accounts/internal/by-owner/{ownerId}/currency/{code}` endpoint). Idempotentno po `(userId, listingId, paymentDate)`. Per-listing istorija dividendi vidljiva u „Moj portfolio".

## Celina 4 — OTC i investicioni fondovi

- **OTC notifikacije**: counter-offer, accept, reject, withdraw event-i publish-uju se ka kontraparti (strani koja nije izvela akciju) u `afterCommit`. Novi scheduler salje podsetnik o opcionim ugovorima koji ce isteci u narednih N dana (default 3), sa `expiry_reminder_sent` markerom da svaki ugovor dobije najvise jedan podsetnik.
- **Istorija pregovora**: do sada su counter-offer-i destruktivno prepisivali postojeci red. Sada se pre svake izmene snima `OtcOfferRevision` (akcija CREATE/COUNTER/ACCEPT/REJECT/WITHDRAW, akter sa rolom buyer/seller, stare + nove vrednosti, timestamp) u istoj transakciji. Dva nova endpoint-a (`GET /otc/offers/history` po svim statusima sa filterima, `GET /otc/offers/{id}/history`) dostupna ucesnicima pregovora. Frontend dobija novu „Istorija pregovora" tab u OTC portalu.
- **Raspodela dividendi u fondovima**: kad akcija koju fond drzi isplati dividendu, iznos se prvo kreditira likvidnosti fonda (konvertovan u RSD). Po per-fond politici `dividendPolicy` (default `REINVEST`, supervizorski izmenljiva): `REINVEST` automatski kupuje dodatne akcije iste hartije (floor(gross/price)), ostatak ostaje kao likvidnost; `DISTRIBUTE` raspodeljuje gross-RSD klijentskim pozicijama proporcionalno (poslednja pozicija prima rounding rezidual, suma raspodele = gross egzaktno, neto promena likvidnosti = 0), ukljucujuci bankinu poziciju (`clientId = -1`). Per-fond izolacija transakcija — pad jedne pozicije ne prekida ostatak rinde.
- **Statistika fondova**: novi entitet `FundValueSnapshot`, mesecni snapshot cron, racunata cetiri kljucna pokazatelja iz serije snapshot-ova — godisnji prinos (`(v_last/v_0)^(12/m) - 1`), reward-to-variability (Sharpe-tip sa risk-free 0), max drawdown (najveca peak-to-trough relativna padajuca pozicija), volatilnost (sample standardna devijacija mesecnih prinosa). Sve cetiri su `BigDecimal` racunate u `DECIMAL128`, zaokruzene na scale 8, izrazene kao razlomak. Konfigurabilan minimum snapshot-ova (default 3) ispod kog metrike nisu dostupne (`metricsAvailable = false`). `InvestmentFundDto` prosiren sa cetiri nullable metric polja; discovery endpoint je sortabilan po njima sa nulls-last politikom. `fundPerformance` koji je ranije vracao jednu konstantnu tacku (lazna ravna linija) sada cita stvarnu seriju iz `fund_value_snapshots`. Novi endpoint-i: `/funds/{id}/statistics`, `/funds/{id}/value-history`, `/funds/value-history/average`. Frontend Discovery dobija sortabilne metric kartice, fund-details dobija metrics panel + linijski grafikon istorije sa overlay-em sistemskog proseka (reuse-ovan ApexCharts theme builder, theme-aware).

## Infrastrukturne izmene

- **API gateway (Nginx)**: novi `location` blokovi za `/price-alerts`, `/watchlists` (`market_service` upstream) i `/recurring-orders`, `/audit`, `/dividends` (`trading_service` upstream). Routing prati `useTrailingSlashMatch=false` Spring Boot 4 ponasanje (exact + prefix location bez 301).
- **Liquibase**: 13 novih changeset-ova kroz module (`client/011`, `verification/006`, `stock/013-014`, `order/012-013`, `trading-otc/011-017`, notification-service Flyway `V2`). Svi registrovani u modulskim master changelog-ima.
- **RabbitMQ**: nova queue/binding za `audit.#` u trading-service-u; dodati binding-ovi `transaction.#` / `transfer.#` / `account.#` / `otc.#` / `price.#` u notification-service-u, plus 24 nove routing-key → tip mape i odgovarajuci template-i.
- **Build/deps**: `dev.samstevens.totp:totp:1.7.1` u verification-service-u; `spring-boot-starter-amqp` u market-service-u i stock-service-u; `spring-boot-starter-security` + `oauth2-resource-server` + `security-lib` u notification-service-u; Spring Boot 4 test-slice starteri (`spring-boot-webmvc-test`, `spring-boot-data-jpa-test`) dodati gde su novi `@WebMvcTest`/`@DataJpaTest` slice-ovi.
- **Dev seed** (`context:dev`): `017-dev-fund-value-snapshots.sql` upisuje ~9 mesecnih snapshot-ova po seed fondu (raznorodne vrednosti) tako da fund statistika ima sta da prikaze odmah nakon prvog up-a; klijent `Mile Interbank` portfolio seed neizmenjen.

## Verifikacija

- **Backend (`gradle clean build`)**: BUILD SUCCESSFUL, **1932 testa**, 0 padova, 0 errora, 0 skipped (svih 20 modula).
- **Frontend (`tsc -p tsconfig.app.json --noEmit`)**: exit 0. **`ng test`**: 397/397 PASS. **`npm run build`** (production): exit 0, initial bundle **1.93 MB** (ispod 2 MB error budget-a).
- **Docker integracija (`docker compose down -v && build --no-cache && up -d`)**: svih 18 kontejnera (8 Spring servisa + api-gateway + frontend + Postgres + RabbitMQ + 6 observability sidecar-a) reaclo `healthy` na prvi pokusaj. `GET /gateway-health` 200. Liquibase apply protiv stvarnog PostgreSQL-a: 0 ValidationFailedException, 0 ChangeLogParseException. Smoke kroz gateway: svi novi endpoint-i (`/notifications`, `/price-alerts`, `/watchlists`, `/recurring-orders`, `/audit`, `/dividends`) odgovaraju 401 bez JWT-a (ruta + servis aktivni); javni `/notifications/fcm/**` putevi rade bez JWT-a.

## Bez breaking promena

Sve postojece public REST rute zadrzavaju iste path-ove i payload-e. TOTP zamena verifikacionog koda je interna — `POST /verification/generate`, `POST /verification/validate`, `GET /verification/{sessionId}/status` zadrzavaju iste request/response oblike i postojeci pozivaoci nisu menjani.

## Hotfix-ovi posle prvog live testiranja

- **`GET /orders/my-orders` (PostgreSQL strict-typing)**: JPQL upit za filterabilan order-history endpoint je koristio `(:p IS NULL OR o.col = :p)` pattern za nullable parametre. PostgreSQL ne ume da odredi tip parametra koriscenog samo u IS NULL poredjenju i baca "could not determine data type of parameter $N". H2 (modul-test) toleriše. Upit prepisan u JPA `JpaSpecificationExecutor`-based varijantu (`buildMyOrdersSpec` u `OrderCreationServiceImpl`) koja dodaje predikate samo kada je odgovarajuca filter vrednost prisutna — isti pattern koji vec koriste `AuditLogRepository` i watchlist repozitorijum. Testovi (`OrderRepositoryMyOrdersTest`, `OrderCreationServiceTest`) prepisani na `findAll(Specification, Pageable)` API.
- **`GET /order/tax/tracking` (stale `SERVICES_*_URL` u `.env`)**: pre-existing konfiguracija — `setup/.env` je nasledjivao predkonsolidacijske host-name-ove (`client-service:8083`, `verification-service:8086`, `exchange-service:8085`, `card-service:8090`, `account-service:8084`) koji vise ne postoje kao kontejneri. Trading-service je pri lookup-u klijenata padao na DNS resoluciji. `SERVICES_USER_URL` / `SERVICES_CLIENT_URL` -> `http://user-service:8081`; `SERVICES_VERIFICATION_URL` / `SERVICES_CARD_URL` / `SERVICES_ACCOUNT_URL` -> `http://banking-core-service:8084`; `SERVICES_EXCHANGE_URL` -> `http://market-service:8085`.

Posle ovih hotfix-ova oba endpoint-a vracaju 401 bez JWT-a (umesto 500); `:order-service:test` 324/324 PASS, `:trading-service:test` 224/224 PASS.
