### PR TITLE
OTC FE: PRIHVATI dugme za inter-bank ponude + valute iz protokola (ne hardkod USD)

### DIFF
--- a/src/app/features/otc/components/otc-available-stocks/otc-available-stocks.component.html
+++ b/src/app/features/otc/components/otc-available-stocks/otc-available-stocks.component.html
@@ -50,7 +50,7 @@
                   <td class="text-right">
                     <a class="z-btn-gold z-btn-sm"
                        [routerLink]="['/otc/create']"
-                       [queryParams]="{ mode: 'banka2', ticker: row.ticker, sellerForeignId: s.id }">
+                       [queryParams]="{ mode: 'banka2', ticker: row.ticker, sellerForeignId: s.id, currency: s.currency }">
                       Pripremi ponudu
                     </a>
                   </td>

--- a/src/app/features/otc/components/otc-create-offer/otc-create-offer.component.html
+++ b/src/app/features/otc/components/otc-create-offer/otc-create-offer.component.html
@@ -81,7 +81,10 @@
                  class="z-input font-mono"
                  data-testid="seller-foreign-input"
                  placeholder="C-2" />
-          <p class="text-xs text-muted-foreground mt-1">Routing number: <span class="font-mono">222</span> (Banka 2).</p>
+          <p class="text-xs text-muted-foreground mt-1">
+            Routing number: <span class="font-mono">222</span> (Banka 2) ·
+            Valuta: <span class="font-mono">{{ form.controls['currency'].value || 'USD' }}</span>
+          </p>
           <p *ngIf="form.controls['sellerForeignId'].invalid && form.controls['sellerForeignId'].touched" class="z-error">
             Format: "C-2" (klijent) ili "E-7" (employee).
           </p>

