### PR TITLE
ci(frontend): GHCR build+push workflow za frontend image (k8s deploy)

### DIFF
--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -1,0 +1,44 @@
+name: cd-frontend
+# Build + push the Angular frontend image to GHCR so the k8s frontend Deployment
+# (image: ghcr.io/raf-si-2025/banka-1-frontend:latest) has something to pull.
+# The repo Dockerfile already does: node build -> nginx:alpine serving the SPA.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lowercase GHCR owner
+        id: owner
+        run: echo "owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build + push banka-1-frontend
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ steps.owner.outputs.owner }}/banka-1-frontend:latest
+            ghcr.io/${{ steps.owner.outputs.owner }}/banka-1-frontend:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION

Frontend repo do sada nije imao CD pipeline koji objavljuje image, pa k8s frontend
Deployment (`image: ghcr.io/<owner>/banka-1-frontend:latest`) nije imao odakle da
povuce image. Ovaj PR dodaje workflow koji gradi i push-uje frontend image na **GHCR**.
Aplikativni frontend kod **nije menjan** — promena je iskljucivo CD/infra.

### Izmene

**`.github/workflows/cd-frontend.yml` (novo).**
- **Trigger:** `push` na `main` + `workflow_dispatch`.
- **Build:** postojeci root `Dockerfile` (multi-stage — Node build Angular SPA →
  `nginx:alpine` servira static). Bez izmena u `Dockerfile`-u i izvornom kodu.
- **Registry:** login na `ghcr.io` preko `GITHUB_TOKEN` (`permissions: packages: write`).
- **Tagovi:** `:latest` + `:<github.sha>`; owner segment lowercase-ovan (GHCR zahtev).
- **Cache:** GitHub Actions cache (`cache-from`/`cache-to: type=gha`, `mode=max`).

### Zasto

`imagePullPolicy: Always` + `:latest` na k8s frontend Deployment-u zahteva da image
postoji na registry-ju; bez ovog workflow-a image nije postojao i deploy nije imao
sta da povuce. Posle merge-a na `main`, prvi build objavljuje
`banka-1-frontend:latest` (i `:<sha>`), koji frontend Deployment povlaci uz
`kubectl rollout restart`. Isti model objavljivanja koji koristi i backend
(`cd-go.yml`).

### Validacija

- Workflow gradi **nepromenjen** postojeci `Dockerfile` kojim se aplikacija vec
  uspesno build-uje lokalno (multi-stage Node → nginx).
- YAML sintaksa workflow-a validna.

### Preduslov / redosled

Image se objavljuje tek po merge-u na `main`. Za k8s deploy redosled i povlacenje
image-a videti infrastrukturni repo (`frontend.yaml`, deploy uputstvo).
