### PR TITLE
Cross-bank FE: placanje (18-34 cifre, RSD-only, brza placanja prefill) + OTC lifecycle vidljivost

### DIFF
--- a/cypress/e2e/kt5/interbank-payment.cy.ts
+++ b/cypress/e2e/kt5/interbank-payment.cy.ts
@@ -32,7 +32,12 @@ describe('Scenario 1: Uspešno plaćanje na drugu banku', () => {
     }).as('getAccounts');
     cy.intercept('POST', /\/verification\/generate/, { statusCode: 200, body: { sessionId: 1 } }).as('generateCode');
     cy.intercept('POST', /\/verification\/validate/, { statusCode: 200, body: 'OK' }).as('validateCode');
-    cy.intercept('POST', /\/transactions\/payments/, { statusCode: 200, body: 'SUCCESS' }).as('createPayment');
+    // Racun primaoca pocinje sa 444 (routing != 111) -> cross-bank placanje ide
+    // preko interbank endpointa, ne preko intra-bank /transactions/payments.
+    cy.intercept('POST', /\/api\/interbank\/payments/, {
+      statusCode: 200,
+      body: { transactionId: 'tx-1', status: 'COMPLETED' },
+    }).as('createPayment');
 
     visitPayment();
     cy.wait('@getAccounts');
@@ -69,9 +74,10 @@ describe('Scenario 2: Plaćanje na neaktivan račun', () => {
     }).as('getAccounts');
     cy.intercept('POST', /\/verification\/generate/, { statusCode: 200, body: { sessionId: 1 } }).as('generateCode');
     cy.intercept('POST', /\/verification\/validate/, { statusCode: 200, body: 'OK' }).as('validateCode');