--- a/src/app/features/otc/components/otc-create-offer/otc-create-offer.component.ts
+++ b/src/app/features/otc/components/otc-create-offer/otc-create-offer.component.ts
@@ -53,6 +53,9 @@ export class OtcCreateOfferComponent implements OnInit {
       pricePerStock: [null, [Validators.required, Validators.min(0.01)]],
       premium: [null, [Validators.required, Validators.min(0)]],
       settlementDate: ['', Validators.required],
+      // PR_33 Phase B: valuta cross-bank ponude — preuzeta iz Banka 2 discovery-ja
+      // (query param), default 'USD'. Koristi se za price/premium currency.
+      currency: ['USD'],
     });
 
     if (this.preselectedStockTicker) {
@@ -75,6 +78,8 @@ export class OtcCreateOfferComponent implements OnInit {
     if (ticker) this.form.patchValue({ stockTicker: ticker });
     const sellerForeignId = params.get('sellerForeignId');
     if (sellerForeignId) this.form.patchValue({ sellerForeignId });
+    const currency = params.get('currency');
+    if (currency) this.form.patchValue({ currency });
   }
 
   /**
@@ -107,12 +112,13 @@ export class OtcCreateOfferComponent implements OnInit {
       // `OffsetDateTime` (Tim 2 protokol §3.4); HTML <input type="date">
       // daje samo "YYYY-MM-DD" pa rucno dodajemo midnight UTC suffix.
       const settlementIso = v.settlementDate ? `${v.settlementDate}T00:00:00Z` : '';
+      const currency = v.currency || 'USD';
       const req: CreateInterbankNegotiationRequest = {
         stockTicker: v.stockTicker,
         settlementDate: settlementIso,
-        priceCurrency: 'USD',
+        priceCurrency: currency,
         pricePerUnit: v.pricePerStock,
-        premiumCurrency: 'USD',
+        premiumCurrency: currency,
         premium: v.premium,
         sellerForeignBankId: {
           routingNumber: BANKA2_ROUTING,

--- a/src/app/features/otc/components/otc-offers/otc-offers.component.html
+++ b/src/app/features/otc/components/otc-offers/otc-offers.component.html
@@ -72,14 +72,14 @@
                 </span>
               </td>
               <td class="text-right font-mono">{{ o.amount | number }}</td>
-              <td class="text-right font-mono">{{ o.pricePerStock | number:'1.2-2' }}</td>
+              <td class="text-right font-mono">{{ o.pricePerStock | number:'1.2-2' }}<span *ngIf="o.priceCurrency"> {{ o.priceCurrency }}</span></td>
               <td class="text-right font-mono">
                 {{ marketPriceFor(o.stockTicker) ? (marketPriceFor(o.stockTicker) | number:'1.2-2') : '—' }}
               </td>
               <td class="text-right font-mono font-semibold" [ngClass]="deviationClass(o)">
                 {{ deviationText(o) }}
               </td>
-              <td class="text-right font-mono">{{ o.premium | number:'1.2-2' }}</td>
+              <td class="text-right font-mono">{{ o.premium | number:'1.2-2' }}<span *ngIf="o.premiumCurrency"> {{ o.premiumCurrency }}</span></td>
               <td class="whitespace-nowrap">{{ formatSettlementDate(o.settlementDate) }}</td>
               <td>
                 <span class="z-badge"

--- a/src/app/features/otc/components/otc-offers/otc-offers.component.ts
+++ b/src/app/features/otc/components/otc-offers/otc-offers.component.ts
@@ -10,6 +10,9 @@ import { AuthService } from '../../../../core/services/auth.service';
 
 export type OtcFilterMode = 'all' | 'local' | 'banka2';
 
+/** PR_33 Phase B: routing number partner banke (Banka 2) — mora se poklapati sa OtcService. */
+const BANKA2_ROUTING = 222;
+
 @Component({
   selector: 'app-otc-offers',
   templateUrl: './otc-offers.component.html',
@@ -76,9 +79,24 @@ export class OtcOffersComponent implements OnInit, OnDestroy {
   }
 
   canAccept(offer: OtcOffer): boolean {
-    if (offer.interbank) return false;
+    if (offer.interbank) {
+      // Inter-bank: prihvatamo kada je na nama red — tj. Banka 2 (routing 222)
+      // je poslednja modifikovala pregovor — i pregovor jos nije sklopljen.
+      return offer.status !== 'ACCEPTED' && this.lastModifierRouting(offer) === BANKA2_ROUTING;
+    }
     // Seller accepts buyer's offer; buyer accepts seller's counter-offer.
     return this.canRespond(offer);
+  }
+
+  /**
+   * PR_33 Phase B: routing number poslednjeg modifikatora cross-bank pregovora.
+   * `modifiedBy` je format "{routingNumber}:{id}" (mapiran u OtcService iz
+   * `state.lastModifiedBy`). Vraca NaN ako parsiranje ne uspe.
+   */
+  private lastModifierRouting(offer: OtcOffer): number {
+    const raw = offer.modifiedBy ?? '';
+    const idx = raw.indexOf(':');
+    return Number(idx >= 0 ? raw.substring(0, idx) : raw);
   }
 
   myRoleIn(offer: OtcOffer): 'Kupac' | 'Prodavac' | '—' {
@@ -228,9 +246,9 @@ export class OtcOffersComponent implements OnInit, OnDestroy {
       const settlementIso = /^\d{4}-\d{2}-\d{2}$/.test(rawDate) ? `${rawDate}T00:00:00Z` : rawDate;
       this.otcService.counterInterbankNegotiation(target.localId, {
         amount: this.counterDraft.amount,
-        priceCurrency: 'USD',
+        priceCurrency: target.priceCurrency ?? 'USD',
         pricePerUnit: this.counterDraft.pricePerStock,
-        premiumCurrency: 'USD',
+        premiumCurrency: target.premiumCurrency ?? 'USD',
         premium: this.counterDraft.premium,
         settlementDate: settlementIso,
       }).subscribe({

--- a/src/app/features/otc/models/otc.model.ts
+++ b/src/app/features/otc/models/otc.model.ts
@@ -31,6 +31,13 @@ export interface OtcOffer {
   counterpartyBankName?: string;
   localId?: string;
   remoteId?: string;
+  /**
+   * PR_33 Phase B: valuta cene/premije (npr. "USD", "EUR").
+   * Za inter-bank pregovore dolazi iz `state.pricePerUnit.currency` /
+   * `state.premium.currency`; za intra-bank ostaje undefined (implicitno RSD/USD).
+   */
+  priceCurrency?: string;
+  premiumCurrency?: string;
 }
 
 export interface CreateOtcOfferRequest {

--- a/src/app/features/otc/services/otc.service.ts
+++ b/src/app/features/otc/services/otc.service.ts
@@ -247,6 +247,10 @@ export class OtcService {
       counterpartyBankName: this.bankNameFor(n.remoteForeignBankId.routingNumber),
       localId: n.localId,
       remoteId: n.remoteForeignBankId.id,
+      // PR_33 Phase B: sacuvaj valutu iz protokol payload-a da counter/accept
+      // path moze da je procita (umesto hard-coded 'USD').
+      priceCurrency: s.pricePerUnit.currency,
+      premiumCurrency: s.premium.currency,
     };
   }
 


### PR DESCRIPTION
## OTC FE — PRIHVATI dugme za inter-bank ponude + valute iz protokola

`canAccept` za interbank je tvrdo vraćao `false` pa se dugme nikad nije renderovalo. Sada vraća `true` kad je Banka 2 (routing `222`) poslednja menjala pregovor (na nama je red).

Valuta cene/premije se čita iz discovery/pregovora (`sellers[].currency` / `pricePerUnit.currency`) umesto hardkodovanog `'USD'`.