-    cy.intercept('POST', /\/transactions\/payments/, {
+    // Cross-bank (444...) placanje -> interbank endpoint; greska dolazi kao {error}.
+    cy.intercept('POST', /\/api\/interbank\/payments/, {
       statusCode: 400,
-      body: { errorTitle: 'Račun primaoca je neaktivan', errorDesc: 'Transakcija nije uspela' },
+      body: { error: 'Račun primaoca je neaktivan' },
     }).as('createPaymentFail');
 
     visitPayment();

--- a/src/app/features/client/components/new-payment/new-payment.component.html
+++ b/src/app/features/client/components/new-payment/new-payment.component.html
@@ -35,9 +35,22 @@
           </div>
           <div>
             <label class="z-label">Račun primaoca</label>
-            <input type="text" formControlName="receiverAccount" class="z-input" placeholder="Npr. 1110001000123456789" maxlength="19"
+            <input type="text" formControlName="receiverAccount" class="z-input" placeholder="Npr. 1110001000123456789" maxlength="34"
                    [class.border-destructive]="paymentForm.get('receiverAccount')?.invalid && paymentForm.get('receiverAccount')?.touched" />
-            <p class="z-error" *ngIf="paymentForm.get('receiverAccount')?.invalid && paymentForm.get('receiverAccount')?.touched">Unesite ispravan broj računa (19 cifara).</p>
+            <p class="z-error" *ngIf="paymentForm.get('receiverAccount')?.invalid && paymentForm.get('receiverAccount')?.touched">Unesite ispravan broj računa (18–34 cifre; Banka 1 = 19, Banka 2 = 18).</p>
+            <p *ngIf="isCrossBank && !crossBankNonRsdBlocked" class="mt-1 inline-flex items-center gap-1.5 text-xs font-medium text-amber-700">
+              <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M3 7h18M3 7l4-4M3 7l4 4M21 17H3m18 0l-4-4m4 4l-4 4"></path>
+              </svg>
+              Račun je u drugoj banci — plaćanje ide kao međubankarsko ({{ senderCurrency }}).
+            </p>
+            <!-- FIX 5: cross-bank ne-RSD placanje je blokirano -->
+            <p *ngIf="crossBankNonRsdBlocked" class="mt-1 inline-flex items-center gap-1.5 text-xs font-medium text-destructive" data-testid="cross-bank-rsd-only-warning">
+              <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line>
+              </svg>
+              {{ crossBankRsdOnlyMessage }}
+            </p>
           </div>
         </div>
 
@@ -61,7 +74,7 @@
             <div class="relative">
               <input type="number" formControlName="amount" class="z-input pr-16" placeholder="0.00"
                      [class.border-destructive]="paymentForm.get('amount')?.invalid && paymentForm.get('amount')?.touched" />
-              <span class="absolute right-3 top-1/2 -translate-y-1/2 text-xs font-semibold bg-green-100 text-green-700 px-2 py-0.5 rounded">RSD</span>
+              <span class="absolute right-3 top-1/2 -translate-y-1/2 text-xs font-semibold bg-green-100 text-green-700 px-2 py-0.5 rounded">{{ senderCurrency }}</span>
             </div>
             <p class="z-error" *ngIf="paymentForm.get('amount')?.invalid && paymentForm.get('amount')?.touched">Unesite validan iznos veci od 0.</p>
             <div *ngIf="showLimitInfo && selectedAccount"
@@ -121,7 +134,7 @@
 
         <div class="flex justify-end gap-3 pt-2">
           <button type="button" class="z-btn-outline" (click)="onCancel()">Nazad na listu</button>
-          <button type="submit" class="z-btn-primary" [disabled]="paymentForm.invalid">POTVRDI PLAĆANJE &rsaquo;</button>
+          <button type="submit" class="z-btn-primary" [disabled]="paymentForm.invalid || crossBankNonRsdBlocked">POTVRDI PLAĆANJE &rsaquo;</button>
         </div>
       </form>
 

--- a/src/app/features/client/components/new-payment/new-payment.component.ts
+++ b/src/app/features/client/components/new-payment/new-payment.component.ts
@@ -1,12 +1,16 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { AccountService } from '../../services/account.service';
 import { Account } from '../../models/account.model';
 import { VerificationModalComponent } from '../../modals/verification-modal/verification-modal.component';
 import { PaymentRecipient } from '../../models/account.model';
 import { ClientService, NewPaymentDto } from '../../services/client.service';
+import {
+  InterbankPaymentService,
+  InterbankPaymentRequest
+} from '../../services/interbank-payment.service';
 import { NotificationService } from '../../../../shared/services/notification.service';
 import { NotificationType } from '../../../../shared/models/notification.model';
 
@@ -34,6 +38,33 @@ export class NewPaymentComponent implements OnInit {
     return this.myAccounts.find((a) => a.accountNumber === acctNum) ?? null;
   }
 
+  /** Valuta racuna posiljaoca (default RSD dok se racuni ne ucitaju). */
+  public get senderCurrency(): string {
+    return this.selectedAccount?.currency ?? 'RSD';
+  }
+
+  /**
+   * True kada je racun primaoca u drugoj banci (routing != 111).
+   * Tada placanje ide preko novog inter-bank endpointa umesto intra-bank toka.
+   */
+  public get isCrossBank(): boolean {
+    const receiver = this.paymentForm?.value?.receiverAccount;
+    return this.interbankService.isForeignAccount(receiver);
+  }
+
+  /**
+   * FIX 5: medjubankarska placanja su podrzana SAMO u RSD (nema FX na inter-bank
+   * sini). Blokira se cross-bank placanje kada racun posiljaoca nije u RSD. (OTC
+   * settlement ide drugom putanjom i ostaje USD — ne tice se ovog placanja.)
+   */
+  public get crossBankNonRsdBlocked(): boolean {
+    return this.isCrossBank && this.senderCurrency.trim().toUpperCase() !== 'RSD';
+  }
+
+  /** FIX 5: poruka koja se prikazuje kada je cross-bank ne-RSD placanje blokirano. */
+  public readonly crossBankRsdOnlyMessage =
+    'Međubankarska plaćanja su trenutno podržana samo u RSD.';
+
   public get remainingDailyLimit(): number {
     const a = this.selectedAccount;
     if (!a) return 0;
@@ -54,13 +85,28 @@ export class NewPaymentComponent implements OnInit {
     private fb: FormBuilder,
     private accountService: AccountService,
     private clientService: ClientService,
+    private interbankService: InterbankPaymentService,
     private notificationService: NotificationService,
-    private router: Router
+    private router: Router,
+    private route: ActivatedRoute
   ) {}
 
   ngOnInit(): void {
     this.initForm();
     this.loadAccounts();
+
+    // Brza plaćanja: home → klik na primaoca navigira ovde sa recipientAccount /
+    // recipientName u query params. Pre-popunjavamo polja primaoca; korisnik samo
+    // unese iznos. (Pre fix-a forma se nije popunjavala jer queryParams nisu čitani.)
+    const qp = this.route.snapshot.queryParamMap;
+    const recipientAccount = qp.get('recipientAccount');
+    const recipientName = qp.get('recipientName');
+    if (recipientAccount) {
+      this.paymentForm.patchValue({ receiverAccount: recipientAccount });
+    }
+    if (recipientName) {
+      this.paymentForm.patchValue({ receiverName: recipientName });
+    }
   }
 /**
    * Kreira reaktivnu formu i definiše stroga pravila validacije za svako polje
@@ -70,8 +116,9 @@ export class NewPaymentComponent implements OnInit {
     this.paymentForm = this.fb.group({
       senderAccount: ['', Validators.required],
       receiverName: ['', Validators.required],
-      // Tačno 19 cifara za račun primaoca
-      receiverAccount: ['', [Validators.required, Validators.pattern('^[0-9]{19}$')]],
+      // Račun primaoca: 18-34 cifre. Banka 1 računi su 19 cifara, ali cross-bank
+      // primaoci imaju druge dužine (npr. Banka 2 = 18 cifara, IBAN do 34).
+      receiverAccount: ['', [Validators.required, Validators.pattern('^[0-9]{18,34}$')]],
       // Iznos mora biti veći od 0
       amount: ['', [Validators.required, Validators.min(0.01)]],
       // Šifra plaćanja: tačno 3 cifre, default za e-banking je obično 289
@@ -112,6 +159,11 @@ export class NewPaymentComponent implements OnInit {
    * Ako nisu, prikazuje korisniku sva polja gde je napravio grešku.
    */
   public onSubmit(): void {
+    // FIX 5: blokiraj cross-bank ne-RSD placanje pre verifikacije i slanja.
+    if (this.crossBankNonRsdBlocked) {
+      this.transactionError = this.crossBankRsdOnlyMessage;
+      return;
+    }
     if (this.paymentForm.valid) {
       this.showVerificationModal = true;
     } else {
@@ -127,6 +179,13 @@ export class NewPaymentComponent implements OnInit {
   private executeTransaction(verificationSessionId: number): void {
     this.transactionError = '';
     const form = this.paymentForm.value;
+
+    // Racun primaoca u drugoj banci (routing != 111) -> novi inter-bank endpoint.
+    // Intra-bank (111) zadrzava postojeci tok placanja.
+    if (this.interbankService.isForeignAccount(form.receiverAccount)) {
+      this.executeInterbankPayment();
+      return;
+    }
 
     const dto: NewPaymentDto = {
       fromAccountNumber: form.senderAccount,
@@ -151,14 +210,65 @@ export class NewPaymentComponent implements OnInit {
         this.checkIfNewRecipient(form.senderAccount, form.receiverAccount);
       },
       error: (err: any) => {
-        const e = err?.error;
-        if (e?.errorTitle && e?.errorDesc) {
-          this.transactionError = `${e.errorTitle}: ${e.errorDesc}`;
-        } else {
-          this.transactionError = e?.message || e?.error || 'Plaćanje nije uspelo. Pokušajte ponovo.';
-        }
+        this.transactionError = this.extractErrorMessage(err);
       }
     });
+  }
+
+  /**
+   * Cross-bank placanje preko POST /api/interbank/payments.
+   * `currency` mora da odgovara valuti racuna posiljaoca; `message` je svrha placanja.
+   * Iznos se salje kao string (decimal-safe).
+   */
+  private executeInterbankPayment(): void {
+    const form = this.paymentForm.value;
+
+    // FIX 5: defanzivni guard — i ako se nekako stigne dovde, ne salji ne-RSD
+    // medjubankarsko placanje (backend ga ionako odbija sa 400 pre 2PC-a).
+    if (this.crossBankNonRsdBlocked) {
+      this.transactionError = this.crossBankRsdOnlyMessage;
+      return;
+    }
+
+    const request: InterbankPaymentRequest = {
+      fromAccount: form.senderAccount,
+      toAccount: form.receiverAccount,
+      amount: String(form.amount),
+      currency: this.senderCurrency,
+      message: form.purpose || undefined
+    };
+
+    this.interbankService.sendInterbankPayment(request).subscribe({
+      next: () => {
+        this.notificationService.addNotification({
+          type: NotificationType.PAYMENT,
+          title: 'Plaćanje izvršeno',
+          message: `Međubankarsko plaćanje od ${this.formatAmount(Number(request.amount))} ${request.currency} sa računa ${request.fromAccount} primacu ${form.receiverName} je uspešno izvršeno.`,
+          data: { interbankPayment: request }
+        });
+        this.refreshAccountsSilently();
+        this.checkIfNewRecipient(form.senderAccount, form.receiverAccount);
+      },
+      error: (err: any) => {
+        this.transactionError = this.extractErrorMessage(err);
+      }
+    });
+  }
+
+  /**
+   * Mapira backend gresku u korisniku-razumljivu poruku.
+   * Podrzava i stari {errorTitle,errorDesc} kontrakt (intra-bank) i novi {error} kontrakt (inter-bank).
+   */
+  private extractErrorMessage(err: unknown): string {
+    const e = (err as { error?: unknown })?.error;
+    if (typeof e === 'string') {
+      return e || 'Plaćanje nije uspelo. Pokušajte ponovo.';
+    }
+    const body = e as { errorTitle?: string; errorDesc?: string; error?: string; message?: string } | undefined;
+    if (body?.errorTitle && body?.errorDesc) {
+      return `${body.errorTitle}: ${body.errorDesc}`;
+    }
+    return body?.error || body?.message || 'Plaćanje nije uspelo. Pokušajte ponovo.';
   }
 
   private refreshAccountsSilently(): void {

--- a/src/app/features/client/services/interbank-payment.service.spec.ts
+++ b/src/app/features/client/services/interbank-payment.service.spec.ts
@@ -1,0 +1,60 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+import { InterbankPaymentService, InterbankPaymentRequest } from './interbank-payment.service';
+import { environment } from 'src/environments/environment';
+
+describe('InterbankPaymentService', () => {
+  let service: InterbankPaymentService;
+  let httpMock: HttpTestingController;
+
+  const endpoint = `${environment.apiUrl}/api/interbank/payments`;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [InterbankPaymentService],
+    });
+    service = TestBed.inject(InterbankPaymentService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('routingOf() vraca prve 3 cifre racuna', () => {
+    expect(service.routingOf('2220001234567890123')).toBe('222');
+    expect(service.routingOf('111')).toBe('111');
+    expect(service.routingOf('22')).toBe('');
+    expect(service.routingOf('')).toBe('');
+    expect(service.routingOf(null)).toBe('');
+  });
+
+  it('isForeignAccount(): 111 je intra-bank (false), ostalo je cross-bank (true)', () => {
+    expect(service.isForeignAccount('1110001234567890123')).toBeFalse();
+    expect(service.isForeignAccount('2220001234567890123')).toBeTrue();
+    expect(service.isForeignAccount('3330001234567890123')).toBeTrue();
+    // Nepotpun racun nije validan cross-bank
+    expect(service.isForeignAccount('22')).toBeFalse();
+    expect(service.isForeignAccount('')).toBeFalse();
+  });
+
+  it('sendInterbankPayment() POST-uje na /api/interbank/payments sa korektnim telom', () => {
+    const request: InterbankPaymentRequest = {
+      fromAccount: '1110001234567890123',
+      toAccount: '2220001234567890123',
+      amount: '1500.00',
+      currency: 'RSD',
+      message: 'Test placanje',
+    };
+
+    let result: { transactionId: string; status: string } | undefined;
+    service.sendInterbankPayment(request).subscribe((res) => (result = res));
+
+    const req = httpMock.expectOne(endpoint);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(request);
+
+    req.flush({ transactionId: 'TX-1', status: 'COMPLETED' });
+    expect(result).toEqual({ transactionId: 'TX-1', status: 'COMPLETED' });
+  });
+});

--- a/src/app/features/client/services/interbank-payment.service.ts
+++ b/src/app/features/client/services/interbank-payment.service.ts
@@ -1,0 +1,65 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+
+/**
+ * Routing broj nase banke (Banka 1). Prve 3 cifre svakog naseg racuna.
+ * Mora se poklapati sa OtcService (PR_33 Phase B) gde je takodje 111.
+ */
+export const BANKA1_ROUTING = '111';
+
+/**
+ * Zahtev za medjubankarsko (cross-bank) placanje.
+ * Salje se na novi backend endpoint POST /api/interbank/payments.
+ * Banka primaoca se identifikuje prvim 3 cifre `toAccount` (routing broj).
+ * `amount` je string (decimal-safe), `currency` MORA da odgovara valuti `fromAccount` racuna.
+ */
+export interface InterbankPaymentRequest {
+  fromAccount: string;
+  toAccount: string;
+  amount: string;
+  currency: string;
+  message?: string;
+}
+
+/** Uspesan odgovor (HTTP 200) sa novog endpointa. */
+export interface InterbankPaymentResponse {
+  transactionId: string;
+  status: 'COMPLETED';
+}
+
+@Injectable({ providedIn: 'root' })
+export class InterbankPaymentService {
+  private readonly endpoint = `${environment.apiUrl}/api/interbank/payments`;
+
+  constructor(private readonly http: HttpClient) {}
+
+  /**
+   * Vraca routing broj (prve 3 cifre) datog broja racuna,
+   * ili prazan string ako racun nema bar 3 cifre.
+   */
+  routingOf(accountNumber: string | null | undefined): string {
+    const digits = (accountNumber ?? '').trim();
+    return digits.length >= 3 ? digits.substring(0, 3) : '';
+  }
+
+  /**
+   * Tacno kada je dati racun u DRUGOJ banci (cross-bank).
+   * True ako routing broj postoji i razlikuje se od naseg (111).
+   * Racuni koji pocinju sa 111 su intra-bank i NE idu preko ovog servisa.
+   */
+  isForeignAccount(accountNumber: string | null | undefined): boolean {
+    const routing = this.routingOf(accountNumber);
+    return routing.length === 3 && routing !== BANKA1_ROUTING;
+  }
+
+  /**
+   * Salje cross-bank placanje na novi backend endpoint.
+   * Backend pokrece 2PC sa partner bankom; uspeh je {transactionId, status:'COMPLETED'}.
+   * Greske dolaze kao {error} (400/401/403/404/409/500).
+   */
+  sendInterbankPayment(request: InterbankPaymentRequest): Observable<InterbankPaymentResponse> {
+    return this.http.post<InterbankPaymentResponse>(this.endpoint, request);
+  }
+}

--- a/src/app/features/otc/components/otc-available-stocks/otc-available-stocks.component.html
+++ b/src/app/features/otc/components/otc-available-stocks/otc-available-stocks.component.html
@@ -46,7 +46,7 @@
                   <td class="font-semibold">{{ row.ticker }}</td>
                   <td><span class="font-mono">{{ s.id }}</span></td>
                   <td class="text-right font-mono">{{ s.amount | number }}</td>
-                  <td class="text-right font-mono">{{ s.pricePerUnit | number:'1.2-2' }} {{ s.currency }}</td>
+                  <td class="text-right font-mono">{{ marketPriceFor(row.ticker) ? (marketPriceFor(row.ticker) | number:'1.2-2') + ' USD' : '—' }}</td>
                   <td class="text-right">
                     <a class="z-btn-gold z-btn-sm"
                        [routerLink]="['/otc/create']"

--- a/src/app/features/otc/components/otc-available-stocks/otc-available-stocks.component.ts
+++ b/src/app/features/otc/components/otc-available-stocks/otc-available-stocks.component.ts
@@ -67,9 +67,14 @@ export class OtcAvailableStocksComponent implements OnInit, OnDestroy {
   }
 
   private startPricePolling(): void {
-    const tickers = Array.from(new Set(this.entries.map(e => e.ticker)));
-    if (tickers.length === 0) return;
-    this.stockPriceService.poll(tickers).pipe(takeUntil(this.destroy$)).subscribe({
+    this.pollPrices(this.entries.map(e => e.ticker));
+  }
+
+  /** Poll current market prices for the given tickers into the shared `prices` map. */
+  private pollPrices(tickers: string[]): void {
+    const unique = Array.from(new Set(tickers));
+    if (unique.length === 0) return;
+    this.stockPriceService.poll(unique).pipe(takeUntil(this.destroy$)).subscribe({
       next: (snapshots: StockPriceSnapshot[]) => {
         for (const s of snapshots) this.prices.set(s.ticker, s.currentPrice);
       },
@@ -102,6 +107,10 @@ export class OtcAvailableStocksComponent implements OnInit, OnDestroy {
           })),
         }));
         this.banka2Loading = false;
+        // The inter-bank /public-stock protocol carries no price (ticker + sellers
+        // only), so enrich with the current market price — global per ticker —
+        // exactly like the local offers table and Banka 2's own /listings do.
+        this.pollPrices(this.banka2PublicStock.map(r => r.ticker));
       },
       error: err => {
         this.banka2Error = err?.error?.message || 'Banka 2 nije dostupna.';

--- a/src/app/features/otc/components/otc-create-offer/otc-create-offer.component.ts
+++ b/src/app/features/otc/components/otc-create-offer/otc-create-offer.component.ts
@@ -127,7 +127,7 @@ export class OtcCreateOfferComponent implements OnInit {
         amount: v.amount,
       };
       this.otcService.createInterbankNegotiation(req).subscribe({
-        next: () => this.router.navigate(['/otc/offers']),
+        next: () => this.router.navigate(['/otc']),
         error: err => {
           this.error = err?.error?.message || 'Greska pri kreiranju cross-bank pregovora.';
           this.loading = false;
@@ -137,7 +137,7 @@ export class OtcCreateOfferComponent implements OnInit {
     }
     const req = this.form.value as CreateOtcOfferRequest;
     this.otcService.createOffer(req).subscribe({
-      next: () => this.router.navigate(['/otc/offers']),
+      next: () => this.router.navigate(['/otc']),
       error: err => {
         this.error = err?.error?.message || 'Greska pri kreiranju ponude.';
         this.loading = false;

--- a/src/app/features/otc/components/otc-interbank-contracts/otc-interbank-contracts.component.html
+++ b/src/app/features/otc/components/otc-interbank-contracts/otc-interbank-contracts.component.html
@@ -1,0 +1,88 @@
+<div>
+  <div class="flex items-center justify-between mb-6 gap-3 flex-wrap">
+    <div>
+      <h1 class="text-2xl font-bold text-foreground">Cross-bank opcioni ugovori</h1>
+      <p class="text-sm text-muted-foreground mt-1">
+        Sklopljeni OTC opcioni ugovori koje ste kupili od druge banke. Aktivne opcije
+        u kojima ste kupac možete iskoristiti pre datuma poravnanja.
+      </p>
+    </div>
+    <button type="button" class="z-btn-outline z-btn-sm" (click)="load()" [disabled]="loading">
+      Osveži
+    </button>
+  </div>
+
+  <app-state *ngIf="loading" mode="loading" text="Ucitavanje ugovora..."></app-state>
+  <app-state *ngIf="error && !loading" mode="error" [text]="error"></app-state>
+
+  <ng-container *ngIf="!loading && !error">
+    <app-state *ngIf="contracts.length === 0"
+               mode="empty" title="Nema cross-bank ugovora"
+               text="Ovde će se pojaviti opcioni ugovori sklopljeni sa drugom bankom."></app-state>
+
+    <div *ngIf="contracts.length > 0" class="z-card overflow-hidden">
+      <div class="flex items-center justify-between px-5 py-4 border-b border-border">
+        <div>
+          <p class="text-xs font-semibold tracking-wider text-muted-foreground uppercase">Cross-bank ugovori</p>
+          <p class="text-sm text-muted-foreground mt-0.5">Iskorišćavanje opcije pokreće poravnanje sa drugom bankom.</p>
+        </div>
+        <span class="z-badge z-badge-blue">{{ contracts.length }} ugovora</span>
+      </div>
+
+      <div class="overflow-x-auto">
+        <table class="z-table min-w-[1020px]" data-testid="otc-interbank-contracts-table">
+          <thead>
+            <tr>
+              <th>Akcija</th>
+              <th>Banka</th>
+              <th>Druga strana</th>
+              <th class="text-right">Količina</th>
+              <th class="text-right">Strike</th>
+              <th>Settlement</th>
+              <th>Sklopljen</th>
+              <th>Status</th>
+              <th class="text-right">Akcije</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let c of contracts; trackBy: trackByLocalId"
+                [attr.data-testid]="'interbank-contract-row'">
+              <td class="font-semibold">{{ c.ticker }}</td>
+              <td>
+                <span class="z-badge z-badge-gold" data-testid="bank-badge">
+                  {{ counterpartyBankName(c) }}
+                </span>
+              </td>
+              <td>
+                <span class="z-badge"
+                      [ngClass]="iAmBuyer(c) ? 'z-badge-blue' : 'z-badge-gold'">
+                  {{ counterpartyLabel(c) }} · {{ iAmBuyer(c) ? 'Prodavac' : 'Kupac' }}
+                </span>
+              </td>
+              <td class="text-right font-mono">{{ c.amount | number }}</td>
+              <td class="text-right font-mono whitespace-nowrap">{{ c.strikeAmount }} {{ c.strikeCurrency }}</td>
+              <td class="whitespace-nowrap">{{ c.settlementDate | slice:0:10 }}</td>
+              <td class="text-muted-foreground whitespace-nowrap">{{ c.createdAt | date:'short' }}</td>
+              <td>
+                <span class="z-badge" [ngClass]="statusBadgeClass(c.status)">
+                  {{ c.status }}
+                </span>
+              </td>
+              <td class="text-right">
+                <button type="button"
+                        *ngIf="canExercise(c) || (c.status === 'ACTIVE' && iAmBuyer(c))"
+                        (click)="exercise(c)"
+                        [disabled]="!canExercise(c)"
+                        class="z-btn-gold z-btn-sm"
+                        data-testid="exercise-btn">
+                  {{ exercisingId === c.localId ? 'Slanje...' : 'Iskoristi' }}
+                </button>
+                <span *ngIf="!(c.status === 'ACTIVE' && iAmBuyer(c))" class="text-xs text-muted-foreground">—</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </ng-container>
+</div>

--- a/src/app/features/otc/components/otc-interbank-contracts/otc-interbank-contracts.component.ts
+++ b/src/app/features/otc/components/otc-interbank-contracts/otc-interbank-contracts.component.ts
@@ -1,0 +1,150 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
+import { OtcService } from '../../services/otc.service';
+import {
+  OtcInterbankContract,
+  OtcInterbankContractStatus,
+} from '../../models/otc.model';
+import { AuthService } from '../../../../core/services/auth.service';
+import { ToastService } from '../../../../shared/services/toast.service';
+
+/** Routing number nase banke (Banka 1). Mora se poklapati sa OtcService. */
+const BANKA1_ROUTING = 111;
+
+/**
+ * Cross-bank OTC opcioni ugovori — sklopljeni ugovori koje je korisnik kupio od
+ * druge banke (npr. Banka 2). Sibling view aktivnim cross-bank pregovorima
+ * (`app-otc-offers`); ovde se prikazuju vec sklopljeni ugovori i nudi se
+ * "Iskoristi" (exercise) akcija za ACTIVE ugovore gde je current user kupac.
+ *
+ * <p>Backend: `GET /api/interbank/otc/contracts/my` +
+ * `POST /api/interbank/otc/contracts/{localId}/exercise`. Uspeh/greska se
+ * prikazuju kroz globalni {@link ToastService}.
+ */
+@Component({
+  selector: 'app-otc-interbank-contracts',
+  templateUrl: './otc-interbank-contracts.component.html',
+})
+export class OtcInterbankContractsComponent implements OnInit, OnDestroy {
+
+  contracts: OtcInterbankContract[] = [];
+  loading = false;
+  error: string | null = null;
+
+  /** localId ugovora koji se trenutno exercise-uje (disable dugme + spinner). */
+  exercisingId: string | null = null;
+
+  private readonly destroy$ = new Subject<void>();
+
+  constructor(
+    private otcService: OtcService,
+    private authService: AuthService,
+    private toast: ToastService,
+  ) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  load(): void {
+    this.loading = true;
+    this.error = null;
+    this.otcService.listMyContracts().pipe(takeUntil(this.destroy$)).subscribe({
+      next: items => {
+        this.contracts = items;
+        this.loading = false;
+      },
+      error: err => {
+        this.error = this.friendlyError(err, 'Greska pri ucitavanju ugovora.');
+        this.contracts = [];
+        this.loading = false;
+      },
+    });
+  }
+
+  trackByLocalId(_index: number, c: OtcInterbankContract): string {
+    return c.localId;
+  }
+
+  /** Display naziv counterparty banke za prikaz u tabeli. */
+  counterpartyBankName(c: OtcInterbankContract): string {
+    const routing = this.iAmBuyer(c) ? c.sellerId.routingNumber : c.buyerId.routingNumber;
+    if (routing === 222) return 'Banka 2';
+    if (routing === BANKA1_ROUTING) return 'Naša banka';
+    return `Banka #${routing}`;
+  }
+
+  /** "{routing}:{id}" identifikator druge strane ugovora. */
+  counterpartyLabel(c: OtcInterbankContract): string {
+    const party = this.iAmBuyer(c) ? c.sellerId : c.buyerId;
+    return `${party.routingNumber}:${party.id}`;
+  }
+
+  /** Da li je current user kupac ovog ugovora (mora biti iz nase banke). */
+  iAmBuyer(c: OtcInterbankContract): boolean {
+    if (c.buyerId.routingNumber !== BANKA1_ROUTING) return false;
+    const myId = this.authService.getUserIdFromToken();
+    if (myId == null) return false;
+    return this.localIdNumber(c.buyerId.id) === myId;
+  }
+
+  /**
+   * Exercise je moguc samo za ACTIVE ugovore, gde je current user kupac i
+   * settlement datum jos nije prosao.
+   */
+  canExercise(c: OtcInterbankContract): boolean {
+    return c.status === 'ACTIVE'
+      && this.iAmBuyer(c)
+      && new Date(c.settlementDate) >= new Date()
+      && this.exercisingId == null;
+  }
+
+  exercise(c: OtcInterbankContract): void {
+    if (!this.canExercise(c)) return;
+    if (!confirm(`Iskoristiti opciju za ${c.amount}× ${c.ticker} po ${c.strikeAmount} ${c.strikeCurrency}?`)) {
+      return;
+    }
+    this.exercisingId = c.localId;
+    this.otcService.exerciseContract(c.localId).pipe(takeUntil(this.destroy$)).subscribe({
+      next: updated => {
+        this.exercisingId = null;
+        this.toast.success(`Opcija ${updated.ticker} uspešno iskorišćena.`);
+        this.load();
+      },
+      error: err => {
+        this.exercisingId = null;
+        this.toast.error(this.friendlyError(err, 'Greska pri iskorišćavanju opcije.'));
+      },
+    });
+  }
+
+  statusBadgeClass(status: OtcInterbankContractStatus): Record<string, boolean> {
+    return {
+      'z-badge-green': status === 'ACTIVE',
+      'z-badge-blue': status === 'EXERCISED',
+      'z-badge-gray': status === 'EXPIRED',
+    };
+  }
+
+  /** Numericki sufiks iz "C-{n}" / "E-{n}" foreign id-a; NaN ako format ne odgovara. */
+  private localIdNumber(foreignId: string): number {
+    const idx = foreignId.lastIndexOf('-');
+    return Number(idx >= 0 ? foreignId.substring(idx + 1) : foreignId);
+  }
+
+  /**
+   * Mapira HTTP error u prijateljsku poruku. Backend cross-bank rute vracaju
+   * `{ error: "..." }`; padamo nazad na `message` ili default tekst.
+   */
+  private friendlyError(err: unknown, fallback: string): string {
+    const body = (err as { error?: { error?: string; message?: string } } | null)?.error;
+    return body?.error || body?.message || fallback;
+  }
+}

--- a/src/app/features/otc/components/otc-offers/otc-offers.component.html
+++ b/src/app/features/otc/components/otc-offers/otc-offers.component.html
@@ -84,11 +84,13 @@
               <td>
                 <span class="z-badge"
                       [ngClass]="{
-                        'z-badge-green': o.status === 'ACCEPTED',
+                        'z-badge-green': o.status === 'ACCEPTED' && !isInterbankClosed(o),
                         'z-badge-yellow': o.status === 'PENDING_BUYER' || o.status === 'PENDING_SELLER',
+                        'z-badge-gray': isInterbankClosed(o),
                         'z-badge-red': o.status === 'REJECTED' || o.status === 'EXPIRED'
-                      }">
-                  {{ canWithdraw(o) && !o.interbank ? 'Čekamo drugu stranu' : o.status }}
+                      }"
+                      [attr.data-testid]="isInterbankClosed(o) ? 'offer-status-closed' : null">
+                  {{ statusLabel(o) }}
                 </span>
               </td>
               <td>

--- a/src/app/features/otc/components/otc-offers/otc-offers.component.ts
+++ b/src/app/features/otc/components/otc-offers/otc-offers.component.ts
@@ -81,11 +81,41 @@ export class OtcOffersComponent implements OnInit, OnDestroy {
   canAccept(offer: OtcOffer): boolean {
     if (offer.interbank) {
       // Inter-bank: prihvatamo kada je na nama red — tj. Banka 2 (routing 222)
-      // je poslednja modifikovala pregovor — i pregovor jos nije sklopljen.
-      return offer.status !== 'ACCEPTED' && this.lastModifierRouting(offer) === BANKA2_ROUTING;
+      // je poslednja modifikovala pregovor — i pregovor je JOS aktivan (FIX 4).
+      // Ranije se gledao samo `status !== 'ACCEPTED'`, ali zatvoren/odbijen pregovor
+      // se mapira u 'ACCEPTED', pa je dugme "Prihvati" ostajalo i nudilo ponovni accept
+      // koji bi partner odbio sa 409. `isOngoing` je sada izvor istine.
+      return this.isInterbankOngoing(offer) && this.lastModifierRouting(offer) === BANKA2_ROUTING;
     }
     // Seller accepts buyer's offer; buyer accepts seller's counter-offer.
     return this.canRespond(offer);
+  }
+
+  /**
+   * FIX 4: za interbank ponudu — da li je pregovor jos aktivan. `isOngoing` je
+   * autoritativno polje sa backenda; kada nedostaje (stari payload) padamo na
+   * `status !== 'ACCEPTED'` da ne bismo regresirali postojece ponasanje.
+   */
+  isInterbankOngoing(offer: OtcOffer): boolean {
+    if (offer.isOngoing !== undefined) return offer.isOngoing;
+    return offer.status !== 'ACCEPTED';
+  }
+
+  /** FIX 4: interbank pregovor koji vise nije aktivan (zatvoren/odbijen/sklopljen). */
+  isInterbankClosed(offer: OtcOffer): boolean {
+    return !!offer.interbank && !this.isInterbankOngoing(offer);
+  }
+
+  /**
+   * FIX 4: label za status badge. Za zatvoren interbank pregovor prikazujemo
+   * "Zatvoreno" (protokol nema reject poruku pa ne mozemo razlikovati prihvaceno od
+   * odbijenog/zatvorenog — ne tvrdimo lazno "Prihvaceno"). Za intra-bank dok cekamo
+   * drugu stranu prikazemo "Čekamo drugu stranu", inace sirov status.
+   */
+  statusLabel(offer: OtcOffer): string {
+    if (this.isInterbankClosed(offer)) return 'Zatvoreno';
+    if (this.canWithdraw(offer) && !offer.interbank) return 'Čekamo drugu stranu';
+    return offer.status;
   }
 
   /**
@@ -107,7 +137,8 @@ export class OtcOffersComponent implements OnInit, OnDestroy {
   }
 
   canCounter(offer: OtcOffer): boolean {
-    if (offer.interbank) return true;
+    // FIX 4: counter je moguc samo dok je interbank pregovor aktivan (ranije: uvek true).
+    if (offer.interbank) return this.isInterbankOngoing(offer);
     return this.canRespond(offer);
   }
 
@@ -123,7 +154,9 @@ export class OtcOffersComponent implements OnInit, OnDestroy {
    * For interbank offers, withdraw (delete) is always available.
    */
   canWithdraw(offer: OtcOffer): boolean {
-    if (offer.interbank) return true;
+    // FIX 4: withdraw (delete) je moguc samo dok je interbank pregovor aktivan
+    // (ranije: uvek true, pa se nudilo povlacenje vec zatvorenog pregovora).
+    if (offer.interbank) return this.isInterbankOngoing(offer);
     if (offer.status === 'PENDING_SELLER') return this.isCurrentUser(offer.buyerId);
     if (offer.status === 'PENDING_BUYER') return this.isCurrentUser(offer.sellerId);
     return false;

--- a/src/app/features/otc/components/otc-portal/otc-portal.component.html
+++ b/src/app/features/otc/components/otc-portal/otc-portal.component.html
@@ -46,6 +46,15 @@
       Izvršeni ugovori
     </button>
     <button type="button"
+            class="px-4 py-2.5 text-sm font-medium whitespace-nowrap transition-colors"
+            [class.border-b-2]="activeTab === 'interbank-contracts'"
+            [class.border-primary]="activeTab === 'interbank-contracts'"
+            [class.text-foreground]="activeTab === 'interbank-contracts'"
+            [class.text-muted-foreground]="activeTab !== 'interbank-contracts'"
+            (click)="setTab('interbank-contracts')">
+      Cross-bank ugovori
+    </button>
+    <button type="button"
                 class="px-4 py-2.5 text-sm font-medium whitespace-nowrap transition-colors"
                 [class.border-b-2]="activeTab === 'history'"
                 [class.border-primary]="activeTab === 'history'"
@@ -63,6 +72,7 @@
     <app-otc-positions        *ngSwitchCase="'positions'"></app-otc-positions>
     <app-otc-offers           *ngSwitchCase="'negotiations'"></app-otc-offers>
     <app-otc-contracts        *ngSwitchCase="'contracts'"></app-otc-contracts>
+    <app-otc-interbank-contracts *ngSwitchCase="'interbank-contracts'"></app-otc-interbank-contracts>
     <app-otc-history          *ngSwitchCase="'history'"></app-otc-history>
   </ng-container>
 </div>

--- a/src/app/features/otc/components/otc-portal/otc-portal.component.ts
+++ b/src/app/features/otc/components/otc-portal/otc-portal.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 
-export type OtcTab = 'available-stocks' | 'positions' | 'negotiations' | 'contracts' | 'history';
+export type OtcTab = 'available-stocks' | 'positions' | 'negotiations' | 'contracts' | 'interbank-contracts' | 'history';
 
 @Component({
   selector: 'app-otc-portal',

--- a/src/app/features/otc/models/otc.model.ts
+++ b/src/app/features/otc/models/otc.model.ts
@@ -32,6 +32,15 @@ export interface OtcOffer {
   localId?: string;
   remoteId?: string;
   /**
+   * FIX 4: za inter-bank pregovore — pravo stanje iz backenda (`is_ongoing`).
+   * `status` se za interbank mapira na 'ACCEPTED' kada je pregovor zatvoren, ali to
+   * NE znaci nuzno da je prihvacen — moze biti i odbijen/zatvoren od partnera (protokol
+   * nema reject poruku). `isOngoing=false` znaci samo da pregovor vise nije aktivan;
+   * UI koristi ovo polje da odluci da li su Counter/Withdraw akcije i dalje moguce i da
+   * prikaze "Zatvoreno" umesto laznog "Prihvaceno". Za intra-bank ostaje undefined.
+   */
+  isOngoing?: boolean;
+  /**
    * PR_33 Phase B: valuta cene/premije (npr. "USD", "EUR").
    * Za inter-bank pregovore dolazi iz `state.pricePerUnit.currency` /
    * `state.premium.currency`; za intra-bank ostaje undefined (implicitno RSD/USD).
@@ -183,18 +192,23 @@ export interface StockRef {
  */
 export interface InterbankNegotiationView {
   localId: string;
-  remoteForeignBankId: ForeignBankId;
-  state: {
-    stock: StockRef;
-    settlementDate: string;
-    pricePerUnit: MonetaryValue;
-    premium: MonetaryValue;
-    buyerId: ForeignBankId;
-    sellerId: ForeignBankId;
-    amount: number;
-    lastModifiedBy: ForeignBankId;
-    isOngoing: boolean;
-  };
+  remoteId?: string | null;
+  isAuthoritative: boolean;
+  counterpartyBankCode: number;
+  counterpartyBankName?: string;
+  buyerId: ForeignBankId;
+  sellerId: ForeignBankId;
+  lastModifiedBy: ForeignBankId;
+  stockTicker: string;
+  priceCurrency: string;
+  pricePerUnit: string;
+  amount: number;
+  settlementDate: string;
+  premiumCurrency: string;
+  premium: string;
+  isOngoing: boolean;
+  createdAt: string;
+  lastModifiedAt: string;
 }
 
 /**
@@ -223,4 +237,37 @@ export interface CounterInterbankNegotiationRequest {
   premiumCurrency: string;
   premium: number;
   settlementDate: string;
+}
+
+/** Status sklopljenog cross-bank opcionog ugovora (vidi GET /api/interbank/otc/contracts/my). */
+export type OtcInterbankContractStatus = 'ACTIVE' | 'EXERCISED' | 'EXPIRED';
+
+/**
+ * Sklopljeni cross-bank OTC opcioni ugovor — response shape iz
+ * `GET /api/interbank/otc/contracts/my` (backend `OtcInterbankContractDto`).
+ *
+ * <p>Za razliku od intra-bank {@link OptionContract}, ovde su `buyerId`/`sellerId`
+ * parovi (routingNumber, id) per inter-bank protokol §3, a strike je `MonetaryValue`
+ * razdvojen na `strikeCurrency` + `strikeAmount` (serijalizovan kao string da bi se
+ * sacuvala BigDecimal preciznost).
+ *
+ * <p>`localId` je nas mirror id ugovora i koristi se za exercise poziv
+ * (`POST /api/interbank/otc/contracts/{localId}/exercise`).
+ */
+export interface OtcInterbankContract {
+  localId: string;
+  negotiationId: string;
+  buyerId: ForeignBankId;
+  sellerId: ForeignBankId;
+  ticker: string;
+  amount: number;
+  strikeCurrency: string;
+  strikeAmount: string;
+  settlementDate: string;
+  status: OtcInterbankContractStatus;
+  optionPseudoOwnerRouting: number;
+  optionPseudoOwnerId: string;
+  createdAt: string;
+  exercisedAt?: string;
+  expiredAt?: string;
 }

--- a/src/app/features/otc/otc.module.ts
+++ b/src/app/features/otc/otc.module.ts
@@ -8,6 +8,7 @@ import { OtcAvailableStocksComponent } from './components/otc-available-stocks/o
 import { OtcPositionsComponent } from './components/otc-positions/otc-positions.component';
 import { OtcOffersComponent } from './components/otc-offers/otc-offers.component';
 import { OtcContractsComponent } from './components/otc-contracts/otc-contracts.component';
+import { OtcInterbankContractsComponent } from './components/otc-interbank-contracts/otc-interbank-contracts.component';
 import { OtcCreateOfferComponent } from './components/otc-create-offer/otc-create-offer.component';
 import { roleGuard } from '../../core/guards/role.guard';
 import { StateComponent } from '../../shared/components/state/state.component';
@@ -33,6 +34,7 @@ const routes: Routes = [
     OtcPositionsComponent,
     OtcOffersComponent,
     OtcContractsComponent,
+    OtcInterbankContractsComponent,
     OtcCreateOfferComponent,
     OtcHistoryComponent,
   ],

--- a/src/app/features/otc/services/otc.service.ts
+++ b/src/app/features/otc/services/otc.service.ts
@@ -16,6 +16,7 @@ import {
   OptionContract,
   OptionContractStatus,
   OtcHistoryParams,
+  OtcInterbankContract,
   OtcOffer,
   OtcOfferHistoryEvent,
   OtcPosition,
@@ -35,6 +36,7 @@ const BANKA2_LABEL = 'Banka 2';
 export class OtcService {
   private readonly baseUrl = `${environment.apiUrl}/otc`;
   private readonly interbankUrl = `${environment.apiUrl}/api/interbank/otc/negotiations`;
+  private readonly interbankContractsUrl = `${environment.apiUrl}/api/interbank/otc/contracts`;
   private readonly activeOffersUrl = `${this.baseUrl}/offers/active`;
   private readonly etagCache: OtcEtagCache;
 
@@ -149,7 +151,22 @@ export class OtcService {
   }
 
   createInterbankNegotiation(req: CreateInterbankNegotiationRequest): Observable<InterbankNegotiationView> {
-    return this.http.post<InterbankNegotiationView>(this.interbankUrl, req).pipe(
+    // Backend OutboundCreateRequest expects FLAT seller fields
+    // (sellerRoutingNumber + sellerForeignId), not a nested sellerForeignBankId.
+    // Sending the nested object made the backend read routing 0 → "partner not
+    // found: routing=0" → 500. Map to the wire shape the backend actually decodes.
+    const body = {
+      stockTicker: req.stockTicker,
+      settlementDate: req.settlementDate,
+      priceCurrency: req.priceCurrency,
+      pricePerUnit: req.pricePerUnit,
+      premiumCurrency: req.premiumCurrency,
+      premium: req.premium,
+      sellerRoutingNumber: req.sellerForeignBankId.routingNumber,
+      sellerForeignId: req.sellerForeignBankId.id,
+      amount: req.amount,
+    };
+    return this.http.post<InterbankNegotiationView>(this.interbankUrl, body).pipe(
       tap(() => this.invalidateOfferPollCache()),
     );
   }
@@ -172,6 +189,31 @@ export class OtcService {
   deleteInterbankNegotiation(localId: string): Observable<void> {
     return this.http.delete<void>(`${this.interbankUrl}/${localId}`).pipe(
       tap(() => this.invalidateOfferPollCache()),
+    );
+  }
+
+  /**
+   * Sklopljeni cross-bank opcioni ugovori za current user-a.
+   * Backend ruta `GET /api/interbank/otc/contracts/my` (server cita id iz JWT-a).
+   * `all=true` je dostupno samo admin/supervizor-ima (vraca ugovore svih korisnika).
+   */
+  listMyContracts(all = false): Observable<OtcInterbankContract[]> {
+    const url = all
+      ? `${this.interbankContractsUrl}/my?all=true`
+      : `${this.interbankContractsUrl}/my`;
+    return this.http.get<OtcInterbankContract[]>(url);
+  }
+
+  /**
+   * Iskoristi (exercise) sklopljeni cross-bank opcioni ugovor.
+   * Backend ruta `POST /api/interbank/otc/contracts/{localId}/exercise`;
+   * vraca azuriran ugovor. Greske: 404 (ne postoji), 403 (nije tvoj / nisi kupac),
+   * 409 (nije ACTIVE / settlement prosao / partner odbio) sa `{ error }` body-jem.
+   */
+  exerciseContract(localId: string): Observable<OtcInterbankContract> {
+    return this.http.post<OtcInterbankContract>(
+      `${this.interbankContractsUrl}/${localId}/exercise`,
+      null,
     );
   }
 
@@ -228,29 +270,37 @@ export class OtcService {
    * sentinel (UI bira `localId` za sve API pozive).
    */
   private toOfferFromNegotiation(n: InterbankNegotiationView): OtcOffer {
-    const s = n.state;
+    // Backend NegotiationView is FLAT (stockTicker, pricePerUnit as a decimal
+    // string, counterpartyBankCode, remoteId, isOngoing…) — there is no nested
+    // `state`/`remoteForeignBankId`. Reading n.state threw, so every interbank
+    // negotiation was silently dropped (catchError → []) and never displayed.
     return {
       // Sentinel: ne koristi se direktno za API pozive (interbank flow gleda localId).
       id: 0,
-      stockTicker: s.stock.ticker,
+      stockTicker: n.stockTicker,
       buyerId: 0,
       sellerId: 0,
-      amount: s.amount,
-      pricePerStock: s.pricePerUnit.amount,
-      premium: s.premium.amount,
-      settlementDate: s.settlementDate,
-      status: s.isOngoing ? 'PENDING_BUYER' : 'ACCEPTED',
-      modifiedBy: `${s.lastModifiedBy.routingNumber}:${s.lastModifiedBy.id}`,
-      lastModified: '',
+      amount: n.amount,
+      pricePerStock: Number(n.pricePerUnit),
+      premium: Number(n.premium),
+      settlementDate: n.settlementDate,
+      // FIX 4: ne mapiraj slepo zatvoren pregovor u 'ACCEPTED'. Protokol nema reject
+      // poruku, pa `is_ongoing=false` moze znaciti i odbijeno/zatvoreno od partnera.
+      // Cuvamo realno stanje u `isOngoing`; status ostaje gruba aproksimacija koju
+      // template prikazuje kao "Zatvoreno" za zatvorene interbank pregovore.
+      status: n.isOngoing ? 'PENDING_BUYER' : 'ACCEPTED',
+      isOngoing: n.isOngoing,
+      modifiedBy: `${n.lastModifiedBy.routingNumber}:${n.lastModifiedBy.id}`,
+      lastModified: n.lastModifiedAt ?? '',
       interbank: true,
-      counterpartyBankCode: n.remoteForeignBankId.routingNumber,
-      counterpartyBankName: this.bankNameFor(n.remoteForeignBankId.routingNumber),
+      counterpartyBankCode: n.counterpartyBankCode,
+      counterpartyBankName: n.counterpartyBankName || this.bankNameFor(n.counterpartyBankCode),
       localId: n.localId,
-      remoteId: n.remoteForeignBankId.id,
+      remoteId: n.remoteId ?? undefined,
       // PR_33 Phase B: sacuvaj valutu iz protokol payload-a da counter/accept
       // path moze da je procita (umesto hard-coded 'USD').
-      priceCurrency: s.pricePerUnit.currency,
-      premiumCurrency: s.premium.currency,
+      priceCurrency: n.priceCurrency,
+      premiumCurrency: n.premiumCurrency,
     };
   }
 


### PR DESCRIPTION
Placanja:
- new-payment: racun primaoca 18-34 cifre (Banka 2 = 18, Banka 1 = 19, IBAN do 34);
  brza placanja prefill (recipientAccount/recipientName iz queryParams); RSD-only blok za
  cross-bank (ne-RSD se odbija jasnom porukom + disable submit).
- interbank-payment.service: poziv ka inter-bank payment endpointu.

OTC:
- otc-offers: canCounter/canWithdraw/canAccept za interbank vezani za isOngoing
  (zatvoreni/odbijeni pregovori ne nude vise akcije); status badge "Zatvoreno".
- otc.service: propagira isOngoing (ne mapira slepo zatvoren -> ACCEPTED).
- otc-interbank-contracts komponenta + portal/available-stocks/create-offer doterivanja.